### PR TITLE
fix(drawio): Prevent host CSS leaking into <foreignObject>

### DIFF
--- a/packages/remark-drawio/src/components/DrawioViewer.module.scss
+++ b/packages/remark-drawio/src/components/DrawioViewer.module.scss
@@ -12,10 +12,16 @@
 // drawio sizes each cell using UA-default HTML metrics and clips overflow via
 // an inline max-height wrapper, so non-default styles (e.g. line-height,
 // margin from a wrapping `.wiki` ruleset) cause label content to be cut off.
+//
+// `!important` is required: host selectors such as `.wiki ol:not(.nav) li`
+// outrank our scoped selector on specificity (`:not(.nav)` adds a class-level
+// weight). Defending the foreignObject content is an adversarial cross-cutting
+// concern, so we explicitly opt out of the specificity contest rather than
+// chasing host selectors.
 .drawio-viewer foreignObject {
   h1, h2, h3, h4, h5, h6,
   p, ul, ol, li, blockquote,
   img, video, table {
-    all: revert;
+    all: revert !important;
   }
 }

--- a/packages/remark-drawio/src/components/DrawioViewer.module.scss
+++ b/packages/remark-drawio/src/components/DrawioViewer.module.scss
@@ -7,3 +7,15 @@
 .drawio-viewer * {
   box-sizing: content-box;
 }
+
+// Revert host-page CSS that leaks into HTML rendered inside <foreignObject>.
+// drawio sizes each cell using UA-default HTML metrics and clips overflow via
+// an inline max-height wrapper, so non-default styles (e.g. line-height,
+// margin from a wrapping `.wiki` ruleset) cause label content to be cut off.
+.drawio-viewer foreignObject {
+  h1, h2, h3, h4, h5, h6,
+  p, ul, ol, li, blockquote,
+  img, video, table {
+    all: revert;
+  }
+}

--- a/packages/remark-drawio/src/components/DrawioViewer.module.scss
+++ b/packages/remark-drawio/src/components/DrawioViewer.module.scss
@@ -18,6 +18,8 @@
 // weight). Defending the foreignObject content is an adversarial cross-cutting
 // concern, so we explicitly opt out of the specificity contest rather than
 // chasing host selectors.
+//
+// See: https://github.com/growilabs/growi/issues/11052
 .drawio-viewer foreignObject {
   h1, h2, h3, h4, h5, h6,
   p, ul, ol, li, blockquote,


### PR DESCRIPTION
## Summary

Prevent GROWI's `.wiki` descendant CSS rules from cascading into HTML embedded inside drawio's `<foreignObject>`, which was causing diagram cell labels (lists, headings, paragraphs) to be clipped.

## Root Cause

- [`RevisionRenderer.tsx`](apps/app/src/components/PageView/RevisionRenderer.tsx) wraps the entire markdown output in `<div class="wiki">`.
- [`DrawioViewer`](packages/remark-drawio/src/components/DrawioViewer.tsx) renders inside that tree, so drawio's injected `<svg>` / `<foreignObject>` HTML becomes a descendant of `.wiki` in the DOM.
- CSS descendant selectors do not stop at the `<svg>` boundary, so rules in [`_wiki.scss`](apps/app/src/styles/organisms/_wiki.scss) — notably `ol li { margin: 5px 0; line-height: 1.8em; }` and the heading rules — match inside `<foreignObject>`.
- drawio sizes each cell using user-agent default HTML metrics and clips overflow via an inline `max-height` wrapper, so the inflated content height causes labels to be cut off (e.g., a 4-item list shows only the first 1–2 items).

## Changes

- [`DrawioViewer.module.scss`](packages/remark-drawio/src/components/DrawioViewer.module.scss): add `all: revert` for common HTML elements inside `.drawio-viewer foreignObject`. Mirrors the existing `.drawio-viewer * { box-sizing: content-box; }` defensive layer that protects drawio rendering from host-page CSS.

The fix lives in `@growi/remark-drawio` (not `_wiki.scss`) because:
- The drawio package owns its own rendered DOM and is the natural place to defend it from host CSS.
- It avoids introducing knowledge of `.mxgraph` (a mxgraph-library-injected class) into wiki styling.
- Any consumer of `@growi/remark-drawio`, not just `apps/app`, benefits.

## Test Plan

- [ ] Build & lint: `turbo run lint --filter @growi/remark-drawio` ✅ (already verified locally)
- [ ] Build: `turbo run build --filter @growi/remark-drawio` ✅ (already verified locally)
- [ ] Manual: paste a drawio diagram with a sticky-note cell containing `<h1>` + multi-item `<ol>` (e.g. drawio's stock template) into a wiki page; confirm all list items render and are not clipped.
- [ ] Manual: confirm existing drawio diagrams (no rich HTML in cells) still render unchanged.
- [ ] Manual: confirm Mermaid and Marp slide rendering are unaffected (the change is scoped to `.drawio-viewer` only).

Closes #11052