### PR TITLE
refactor(news-inappnotification): 181356-182878 refactor stale item deletion

### DIFF
--- a/apps/app/src/features/news/server/services/news-cron-service.spec.ts
+++ b/apps/app/src/features/news/server/services/news-cron-service.spec.ts
@@ -1,17 +1,17 @@
 // Hoisted mocks
 const mocks = vi.hoisted(() => {
   const upsertNewsItems = vi.fn();
-  const deleteNewsItemsByExternalIds = vi.fn();
+  const deleteItemsNotInFeed = vi.fn();
   const mockFetch = vi.fn();
   const getGrowiVersion = vi.fn(() => '7.5.0');
 
   return {
     NewsService: vi.fn(() => ({
       upsertNewsItems,
-      deleteNewsItemsByExternalIds,
+      deleteItemsNotInFeed,
     })),
     upsertNewsItems,
-    deleteNewsItemsByExternalIds,
+    deleteItemsNotInFeed,
     mockFetch,
     getGrowiVersion,
   };
@@ -146,7 +146,10 @@ describe('NewsCronService', () => {
       await service.executeJob();
 
       expect(mocks.upsertNewsItems).toHaveBeenCalledWith(VALID_FEED.items);
-      expect(mocks.deleteNewsItemsByExternalIds).toHaveBeenCalledWith([]);
+      expect(mocks.deleteItemsNotInFeed).toHaveBeenCalledWith([
+        'item-001',
+        'item-002',
+      ]);
     });
 
     test('should NOT update DB when fetch fails', async () => {
@@ -156,7 +159,7 @@ describe('NewsCronService', () => {
       await service.executeJob();
 
       expect(mocks.upsertNewsItems).not.toHaveBeenCalled();
-      expect(mocks.deleteNewsItemsByExternalIds).not.toHaveBeenCalled();
+      expect(mocks.deleteItemsNotInFeed).not.toHaveBeenCalled();
     });
 
     test('should NOT update DB when fetch throws', async () => {

--- a/apps/app/src/features/news/server/services/news-cron-service.spec.ts
+++ b/apps/app/src/features/news/server/services/news-cron-service.spec.ts
@@ -238,5 +238,53 @@ describe('NewsCronService', () => {
         'invalid-regex-item',
       );
     });
+
+    // Regression for Requirement 1.3: items removed from the feed must be
+    // deleted from the local DB. Earlier code computed `idsToDelete` from
+    // `feedJson.items` only, so DB items absent from the feed were never
+    // cleaned up. The cron must now hand the full set of feed externalIds
+    // to `deleteItemsNotInFeed`, which uses a $nin filter to remove the rest.
+    test('should pass every feed externalId to deleteItemsNotInFeed (regression for stale-item bug)', async () => {
+      process.env.NEWS_FEED_URL = 'https://example.com/feed.json';
+      const feed = {
+        version: '1.0',
+        items: [
+          {
+            id: 'still-present-1',
+            title: { ja_JP: 'still present 1' },
+            publishedAt: '2026-01-01T00:00:00Z',
+          },
+          {
+            id: 'still-present-2',
+            title: { ja_JP: 'still present 2' },
+            publishedAt: '2026-01-02T00:00:00Z',
+          },
+          // Item present in feed but version-filtered out — must remain in
+          // the deletion safelist so it is not wiped from the DB.
+          {
+            id: 'version-filtered',
+            title: { ja_JP: 'version filtered' },
+            publishedAt: '2026-01-03T00:00:00Z',
+            conditions: { growiVersionRegExps: ['^999\\.'] },
+          },
+        ],
+      };
+      mocks.mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(feed),
+      });
+
+      await service.executeJob();
+
+      // The argument is the *full* feed externalId list, not the
+      // version-matched subset. Items absent from this list (e.g. an
+      // earlier `removed-from-feed` item still in the DB) will be
+      // deleted by the service via `$nin`.
+      expect(mocks.deleteItemsNotInFeed).toHaveBeenCalledWith([
+        'still-present-1',
+        'still-present-2',
+        'version-filtered',
+      ]);
+    });
   });
 });

--- a/apps/app/src/features/news/server/services/news-cron-service.spec.ts
+++ b/apps/app/src/features/news/server/services/news-cron-service.spec.ts
@@ -261,9 +261,21 @@ describe('NewsCronService', () => {
           },
         ],
       };
-      mocks.mockFetch.mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(feed),
+      mocks.mockFetch.mockResolvedValue(mockResponse(feed));
+
+      await service.executeJob();
+
+      // The argument is the *full* feed externalId list, not the
+      // version-matched subset. Items absent from this list (e.g. an
+      // earlier `removed-from-feed` item still in the DB) will be
+      // deleted by the service via `$nin`.
+      expect(mocks.deleteItemsNotInFeed).toHaveBeenCalledWith([
+        'still-present-1',
+        'still-present-2',
+        'version-filtered',
+      ]);
+    });
+
     test('should skip when response body exceeds size limit (5 MiB)', async () => {
       process.env.NEWS_FEED_URL = 'https://example.com/feed.json';
       // Build a string that exceeds 5 MiB
@@ -324,15 +336,6 @@ describe('NewsCronService', () => {
 
       await service.executeJob();
 
-      // The argument is the *full* feed externalId list, not the
-      // version-matched subset. Items absent from this list (e.g. an
-      // earlier `removed-from-feed` item still in the DB) will be
-      // deleted by the service via `$nin`.
-      expect(mocks.deleteItemsNotInFeed).toHaveBeenCalledWith([
-        'still-present-1',
-        'still-present-2',
-        'version-filtered',
-      ]);
       expect(mocks.upsertNewsItems).not.toHaveBeenCalled();
     });
   });

--- a/apps/app/src/features/news/server/services/news-cron-service.ts
+++ b/apps/app/src/features/news/server/services/news-cron-service.ts
@@ -132,15 +132,14 @@ export class NewsCronService extends CronService {
         : undefined,
     }));
 
-    const feedIds = new Set(filteredItems.map((item) => item.id));
-
-    // Get all existing external IDs to find which ones are no longer in the feed
-    // We pass all filtered items' IDs — items not in the feed are determined by exclusion
-    const allFeedIds = feedJson.items.map((item) => item.id);
-    const idsToDelete = allFeedIds.filter((id) => !feedIds.has(id));
+    // Pass the full set of feed externalIds so the service can delete any DB
+    // item that is no longer present in the feed (Requirement 1.3). Includes
+    // items filtered out by version match — those remain "in the feed" and
+    // are allowed to age out via the NewsItem TTL.
+    const feedExternalIds = feedJson.items.map((item) => item.id);
 
     const service = new NewsService();
     await service.upsertNewsItems(newsItemInputs);
-    await service.deleteNewsItemsByExternalIds(idsToDelete);
+    await service.deleteItemsNotInFeed(feedExternalIds);
   }
 }

--- a/apps/app/src/features/news/server/services/news-service.spec.ts
+++ b/apps/app/src/features/news/server/services/news-service.spec.ts
@@ -437,4 +437,26 @@ describe('NewsService', () => {
       expect(mocks.newsItemDeleteMany).not.toHaveBeenCalled();
     });
   });
+
+  describe('deleteItemsNotInFeed', () => {
+    test('should call deleteMany with $nin filter for items not in feed', async () => {
+      mocks.newsItemDeleteMany.mockResolvedValue({ deletedCount: 1 });
+
+      await service.deleteItemsNotInFeed(['ext-001', 'ext-002']);
+
+      expect(mocks.newsItemDeleteMany).toHaveBeenCalledWith({
+        externalId: { $nin: ['ext-001', 'ext-002'] },
+      });
+    });
+
+    test('should call deleteMany with $nin: [] when feed is empty (deletes all cached items)', async () => {
+      mocks.newsItemDeleteMany.mockResolvedValue({ deletedCount: 5 });
+
+      await service.deleteItemsNotInFeed([]);
+
+      expect(mocks.newsItemDeleteMany).toHaveBeenCalledWith({
+        externalId: { $nin: [] },
+      });
+    });
+  });
 });

--- a/apps/app/src/features/news/server/services/news-service.spec.ts
+++ b/apps/app/src/features/news/server/services/news-service.spec.ts
@@ -421,23 +421,6 @@ describe('NewsService', () => {
     });
   });
 
-  describe('deleteNewsItemsByExternalIds', () => {
-    test('should call deleteMany with externalId filter', async () => {
-      mocks.newsItemDeleteMany.mockResolvedValue({ deletedCount: 1 });
-
-      await service.deleteNewsItemsByExternalIds(['ext-001', 'ext-002']);
-
-      expect(mocks.newsItemDeleteMany).toHaveBeenCalledWith({
-        externalId: { $in: ['ext-001', 'ext-002'] },
-      });
-    });
-
-    test('should do nothing if externalIds is empty', async () => {
-      await service.deleteNewsItemsByExternalIds([]);
-      expect(mocks.newsItemDeleteMany).not.toHaveBeenCalled();
-    });
-  });
-
   describe('deleteItemsNotInFeed', () => {
     test('should call deleteMany with $nin filter for items not in feed', async () => {
       mocks.newsItemDeleteMany.mockResolvedValue({ deletedCount: 1 });

--- a/apps/app/src/features/news/server/services/news-service.ts
+++ b/apps/app/src/features/news/server/services/news-service.ts
@@ -178,4 +178,16 @@ export class NewsService {
 
     await NewsItem.deleteMany({ externalId: { $in: externalIds } });
   }
+
+  /**
+   * Delete every cached news item whose externalId is NOT in the supplied set.
+   * Caller passes the full list of externalIds present in the latest feed; any DB
+   * item missing from that list is considered stale and removed (Requirement 1.3).
+   *
+   * Note: passing an empty array means "feed has no items" and will delete every
+   * cached news item. Callers must only invoke this after a successful feed fetch.
+   */
+  async deleteItemsNotInFeed(feedExternalIds: string[]): Promise<void> {
+    await NewsItem.deleteMany({ externalId: { $nin: feedExternalIds } });
+  }
 }

--- a/apps/app/src/features/news/server/services/news-service.ts
+++ b/apps/app/src/features/news/server/services/news-service.ts
@@ -171,15 +171,6 @@ export class NewsService {
   }
 
   /**
-   * Delete news items that are no longer in the feed
-   */
-  async deleteNewsItemsByExternalIds(externalIds: string[]): Promise<void> {
-    if (externalIds.length === 0) return;
-
-    await NewsItem.deleteMany({ externalId: { $in: externalIds } });
-  }
-
-  /**
    * Delete every cached news item whose externalId is NOT in the supplied set.
    * Caller passes the full list of externalIds present in the latest feed; any DB
    * item missing from that list is considered stale and removed (Requirement 1.3).


### PR DESCRIPTION
### Task
https://redmine.weseek.co.jp/issues/182878

### What
配信元から削除されたニュースが GROWI本体 に残り続けるバグ（要件違反）の修正

<h3 style="line-height: normal; font-size: 13px; font-weight: 600; margin: 1.5em 0px 0.875em; font-family: -apple-system, &quot;system-ui&quot;, sans-serif; color: rgb(191, 191, 191); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">概要</h3><p style="margin: 0px 0px 16px; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">ニュースフィードのキャッシュと外部フィード状態の<span> </span><strong style="font-weight: 600;">整合性を回復させるリファクタリング</strong>。Cron 実行時に「フィードから消えた news item」が DB に残り続ける挙動（要件 1.3 違反）を修正し、検出のための回帰テストを追加。</p><h3 style="line-height: normal; font-size: 13px; font-weight: 600; margin: 1.5em 0px 0.875em; font-family: -apple-system, &quot;system-ui&quot;, sans-serif; color: rgb(191, 191, 191); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">変更内容</h3><div class="monaco-scrollable-element mac rendered-markdown-table-scroll-wrapper" role="presentation" style="width: 918px; margin-bottom: 16px; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; position: relative; overflow: hidden;"><div style="overflow: hidden;">

`-` | コミット | 内容 | 修正の説明
-- | -- | -- | --
1 | df5196c | バグ修正本体 | idsToDelete の算出が「バージョンフィルタで弾かれた item」を対象にしており、DB と feed の集合差分になっていなかった。NewsService.deleteItemsNotInFeed(feedExternalIds) を新設し、$nin で「feed に無い item」を削除する正しい意味論に置き換え。<br>防止対象: フィード提供側で削除したニュースが DB に最大 90 日（TTL 期限）残り続け、フィード元の意図と GROWI 側表示が乖離する状態
2 | 31d5c09 | 旧メソッド削除 | コミット 1 で参照を切り替えたあと未使用となった deleteNewsItemsByExternalIds() メソッドとそのテストを除去。<br>防止対象: 同義の 2 メソッド共存による誤用（次の改修で $in 系の旧 API を再び呼んでしまうリスク）
3 | bd81bab | 回帰テスト追加 | 当初のバグを通してしまった原因 — news-cron-service.spec.ts に削除パスの assertion が存在しなかった点 — を埋める。Cron が フィード全 externalId（バージョン不一致 item を含む） を deleteItemsNotInFeed に渡すことを検証。<br>防止対象: 同種の集合演算ミス（version-filtered と feed-removed の混同）が今後再発した場合、CI で確実に検知できないこと

</div><div role="presentation" aria-hidden="true" class="invisible scrollbar horizontal" style="opacity: 0; pointer-events: none; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(0, 0, 0, 0); position: absolute; width: 918px; height: 10px; left: 0px; bottom: 0px;"><div class="slider" style="background: none 0% 0% / auto repeat scroll padding-box border-box rgba(131, 132, 133, 0.2); position: absolute; top: 0px; left: 0px; height: 10px; transform: translate3d(0px, 0px, 0px); contain: strict; width: 918px;"></div></div><div role="presentation" aria-hidden="true" class="invisible scrollbar vertical" style="opacity: 0; pointer-events: none; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(0, 0, 0, 0); z-index: 14; position: absolute; width: 0px; height: 273px; right: 0px; top: 0px;"><div class="slider" style="background: none 0% 0% / auto repeat scroll padding-box border-box rgba(131, 132, 133, 0.2); position: absolute; top: 0px; left: 0px; width: 10px; transform: translate3d(0px, 0px, 0px); contain: strict; height: 273px;"></div></div></div><h3 style="line-height: normal; font-size: 13px; font-weight: 600; margin: 1.5em 0px 0.875em; font-family: -apple-system, &quot;system-ui&quot;, sans-serif; color: rgb(191, 191, 191); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">アーキテクチャ原則</h3><p style="margin: 0px 0px 16px; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">「<strong style="font-weight: 600;">外部フィードを Source of Truth、DB はキャッシュ</strong>」というデータフローを再確立。コミット 1 はそのキャッシュ無効化ロジックの正常化、コミット 3 は同種のロジック誤りに対する CI gate を追加。</p><h3 style="line-height: normal; font-size: 13px; font-weight: 600; margin: 1.5em 0px 0.875em; font-family: -apple-system, &quot;system-ui&quot;, sans-serif; color: rgb(191, 191, 191); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Test</h3><ul style="padding-inline-start: 24px; margin-bottom: 0px; color: rgb(191, 191, 191); font-family: -apple-system, &quot;system-ui&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="margin: 4px 0px;">既存 71 件 + 新規回帰テスト 1 件 = 72 件すべて pass</li><li style="margin: 4px 0px;">削除した dead test 2 件分を含めると net +1 件のカバレッジ純増</li></ul>