### PR TITLE
fix: Unify documentation URL locale logic

### DIFF
--- a/apps/app/src/client/components/PageCreateModal.tsx
+++ b/apps/app/src/client/components/PageCreateModal.tsx
@@ -28,7 +28,7 @@ import {
   usePageCreateModalActions,
   usePageCreateModalStatus,
 } from '~/states/ui/modal/page-create';
-import { getDocumentationLocale } from '~/utils/locale-utils';
+import { getLocale } from '~/utils/locale-utils';
 
 import PagePathAutoComplete from './PagePathAutoComplete';
 
@@ -74,7 +74,7 @@ const PageCreateModal: React.FC = () => {
     [userHomepagePath, t, now],
   );
 
-  const docsLang = getDocumentationLocale(i18n.language);
+  const docsLang = getLocale(i18n.language).code === 'ja' ? 'ja' : 'en';
   const templateHelpUrl = `${documentationUrl}/${docsLang}/guide/features/template.html`;
 
   const [todayInput, setTodayInput] = useState('');

--- a/apps/app/src/client/components/PageCreateModal.tsx
+++ b/apps/app/src/client/components/PageCreateModal.tsx
@@ -21,12 +21,14 @@ import { debounce } from 'throttle-debounce';
 import { useCreateTemplatePage } from '~/client/services/create-page';
 import { useCreatePage } from '~/client/services/create-page/use-create-page';
 import { useToastrOnError } from '~/client/services/use-toastr-on-error';
-import { useCurrentUser, useGrowiCloudUri } from '~/states/global';
+import { useGrowiDocumentationUrl } from '~/states/context';
+import { useCurrentUser } from '~/states/global';
 import { isSearchServiceReachableAtom } from '~/states/server-configurations';
 import {
   usePageCreateModalActions,
   usePageCreateModalStatus,
 } from '~/states/ui/modal/page-create';
+import { getDocumentationLocale } from '~/utils/locale-utils';
 
 import PagePathAutoComplete from './PagePathAutoComplete';
 
@@ -38,7 +40,7 @@ const PageCreateModal: React.FC = () => {
   const { t, i18n } = useTranslation();
 
   const currentUser = useCurrentUser();
-  const growiCloudUri = useGrowiCloudUri();
+  const documentationUrl = useGrowiDocumentationUrl();
 
   const { isOpened, path: pathname = '' } = usePageCreateModalStatus();
   const { close: closeCreateModal } = usePageCreateModalActions();
@@ -72,11 +74,8 @@ const PageCreateModal: React.FC = () => {
     [userHomepagePath, t, now],
   );
 
-  const templateHelpLang = i18n.language === 'ja' ? 'ja' : 'en';
-  const templateHelpUrl =
-    growiCloudUri != null
-      ? `https://growi.cloud/help/${templateHelpLang}/guide/features/template.html`
-      : `https://docs.growi.org/${templateHelpLang}/guide/features/template.html`;
+  const docsLang = getDocumentationLocale(i18n.language);
+  const templateHelpUrl = `${documentationUrl}/${docsLang}/guide/features/template.html`;
 
   const [todayInput, setTodayInput] = useState('');
   const [pageNameInput, setPageNameInput] = useState(pageNameInputInitialValue);

--- a/apps/app/src/utils/locale-utils.ts
+++ b/apps/app/src/utils/locale-utils.ts
@@ -42,3 +42,14 @@ export const getLocale = (langCode: string): Locale => {
 
   return locale ?? enUS;
 };
+
+/**
+ * Gets the documentation site language code from an i18next language code.
+ * Only 'ja' and 'en' are supported on the GROWI documentation site.
+ * @param langCode The i18n language code (e.g., 'ja_JP').
+ * @returns 'ja' or 'en', defaulting to 'en' if not Japanese.
+ */
+export const getDocumentationLocale = (langCode: string): 'ja' | 'en' => {
+  const baseCode = langCode.split(/[-_]/)[0];
+  return baseCode === 'ja' ? 'ja' : 'en';
+};

--- a/apps/app/src/utils/locale-utils.ts
+++ b/apps/app/src/utils/locale-utils.ts
@@ -42,14 +42,3 @@ export const getLocale = (langCode: string): Locale => {
 
   return locale ?? enUS;
 };
-
-/**
- * Gets the documentation site language code from an i18next language code.
- * Only 'ja' and 'en' are supported on the GROWI documentation site.
- * @param langCode The i18n language code (e.g., 'ja_JP').
- * @returns 'ja' or 'en', defaulting to 'en' if not Japanese.
- */
-export const getDocumentationLocale = (langCode: string): 'ja' | 'en' => {
-  const baseCode = langCode.split(/[-_]/)[0];
-  return baseCode === 'ja' ? 'ja' : 'en';
-};


### PR DESCRIPTION
## Task
https://redmine.weseek.co.jp/issues/181684

## Summary
- Add `getDocumentationLocale()` helper to `locale-utils.ts` for type-safe docs language resolution from i18n language codes
- Fix PageCreateModal bug: `i18n.language === 'ja'` always returned `'en'` because `i18n.language` returns `'ja_JP'`, not `'ja'`
- Replace hardcoded URL construction in PageCreateModal with `useGrowiDocumentationUrl` hook + `getDocumentationLocale` helper

## Background
Raised by @miya in [PR #10976 review](https://github.com/growilabs/growi/pull/10976) — documentation link locale logic should be unified across components. This PR extracts the shared logic so that future docs links (e.g. ShortcutsModal in #10976) can reuse it.

## Test plan
- [ ] Open PageCreateModal and verify the template help link goes to the correct locale (`/ja/` for Japanese, `/en/` for others)
- [ ] Verify GROWI Cloud users get the correct help URL base (`/help/...` instead of `docs.growi.org/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)