### PR TITLE
imprv: Render page tree item title as a real anchor

### DIFF
--- a/apps/app/src/client/components/Sidebar/PageTreeItem/PageTreeItem.tsx
+++ b/apps/app/src/client/components/Sidebar/PageTreeItem/PageTreeItem.tsx
@@ -173,6 +173,7 @@ export const PageTreeItem: FC<TreeItemProps> = ({
       isWipPageShown={isWipPageShown}
       isEnableActions={isEnableActions}
       isReadOnlyUser={isReadOnlyUser}
+      asLink
       onClick={itemSelectedHandler}
       onWheelClick={itemSelectedByWheelClickHandler}
       onToggle={onToggle}

--- a/apps/app/src/features/page-tree/components/SimpleItemContent.tsx
+++ b/apps/app/src/features/page-tree/components/SimpleItemContent.tsx
@@ -1,4 +1,6 @@
 import { useId } from 'react';
+import Link from 'next/link';
+import { pathUtils } from '@growi/core/dist/utils';
 import { useTranslation } from 'next-i18next';
 import path from 'pathe';
 import { UncontrolledTooltip } from 'reactstrap';
@@ -12,8 +14,10 @@ const moduleClass = styles['simple-item-content'] ?? '';
 
 export const SimpleItemContent = ({
   page,
+  asLink = false,
 }: {
   page: IPageForItem;
+  asLink?: boolean;
 }): JSX.Element => {
   const { t } = useTranslation();
 
@@ -24,9 +28,21 @@ export const SimpleItemContent = ({
 
   const spanId = `path-recovery-${useId()}`;
 
+  // When asLink is true, render the title as an anchor so that the browser
+  // recognizes it as a link (enables Ctrl/Cmd+click to open in new tab,
+  // middle-click, and the right-click "Open link in new tab" context menu).
+  // Otherwise we render a plain div and let the surrounding <li> capture
+  // clicks via JS (existing non-navigation usages such as modals).
+  const href =
+    asLink && page.path != null && page._id != null
+      ? pathUtils.returnPathForURL(page.path, page._id)
+      : undefined;
+
+  const titleClassName = `grw-page-title-anchor flex-grow-1 text-truncate ${page.isEmpty ? 'opacity-75' : ''}`;
+
   return (
     <div
-      className={`${moduleClass} flex-grow-1 d-flex align-items-center pe-none`}
+      className={`${moduleClass} flex-grow-1 d-flex align-items-center ${href != null ? '' : 'pe-none'}`}
       style={{ minWidth: 0 }}
     >
       {shouldShowAttentionIcon && (
@@ -42,21 +58,29 @@ export const SimpleItemContent = ({
           </UncontrolledTooltip>
         </>
       )}
-      {page != null && page.path != null && page._id != null && (
-        <div className="grw-page-title-anchor flex-grow-1">
-          <div className="d-flex align-items-center">
-            <span
-              className={`text-truncate me-1 ${page.isEmpty && 'opacity-75'}`}
-            >
-              {pageName}
-            </span>
-            {page.wip && (
-              <span className="wip-page-badge badge rounded-pill me-1 text-bg-secondary">
-                WIP
-              </span>
-            )}
+      {page != null &&
+        page.path != null &&
+        page._id != null &&
+        (href != null ? (
+          <Link
+            href={href}
+            prefetch={false}
+            className={`${titleClassName} text-reset`}
+            style={{ minWidth: 0 }}
+          >
+            {pageName}
+          </Link>
+        ) : (
+          <div className={titleClassName} style={{ minWidth: 0 }}>
+            {pageName}
           </div>
-        </div>
+        ))}
+      {/* WIP is a status indicator — kept outside the link so it is not
+          read as part of the anchor's accessible name, and not truncated. */}
+      {page.wip && (
+        <span className="wip-page-badge badge rounded-pill ms-1 text-bg-secondary flex-shrink-0">
+          WIP
+        </span>
       )}
     </div>
   );

--- a/apps/app/src/features/page-tree/components/TreeItemLayout.tsx
+++ b/apps/app/src/features/page-tree/components/TreeItemLayout.tsx
@@ -12,6 +12,7 @@ const indentSize = 10; // in px
 
 type TreeItemLayoutProps = TreeItemProps & {
   className?: string;
+  asLink?: boolean;
 };
 
 export const TreeItemLayout = (props: TreeItemLayoutProps): JSX.Element => {
@@ -24,6 +25,7 @@ export const TreeItemLayout = (props: TreeItemLayoutProps): JSX.Element => {
     isReadOnlyUser,
     isWipPageShown = true,
     showAlternativeContent,
+    asLink,
     onRenamed,
     onClick,
     onClickDuplicateMenuItem,
@@ -142,7 +144,7 @@ export const TreeItemLayout = (props: TreeItemLayoutProps): JSX.Element => {
           ))
         ) : (
           <>
-            <SimpleItemContent page={page} />
+            <SimpleItemContent page={page} asLink={asLink} />
             <div className="d-hover-none">
               {EndComponents?.map((EndComponent, index) => (
                 // biome-ignore lint/suspicious/noArrayIndexKey: static component list


### PR DESCRIPTION
## Summary

- ページツリーの項目タイトルを実際の `<a>`（Next.js `Link`）としてレンダリングし、Ctrl/Cmd+クリック・中クリック・右クリックの「新しいタブで開く」などのブラウザネイティブ挙動を有効化
- `href` は呼び出し側で導出せず、`SimpleItemContent` が受け取っている `page.path` / `page._id` から内部で導出。リンク化の可否は `asLink` prop で opt-in（モーダル等の非遷移用途は既定の `false` で従来通り）
- WIP バッジをリンクの外に出し、アンカーのアクセシブルネームに含まれないように / タイトル truncate の影響を受けないように配置

## Background

PageTreeItem は `<li onClick>` による JS 遷移のみで実装されていたため、ブラウザがリンクとして認識せず、

- Ctrl/Cmd + クリックで新しいタブで開けない
- 右クリックメニューに「新しいタブで開く」が出ない
- リンク URL のホバープレビューも出ない

という問題がありました。行全体を `<a>` で包むとトライアングル/3点メニュー等との対話要素ネストで HTML 仕様違反になるため、タイトル部分のみをアンカー化する方針としました。

## Test plan

- [ ] Sidebar の PageTree でページ項目を通常クリック → 該当ページへ SPA 遷移する
- [ ] Ctrl/Cmd + クリック → 新しいタブで開く
- [ ] 中クリック → 新しいタブで開く
- [ ] 右クリック → ブラウザのコンテキストメニューに「新しいタブで開く」等のリンク操作が出る
- [ ] ホバー時に 3 点メニュー / 作成ボタンが表示され、それらをクリックしてもページ遷移しない
- [ ] トライアングル（展開/折りたたみ）ボタンが従来通り動作する
- [ ] WIP ページで WIP バッジが右側に表示され、長いタイトルが truncate されても可視
- [ ] PageSelectModal / AI アシスタント管理モーダルのツリーアイテム：クリックで選択ができ、ページ遷移は発生しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)