### PR TITLE
fix(slack): Normalize proxyUri to undefined for custom bot without proxy mode

### DIFF
--- a/apps/app/src/server/routes/apiv3/slack-integration.js
+++ b/apps/app/src/server/routes/apiv3/slack-integration.js
@@ -280,7 +280,7 @@ module.exports = (crowi) => {
   };
 
   function getRespondUtil(responseUrl) {
-    const proxyUri = slackIntegrationService.proxyUriForCurrentType ?? null; // can be null
+    const proxyUri = slackIntegrationService.proxyUriForCurrentType;
 
     const appSiteUrl = growiInfoService.getSiteUrl();
     if (appSiteUrl == null || appSiteUrl === '') {

--- a/apps/app/src/server/service/config-manager/config-definition.ts
+++ b/apps/app/src/server/service/config-manager/config-definition.ts
@@ -1115,7 +1115,7 @@ export const CONFIG_DEFINITIONS = {
     envVarName: 'SLACKBOT_TYPE',
     defaultValue: undefined,
   }),
-  'slackbot:proxyUri': defineConfig<string | undefined>({
+  'slackbot:proxyUri': defineConfig<NonBlankString | undefined>({
     envVarName: 'SLACKBOT_INTEGRATION_PROXY_URI',
     defaultValue: undefined,
   }),

--- a/apps/app/src/server/service/slack-integration.ts
+++ b/apps/app/src/server/service/slack-integration.ts
@@ -1,3 +1,4 @@
+import { toNonBlankStringOrUndefined } from '@growi/core/dist/interfaces';
 import {
   type GrowiBotEvent,
   type GrowiCommand,
@@ -132,18 +133,14 @@ export class SlackIntegrationService implements S2sMessageHandlable {
 
     // TODO assert currentBotType is not null and CUSTOM_WITHOUT_PROXY
 
-    let proxyUri: string | undefined;
-
     switch (currentBotType) {
       case SlackbotType.OFFICIAL:
-        proxyUri = OFFICIAL_SLACKBOT_PROXY_URI;
-        break;
+        return OFFICIAL_SLACKBOT_PROXY_URI;
       default:
-        proxyUri = configManager.getConfig('slackbot:proxyUri');
-        break;
+        return toNonBlankStringOrUndefined(
+          configManager.getConfig('slackbot:proxyUri'),
+        );
     }
-
-    return proxyUri;
   }
 
   /**

--- a/apps/app/src/server/service/slack-integration.ts
+++ b/apps/app/src/server/service/slack-integration.ts
@@ -1,4 +1,7 @@
-import { toNonBlankStringOrUndefined } from '@growi/core/dist/interfaces';
+import {
+  type NonBlankString,
+  toNonBlankStringOrUndefined,
+} from '@growi/core/dist/interfaces';
 import {
   type GrowiBotEvent,
   type GrowiCommand,
@@ -26,7 +29,8 @@ import { LinkSharedEventHandler } from './slack-event-handler/link-shared';
 
 const logger = loggerFactory('growi:service:SlackBotService');
 
-const OFFICIAL_SLACKBOT_PROXY_URI = 'https://slackbot-proxy.growi.org';
+const OFFICIAL_SLACKBOT_PROXY_URI =
+  'https://slackbot-proxy.growi.org' as NonBlankString;
 
 type S2sMessageForSlackIntegration = S2sMessage & { updatedAt: Date };
 
@@ -128,7 +132,7 @@ export class SlackIntegrationService implements S2sMessageHandlable {
     return true;
   }
 
-  get proxyUriForCurrentType(): string | undefined {
+  get proxyUriForCurrentType(): NonBlankString | undefined {
     const currentBotType = configManager.getConfig('slackbot:currentBotType');
 
     // TODO assert currentBotType is not null and CUSTOM_WITHOUT_PROXY


### PR DESCRIPTION
## Summary

- `slackbot:proxyUri` config の型を `NonBlankString | undefined` に変更し、空文字列や null が入らないよう型レベルで明示
- `proxyUriForCurrentType` getter で `toNonBlankStringOrUndefined()` を使い、DB から null や空文字列が返った場合に `undefined` へノーマライズ
- `getRespondUtil` 内の `?? null`（`undefined` を `null` に変換していたバグ）を削除

## Root Cause

`CUSTOM_WITHOUT_PROXY` モードで proxy URI が未設定の場合:

1. `configManager.getConfig('slackbot:proxyUri')` が DB の null を `?? envValue` でフォールスルーし、`undefined` を返す
2. `proxyUriForCurrentType` がその `undefined` を呼び出し元に返す
3. **バグ**: `getRespondUtil` 内の `?? null` が `undefined → null` に変換
4. `generateRespondUtil({ proxyUri: null })` に渡ると、ライブラリの `proxyUri === undefined` チェックが false になり proxy モードと誤判断
5. `urljoin(null, ...)` が `null.length` を参照し TypeError

## Changes

- `apps/app/src/server/service/config-manager/config-definition.ts`: `slackbot:proxyUri` を `NonBlankString | undefined` 型に変更
- `apps/app/src/server/service/slack-integration.ts`: `proxyUriForCurrentType` で `toNonBlankStringOrUndefined()` を使い正規化
- `apps/app/src/server/routes/apiv3/slack-integration.js`: `getRespondUtil` の誤った `?? null` を削除

## Test Plan

- [ ] `CUSTOM_WITHOUT_PROXY` モードで Slack bot を設定し、`/growi help` コマンドが正常に応答することを確認
- [ ] proxy モード (`OFFICIAL` または `CUSTOM_WITH_PROXY`) で既存の動作が変わらないことを確認

Closes #11031