### PR TITLE
feat: Cleanup after automatic deletion by TTL Index

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -233,6 +233,7 @@
     "@testing-library/user-event": "^14.5.2",
     "@types/express": "^4.17.11",
     "@types/jest": "^29.5.2",
+    "@types/node-cron": "^3.0.11",
     "@types/react-scroll": "^1.8.4",
     "@types/throttle-debounce": "^5.0.1",
     "@types/unzip-stream": "^0.3.4",

--- a/apps/app/src/server/crowi/index.js
+++ b/apps/app/src/server/crowi/index.js
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-this-alias */
+import { throws } from 'assert';
 import http from 'http';
 import path from 'path';
 
@@ -33,6 +34,7 @@ import { normalizeData } from '../service/normalize-data';
 import PageService from '../service/page';
 import PageGrantService from '../service/page-grant';
 import PageOperationService from '../service/page-operation';
+import PageCleanupCronService from '../service/page/page-cleanup-cron';
 import PassportService from '../service/passport';
 import SearchService from '../service/search';
 import { SlackIntegrationService } from '../service/slack-integration';
@@ -100,6 +102,7 @@ class Crowi {
     this.xss = new Xss();
     this.questionnaireService = null;
     this.questionnaireCronService = null;
+    this.pageCleanupCronService = null;
 
     this.tokens = null;
 
@@ -175,6 +178,9 @@ Crowi.prototype.init = async function() {
     this.setupExternalAccountService(),
     this.setupExternalUserGroupSyncService(),
   ]);
+
+  // Must be called after this.setupPageService() completes
+  await this.setupPageCleanupCronService();
 
   await this.autoInstall();
 
@@ -729,6 +735,12 @@ Crowi.prototype.setupPageService = async function() {
   if (this.pageOperationService == null) {
     this.pageOperationService = new PageOperationService(this);
     await this.pageOperationService.init();
+  }
+};
+
+Crowi.prototype.setupPageCleanupCronService = async function() {
+  if (this.pageCleanupCronService == null) {
+    this.pageCleanupCronService = new PageCleanupCronService(this);
   }
 };
 

--- a/apps/app/src/server/crowi/index.js
+++ b/apps/app/src/server/crowi/index.js
@@ -741,6 +741,7 @@ Crowi.prototype.setupPageService = async function() {
 Crowi.prototype.setupPageCleanupCronService = async function() {
   if (this.pageCleanupCronService == null) {
     this.pageCleanupCronService = new PageCleanupCronService(this);
+    this.pageCleanupCronService.startCron();
   }
 };
 

--- a/apps/app/src/server/service/page/page-cleanup-cron.ts
+++ b/apps/app/src/server/service/page/page-cleanup-cron.ts
@@ -1,0 +1,27 @@
+import nodeCron from 'node-cron';
+
+class CleanupPageCronService {
+
+  crowi: any;
+
+  cronJob: any;
+
+  constructor(crowi) {
+    this.crowi = crowi;
+  }
+
+  startCron(): void {
+    //
+  }
+
+  async executeJob(): Promise<void> {
+    //
+  }
+
+  private generateCronJob() {
+    //
+  }
+
+}
+
+export default CleanupPageCronService;

--- a/apps/app/src/server/service/page/page-cleanup-cron.ts
+++ b/apps/app/src/server/service/page/page-cleanup-cron.ts
@@ -1,25 +1,40 @@
-import nodeCron from 'node-cron';
+import nodeCron, { type ScheduledTask } from 'node-cron';
+
+import type Crowi from '~/server/crowi';
+import loggerFactory from '~/utils/logger';
+
+const logger = loggerFactory('growi:service:page-cleanup-cron-service');
+
+const CRON_SCHEDULE = '1 * * * * *';
 
 class CleanupPageCronService {
 
-  crowi: any;
+  crowi: Crowi;
 
-  cronJob: any;
+  cronJob: ScheduledTask;
 
-  constructor(crowi) {
+  constructor(crowi: Crowi) {
     this.crowi = crowi;
   }
 
   startCron(): void {
-    //
+    this.cronJob = this.generateCronJob(CRON_SCHEDULE);
+    this.cronJob.start();
   }
 
-  async executeJob(): Promise<void> {
-    //
+  private async executeJob(): Promise<void> {
+    // TODO: implement
   }
 
-  private generateCronJob() {
-    //
+  private generateCronJob(cronSchedule: string) {
+    return nodeCron.schedule(cronSchedule, async() => {
+      try {
+        this.executeJob();
+      }
+      catch (err) {
+        logger.error(err);
+      }
+    });
   }
 
 }

--- a/apps/app/src/server/service/page/page-cleanup-cron.ts
+++ b/apps/app/src/server/service/page/page-cleanup-cron.ts
@@ -23,7 +23,7 @@ class CleanupPageCronService {
   }
 
   private async executeJob(): Promise<void> {
-    // TODO: implement
+    // TODO: https://redmine.weseek.co.jp/issues/141122
   }
 
   private generateCronJob(cronSchedule: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4127,6 +4127,11 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
   integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
+"@types/node-cron@^3.0.11":
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/@types/node-cron/-/node-cron-3.0.11.tgz#70b7131f65038ae63cfe841354c8aba363632344"
+  integrity sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==
+
 "@types/node-fetch@^2.5.0":
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.8.tgz#9a2993583975849c2e1f360b6ca2f11755b2c504"


### PR DESCRIPTION
## Task
[#141122](https://redmine.weseek.co.jp/issues/141122) [v7] [WIP page] TTL Index によって削除された階層の子孫数カウントの整頓と Empty page のみの階層の削除を定期実行できる
┗  [#141124](https://redmine.weseek.co.jp/issues/141124) 実装