### PR TITLE
always show page controls in drawer mode

### DIFF
--- a/apps/app/src/client/components/Bookmarks/BookmarkFolderItem.tsx
+++ b/apps/app/src/client/components/Bookmarks/BookmarkFolderItem.tsx
@@ -19,6 +19,7 @@ import type {
 import { DRAG_ITEM_TYPE } from '~/interfaces/bookmark-info';
 import type { onDeletedBookmarkFolderFunction } from '~/interfaces/ui';
 import { useDeleteBookmarkFolderModalActions } from '~/states/ui/modal/delete-bookmark-folder';
+import { useSidebarMode } from '~/states/ui/sidebar';
 
 import { BookmarkFolderItemControl } from './BookmarkFolderItemControl';
 import { BookmarkFolderNameInput } from './BookmarkFolderNameInput';
@@ -72,6 +73,7 @@ export const BookmarkFolderItem: FC<BookmarkFolderItemProps> = (
 
   const { open: openDeleteBookmarkFolderModal } =
     useDeleteBookmarkFolderModalActions();
+  const { isDrawerMode } = useSidebarMode();
 
   const childrenExists = hasChildren({ childFolder, bookmarks });
 
@@ -364,7 +366,7 @@ export const BookmarkFolderItem: FC<BookmarkFolderItemProps> = (
               >
                 <DropdownToggle
                   color="transparent"
-                  className="border-0 rounded btn-page-item-control p-0 grw-visible-on-hover me-1"
+                  className={`border-0 rounded btn-page-item-control p-0 ${isDrawerMode() ? '' : 'grw-visible-on-hover'} me-1`}
                   onClick={(event) => {
                     event.stopPropagation();
                   }}
@@ -377,7 +379,7 @@ export const BookmarkFolderItem: FC<BookmarkFolderItemProps> = (
                 <button
                   id="create-bookmark-folder-button"
                   type="button"
-                  className="border-0 rounded btn btn-page-item-control p-0 grw-visible-on-hover"
+                  className={`border-0 rounded btn btn-page-item-control p-0 ${isDrawerMode() ? '' : 'grw-visible-on-hover'}`}
                   onClick={onClickPlusButton}
                 >
                   <span className="material-symbols-outlined">add_circle</span>

--- a/apps/app/src/client/components/Bookmarks/BookmarkItem.tsx
+++ b/apps/app/src/client/components/Bookmarks/BookmarkItem.tsx
@@ -22,6 +22,7 @@ import type {
 import { DRAG_ITEM_TYPE } from '~/interfaces/bookmark-info';
 import { useFetchCurrentPage } from '~/states/page';
 import { usePutBackPageModalActions } from '~/states/ui/modal/put-back-page';
+import { useSidebarMode } from '~/states/ui/sidebar';
 import { mutateAllPageInfo, useSWRxPageInfo } from '~/stores/page';
 
 import {
@@ -62,6 +63,7 @@ export const BookmarkItem = (props: Props): JSX.Element => {
     bookmarkFolderTreeMutation,
   } = props;
   const { open: openPutBackPageModal } = usePutBackPageModalActions();
+  const { isDrawerMode } = useSidebarMode();
   const [isRenameInputShown, setRenameInputShown] = useState(false);
 
   const { data: pageInfo, mutate: mutatePageInfo } = useSWRxPageInfo(
@@ -258,6 +260,7 @@ export const BookmarkItem = (props: Props): JSX.Element => {
             page={bookmarkedPage}
             pageTitle={pageTitle}
             isNarrowView
+            hidePageListMeta={isDrawerMode()}
           />
         )}
 
@@ -286,7 +289,7 @@ export const BookmarkItem = (props: Props): JSX.Element => {
           >
             <DropdownToggle
               color="transparent"
-              className="border-0 rounded btn-page-item-control p-0 grw-visible-on-hover me-1"
+              className={`border-0 rounded btn-page-item-control p-0 ${isDrawerMode() ? '' : 'grw-visible-on-hover'} me-1`}
             >
               <span className="material-symbols-outlined p-1">more_vert</span>
             </DropdownToggle>

--- a/apps/app/src/client/components/PageList/PageListItemS.tsx
+++ b/apps/app/src/client/components/PageList/PageListItemS.tsx
@@ -15,10 +15,17 @@ type PageListItemSProps = {
   noLink?: boolean;
   pageTitle?: string;
   isNarrowView?: boolean;
+  hidePageListMeta?: boolean;
 };
 
 export const PageListItemS = (props: PageListItemSProps): JSX.Element => {
-  const { page, noLink = false, pageTitle, isNarrowView = false } = props;
+  const {
+    page,
+    noLink = false,
+    pageTitle,
+    isNarrowView = false,
+    hidePageListMeta = false,
+  } = props;
 
   const path = pageTitle != null ? pageTitle : page.path;
 
@@ -47,9 +54,11 @@ export const PageListItemS = (props: PageListItemSProps): JSX.Element => {
       ) : (
         pagePathElement
       )}
-      <span className="ms-1">
-        <PageListMeta page={page} shouldSpaceOutIcon />
-      </span>
+      {!hidePageListMeta && (
+        <span className="ms-1">
+          <PageListMeta page={page} shouldSpaceOutIcon />
+        </span>
+      )}
     </>
   );
 };

--- a/apps/app/src/client/components/Sidebar/PageTreeItem/PageTreeItem.tsx
+++ b/apps/app/src/client/components/Sidebar/PageTreeItem/PageTreeItem.tsx
@@ -22,6 +22,7 @@ import { useCurrentPagePath, useFetchCurrentPage } from '~/states/page';
 import { usePageDeleteModalActions } from '~/states/ui/modal/page-delete';
 import type { IPageForPageDuplicateModal } from '~/states/ui/modal/page-duplicate';
 import { usePageDuplicateModalActions } from '~/states/ui/modal/page-duplicate';
+import { useSidebarMode } from '~/states/ui/sidebar';
 import { mutateAllPageInfo } from '~/stores/page';
 import { mutatePageList, mutatePageTree } from '~/stores/page-listing';
 import { mutateSearching } from '~/stores/search';
@@ -132,6 +133,8 @@ export const PageTreeItem: FC<TreeItemProps> = ({
     ],
   );
 
+  const { isDrawerMode } = useSidebarMode();
+
   const { Control } = usePageItemControl();
 
   // Rename feature from usePageRename hook
@@ -179,8 +182,15 @@ export const PageTreeItem: FC<TreeItemProps> = ({
       onToggle={onToggle}
       onClickDuplicateMenuItem={onClickDuplicateMenuItem}
       onClickDeleteMenuItem={onClickDeleteMenuItem}
-      customEndComponents={[CountBadgeForPageTreeItem]}
-      customHoveredEndComponents={[Control, CreateButton]}
+      customEndComponents={
+        isDrawerMode() ? undefined : [CountBadgeForPageTreeItem]
+      }
+      customHoveredEndComponents={
+        isDrawerMode() ? undefined : [Control, CreateButton]
+      }
+      customPinnedEndComponents={
+        isDrawerMode() ? [Control, CreateButton] : undefined
+      }
       showAlternativeContent={isRenaming(item) || isCreatingPlaceholder(item)}
       customAlternativeComponents={[TreeNameInput]}
     />

--- a/apps/app/src/features/page-tree/components/TreeItemLayout.tsx
+++ b/apps/app/src/features/page-tree/components/TreeItemLayout.tsx
@@ -96,6 +96,7 @@ export const TreeItemLayout = (props: TreeItemLayoutProps): JSX.Element => {
 
   const EndComponents = props.customEndComponents;
   const HoveredEndComponents = props.customHoveredEndComponents;
+  const PinnedEndComponents = props.customPinnedEndComponents;
   const AlternativeComponents = props.customAlternativeComponents;
 
   if (!isWipPageShown && page.wip) {
@@ -155,6 +156,12 @@ export const TreeItemLayout = (props: TreeItemLayoutProps): JSX.Element => {
               {HoveredEndComponents?.map((HoveredEndContent, index) => (
                 // biome-ignore lint/suspicious/noArrayIndexKey: static component list
                 <HoveredEndContent key={index} {...toolProps} />
+              ))}
+            </div>
+            <div className="d-flex">
+              {PinnedEndComponents?.map((PinnedEndContent, index) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: static component list
+                <PinnedEndContent key={index} {...toolProps} />
               ))}
             </div>
           </>

--- a/apps/app/src/features/page-tree/interfaces/index.ts
+++ b/apps/app/src/features/page-tree/interfaces/index.ts
@@ -32,6 +32,7 @@ export type TreeItemProps = TreeItemBaseProps & {
   customHoveredEndComponents?: Array<
     React.FunctionComponent<TreeItemToolProps>
   >;
+  customPinnedEndComponents?: Array<React.FunctionComponent<TreeItemToolProps>>;
   customHeadOfChildrenComponents?: Array<
     React.FunctionComponent<TreeItemToolProps>
   >;


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/182754
https://redmine.weseek.co.jp/issues/182768
## 概要

drawer モードはタッチデバイスを前提としているため（既存の実装で画面幅 XL 未満のとき drawer モードになります）、
ホバーが使えず操作ボタンにアクセスできない問題がありました。

## 変更内容

### ページツリー

- `TreeItemLayout` に `customPinnedEndComponents` prop を追加（ホバー制御を受けない常時表示スロット）
- drawer モード時：
  - `Vertical Ellipsis` と "+" ボタンを `customPinnedEndComponents` 経由で常時表示に
  - 配下ページのカウントバッジ（CountBadge）を非表示

### ブックマーク

- drawer モード時：
  - ブックマーク: Vertical Ellipsis を常時表示、足跡（閲覧者数メタ情報）を非表示
  - フォルダ: Vertical Ellipsis を常時表示。加えてルートフォルダのみ "+" ボタンを常時表示（ネストフォルダは対象外）
- `PageListItemS` に `hidePageListMeta` prop を追加し、drawer モード時に `PageListMeta` を非表示
