### PR TITLE
fix: Rebalance blockquote margins in wiki and page comments

### DIFF
--- a/apps/app/src/client/components/PageComment/Comment.module.scss
+++ b/apps/app/src/client/components/PageComment/Comment.module.scss
@@ -41,8 +41,16 @@
     // comment body
     :global(.page-comment-body) {
       word-wrap: break-word;
-      :global(.wiki p) {
-        margin: 8px 0;
+      :global(.wiki) {
+        p {
+          margin: 8px 0;
+        }
+        blockquote {
+          margin: 24px 0 8px;
+          &:first-child {
+            margin-top: 0;
+          }
+        }
       }
     }
 

--- a/apps/app/src/styles/organisms/_wiki.scss
+++ b/apps/app/src/styles/organisms/_wiki.scss
@@ -123,11 +123,15 @@
 
   blockquote {
     padding: 0 20px;
-    margin: 0 0 30px;
+    margin: 24px 0 16px;
     font-size: 0.9em;
     /* stylelint-disable-next-line scss/no-global-function-names */
     color: lighten(bs.$gray-800, 35%);
     border-left: 0.3rem solid #ddd;
+
+    &:first-child {
+      margin-top: 0;
+    }
   }
 
   img,video {


### PR DESCRIPTION
## Summary

- Change `.wiki blockquote` margin from `0 0 30px` to `24px 0 16px` — the asymmetric bottom-only margin caused a jarring visual imbalance between blockquote→paragraph (30px) and paragraph→blockquote (0px) gaps
- Add `&:first-child { margin-top: 0 }` so a blockquote at the top of a document doesn't add unnecessary whitespace
- Mirror the same fix in PageComment: add `blockquote { margin: 24px 0 8px }` override alongside the existing `p { margin: 8px 0 }` rule, keeping the two in proportion

## Before / After (margin-collapse applied)

| Gap | Before | After |
|---|---|---|
| paragraph → blockquote (wiki) | `max(15, 0)` = **15px** | `max(15, 24)` = **24px** |
| blockquote → paragraph (wiki) | `max(30, 15)` = **30px** | `max(16, 15)` = **16px** |
| PageComment: paragraph → blockquote | `max(8, 0)` = **8px** | `max(8, 24)` = **24px** |
| PageComment: blockquote → paragraph | `max(30, 8)` = **30px** | `max(8, 8)` = **8px** |

## Test plan

- [ ] Open a wiki page with blockquotes surrounded by paragraphs and verify spacing looks balanced
- [ ] Check that a page starting with a blockquote has no excess top whitespace
- [ ] Verify the same in the PageComment section
- [ ] Check both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)