### PR TITLE
fix(search): resolve nested <button> DOM warning in search result list

### DIFF
--- a/apps/app/src/client/components/PageList/PageListItemL.tsx
+++ b/apps/app/src/client/components/PageList/PageListItemL.tsx
@@ -238,11 +238,22 @@ const PageListItemLSubstance: ForwardRefRenderFunction<ISelectable, Props> = (
 
   return (
     <li key={pageData._id}>
-      <button
-        type="button"
+      {/* biome-ignore lint/a11y/useSemanticElements: cannot use <button> here because PageItemControl renders a nested <button> (DropdownToggle) */}
+      <div
+        role="button"
+        tabIndex={0}
         className={`list-group-item d-flex align-items-center px-3 px-md-1 text-start w-100 ${styleListGroupItem} ${styleActive}`}
         data-testid="page-list-item-L"
         onClick={clickHandler}
+        onKeyDown={(e) => {
+          if (
+            e.target === e.currentTarget &&
+            (e.key === 'Enter' || e.key === ' ')
+          ) {
+            e.preventDefault();
+            clickHandler();
+          }
+        }}
       >
         <div className="text-break w-100">
           <div className="d-flex">
@@ -365,7 +376,7 @@ const PageListItemLSubstance: ForwardRefRenderFunction<ISelectable, Props> = (
           </div>
         </div>
         {/* TODO: adjust snippet position */}
-      </button>
+      </div>
     </li>
   );
 };


### PR DESCRIPTION
## Summary

- 検索結果ページで発生していた `validateDOMNesting(...): <button> cannot appear as a descendant of <button>` 警告を解消。
- `PageListItemL` がリストアイテム全体を `<button>` で囲っており、その内部にある `PageItemControl` の `DropdownToggle` (reactstrap が `<button>` を出力) と入れ子になって不正な HTML 構造になっていた。
- 外側を `<div role="button" tabIndex={0}>` に変更し、`onKeyDown` で Enter / Space のキーボード操作を補完。デスクトップでの「クリックでプレビュー表示」既存挙動は維持。

## Notes

- `<button>` を使えない理由（内部に `DropdownToggle` がいる）をコメントで明示し、`useSemanticElements` の biome-ignore を 1 か所のみ追加。

## Test plan

- [ ] 検索結果ページを開き、ブラウザコンソールに `validateDOMNesting` 警告が出ないことを確認
- [ ] 検索結果アイテムをマウスクリックしたとき、デスクトップ幅でプレビューペインが切り替わること
- [ ] アイテム内のページタイトル (Link) クリックでページに遷移できること
- [ ] アイテム内のチェックボックス、メニュー (`...` ボタン) が個別に機能すること
- [ ] Tab キーで内部の Link / チェックボックス / メニューにフォーカスが当たること、外側 div に Tab で当たった状態で Enter / Space を押すとプレビューが切り替わること
- [ ] ゲストユーザーでも警告が出ず、メニューがゲスト無効表示になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)