### PR TITLE
fix: Code block is not line-broken in AI response

### DIFF
--- a/apps/app/src/styles/tailwind.css
+++ b/apps/app/src/styles/tailwind.css
@@ -109,6 +109,15 @@
   background: transparent;
 }
 
+/* Streamdown's CodeBlock pre-tokenises each source line into a sibling <span>
+ * (no trailing newline) and relies on the unprefixed Tailwind `block` utility
+ * to lay them out vertically. This app uses `@import "tailwindcss" prefix(tw)`,
+ * so the unprefixed class never matches and every line collapses onto one row.
+ * Force `display: block` directly on the line spans so newlines are preserved. */
+[data-streamdown="code-block-body"] > code > span {
+  display: block;
+}
+
 .tw-prose code:not(pre code) {
   padding: 0.125rem 0.375rem;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;


### PR DESCRIPTION
## Task
https://redmine.weseek.co.jp/issues/182709