### PR TITLE
feat: always show page path header buttons on mobile

### DIFF
--- a/apps/app/src/client/components/Bookmarks/BookmarkFolderItem.tsx
+++ b/apps/app/src/client/components/Bookmarks/BookmarkFolderItem.tsx
@@ -19,6 +19,7 @@ import type {
 import { DRAG_ITEM_TYPE } from '~/interfaces/bookmark-info';
 import type { onDeletedBookmarkFolderFunction } from '~/interfaces/ui';
 import { useDeleteBookmarkFolderModalActions } from '~/states/ui/modal/delete-bookmark-folder';
+import { useSidebarMode } from '~/states/ui/sidebar';
 
 import { BookmarkFolderItemControl } from './BookmarkFolderItemControl';
 import { BookmarkFolderNameInput } from './BookmarkFolderNameInput';
@@ -72,6 +73,7 @@ export const BookmarkFolderItem: FC<BookmarkFolderItemProps> = (
 
   const { open: openDeleteBookmarkFolderModal } =
     useDeleteBookmarkFolderModalActions();
+  const { isDrawerMode } = useSidebarMode();
 
   const childrenExists = hasChildren({ childFolder, bookmarks });
 
@@ -364,7 +366,7 @@ export const BookmarkFolderItem: FC<BookmarkFolderItemProps> = (
               >
                 <DropdownToggle
                   color="transparent"
-                  className="border-0 rounded btn-page-item-control p-0 grw-visible-on-hover me-1"
+                  className={`border-0 rounded btn-page-item-control p-0 ${isDrawerMode() ? '' : 'grw-visible-on-hover'} me-1`}
                   onClick={(event) => {
                     event.stopPropagation();
                   }}
@@ -377,7 +379,7 @@ export const BookmarkFolderItem: FC<BookmarkFolderItemProps> = (
                 <button
                   id="create-bookmark-folder-button"
                   type="button"
-                  className="border-0 rounded btn btn-page-item-control p-0 grw-visible-on-hover"
+                  className={`border-0 rounded btn btn-page-item-control p-0 ${isDrawerMode() ? '' : 'grw-visible-on-hover'}`}
                   onClick={onClickPlusButton}
                 >
                   <span className="material-symbols-outlined">add_circle</span>

--- a/apps/app/src/client/components/Bookmarks/BookmarkFolderItem.tsx
+++ b/apps/app/src/client/components/Bookmarks/BookmarkFolderItem.tsx
@@ -366,7 +366,7 @@ export const BookmarkFolderItem: FC<BookmarkFolderItemProps> = (
               >
                 <DropdownToggle
                   color="transparent"
-                  className={`border-0 rounded btn-page-item-control p-0 grw-visible-on-hover ${isMobile ? 'grw-pinned' : ''} me-1`}
+                  className={`border-0 rounded btn-page-item-control p-0 ${isMobile ? '' : 'grw-visible-on-hover'} me-1`}
                   onClick={(event) => {
                     event.stopPropagation();
                   }}
@@ -379,7 +379,7 @@ export const BookmarkFolderItem: FC<BookmarkFolderItemProps> = (
                 <button
                   id="create-bookmark-folder-button"
                   type="button"
-                  className={`border-0 rounded btn btn-page-item-control p-0 grw-visible-on-hover ${isMobile ? 'grw-pinned' : ''}`}
+                  className={`border-0 rounded btn btn-page-item-control p-0 ${isMobile ? '' : 'grw-visible-on-hover'}`}
                   onClick={onClickPlusButton}
                 >
                   <span className="material-symbols-outlined">add_circle</span>

--- a/apps/app/src/client/components/Bookmarks/BookmarkFolderItem.tsx
+++ b/apps/app/src/client/components/Bookmarks/BookmarkFolderItem.tsx
@@ -18,8 +18,8 @@ import type {
 } from '~/interfaces/bookmark-info';
 import { DRAG_ITEM_TYPE } from '~/interfaces/bookmark-info';
 import type { onDeletedBookmarkFolderFunction } from '~/interfaces/ui';
+import { useIsMobile } from '~/states/ui/device';
 import { useDeleteBookmarkFolderModalActions } from '~/states/ui/modal/delete-bookmark-folder';
-import { useSidebarMode } from '~/states/ui/sidebar';
 
 import { BookmarkFolderItemControl } from './BookmarkFolderItemControl';
 import { BookmarkFolderNameInput } from './BookmarkFolderNameInput';
@@ -73,7 +73,7 @@ export const BookmarkFolderItem: FC<BookmarkFolderItemProps> = (
 
   const { open: openDeleteBookmarkFolderModal } =
     useDeleteBookmarkFolderModalActions();
-  const { isDrawerMode } = useSidebarMode();
+  const [isMobile] = useIsMobile();
 
   const childrenExists = hasChildren({ childFolder, bookmarks });
 
@@ -366,7 +366,7 @@ export const BookmarkFolderItem: FC<BookmarkFolderItemProps> = (
               >
                 <DropdownToggle
                   color="transparent"
-                  className={`border-0 rounded btn-page-item-control p-0 ${isDrawerMode() ? '' : 'grw-visible-on-hover'} me-1`}
+                  className={`border-0 rounded btn-page-item-control p-0 grw-visible-on-hover ${isMobile ? 'grw-pinned' : ''} me-1`}
                   onClick={(event) => {
                     event.stopPropagation();
                   }}
@@ -379,7 +379,7 @@ export const BookmarkFolderItem: FC<BookmarkFolderItemProps> = (
                 <button
                   id="create-bookmark-folder-button"
                   type="button"
-                  className={`border-0 rounded btn btn-page-item-control p-0 ${isDrawerMode() ? '' : 'grw-visible-on-hover'}`}
+                  className={`border-0 rounded btn btn-page-item-control p-0 grw-visible-on-hover ${isMobile ? 'grw-pinned' : ''}`}
                   onClick={onClickPlusButton}
                 >
                   <span className="material-symbols-outlined">add_circle</span>

--- a/apps/app/src/client/components/Bookmarks/BookmarkFolderTree.module.scss
+++ b/apps/app/src/client/components/Bookmarks/BookmarkFolderTree.module.scss
@@ -29,6 +29,10 @@ $grw-bookmark-item-padding-left: 35px;
       display: none;
     }
 
+    :global(.grw-visible-on-hover.grw-pinned) {
+      display: block;
+    }
+
     &:hover {
       :global(.grw-visible-on-hover) {
         display: block;

--- a/apps/app/src/client/components/Bookmarks/BookmarkFolderTree.module.scss
+++ b/apps/app/src/client/components/Bookmarks/BookmarkFolderTree.module.scss
@@ -29,10 +29,6 @@ $grw-bookmark-item-padding-left: 35px;
       display: none;
     }
 
-    :global(.grw-visible-on-hover.grw-pinned) {
-      display: block;
-    }
-
     &:hover {
       :global(.grw-visible-on-hover) {
         display: block;

--- a/apps/app/src/client/components/Bookmarks/BookmarkItem.tsx
+++ b/apps/app/src/client/components/Bookmarks/BookmarkItem.tsx
@@ -22,6 +22,7 @@ import type {
 import { DRAG_ITEM_TYPE } from '~/interfaces/bookmark-info';
 import { useFetchCurrentPage } from '~/states/page';
 import { usePutBackPageModalActions } from '~/states/ui/modal/put-back-page';
+import { useSidebarMode } from '~/states/ui/sidebar';
 import { mutateAllPageInfo, useSWRxPageInfo } from '~/stores/page';
 
 import {
@@ -62,6 +63,7 @@ export const BookmarkItem = (props: Props): JSX.Element => {
     bookmarkFolderTreeMutation,
   } = props;
   const { open: openPutBackPageModal } = usePutBackPageModalActions();
+  const { isDrawerMode } = useSidebarMode();
   const [isRenameInputShown, setRenameInputShown] = useState(false);
 
   const { data: pageInfo, mutate: mutatePageInfo } = useSWRxPageInfo(
@@ -258,6 +260,7 @@ export const BookmarkItem = (props: Props): JSX.Element => {
             page={bookmarkedPage}
             pageTitle={pageTitle}
             isNarrowView
+            hidePageListMeta={isDrawerMode()}
           />
         )}
 
@@ -286,7 +289,7 @@ export const BookmarkItem = (props: Props): JSX.Element => {
           >
             <DropdownToggle
               color="transparent"
-              className="border-0 rounded btn-page-item-control p-0 grw-visible-on-hover me-1"
+              className={`border-0 rounded btn-page-item-control p-0 ${isDrawerMode() ? '' : 'grw-visible-on-hover'} me-1`}
             >
               <span className="material-symbols-outlined p-1">more_vert</span>
             </DropdownToggle>

--- a/apps/app/src/client/components/Bookmarks/BookmarkItem.tsx
+++ b/apps/app/src/client/components/Bookmarks/BookmarkItem.tsx
@@ -21,8 +21,8 @@ import type {
 } from '~/interfaces/bookmark-info';
 import { DRAG_ITEM_TYPE } from '~/interfaces/bookmark-info';
 import { useFetchCurrentPage } from '~/states/page';
+import { useIsMobile } from '~/states/ui/device';
 import { usePutBackPageModalActions } from '~/states/ui/modal/put-back-page';
-import { useSidebarMode } from '~/states/ui/sidebar';
 import { mutateAllPageInfo, useSWRxPageInfo } from '~/stores/page';
 
 import {
@@ -63,7 +63,7 @@ export const BookmarkItem = (props: Props): JSX.Element => {
     bookmarkFolderTreeMutation,
   } = props;
   const { open: openPutBackPageModal } = usePutBackPageModalActions();
-  const { isDrawerMode } = useSidebarMode();
+  const [isMobile] = useIsMobile();
   const [isRenameInputShown, setRenameInputShown] = useState(false);
 
   const { data: pageInfo, mutate: mutatePageInfo } = useSWRxPageInfo(
@@ -260,7 +260,7 @@ export const BookmarkItem = (props: Props): JSX.Element => {
             page={bookmarkedPage}
             pageTitle={pageTitle}
             isNarrowView
-            hidePageListMeta={isDrawerMode()}
+            hidePageListMeta={isMobile}
           />
         )}
 
@@ -289,7 +289,7 @@ export const BookmarkItem = (props: Props): JSX.Element => {
           >
             <DropdownToggle
               color="transparent"
-              className={`border-0 rounded btn-page-item-control p-0 ${isDrawerMode() ? '' : 'grw-visible-on-hover'} me-1`}
+              className={`border-0 rounded btn-page-item-control p-0 grw-visible-on-hover ${isMobile ? 'grw-pinned' : ''} me-1`}
             >
               <span className="material-symbols-outlined p-1">more_vert</span>
             </DropdownToggle>

--- a/apps/app/src/client/components/Bookmarks/BookmarkItem.tsx
+++ b/apps/app/src/client/components/Bookmarks/BookmarkItem.tsx
@@ -289,7 +289,7 @@ export const BookmarkItem = (props: Props): JSX.Element => {
           >
             <DropdownToggle
               color="transparent"
-              className={`border-0 rounded btn-page-item-control p-0 grw-visible-on-hover ${isMobile ? 'grw-pinned' : ''} me-1`}
+              className={`border-0 rounded btn-page-item-control p-0 ${isMobile ? '' : 'grw-visible-on-hover'} me-1`}
             >
               <span className="material-symbols-outlined p-1">more_vert</span>
             </DropdownToggle>

--- a/apps/app/src/client/components/PageHeader/PagePathHeader.tsx
+++ b/apps/app/src/client/components/PageHeader/PagePathHeader.tsx
@@ -14,6 +14,7 @@ import {
 } from '~/client/util/use-input-validator';
 import type { IPageForItem } from '~/interfaces/page';
 import { LinkedPagePath } from '~/models/linked-page-path';
+import { useIsMobile } from '~/states/ui/device';
 import { usePageSelectModalActions } from '~/states/ui/modal/page-select';
 
 import { PagePathHierarchicalLink } from '../../../components/Common/PagePathHierarchicalLink';
@@ -45,6 +46,7 @@ export const PagePathHeader = memo((props: Props): JSX.Element => {
 
   const [isRenameInputShown, setRenameInputShown] = useState(false);
   const [isHover, setHover] = useState(false);
+  const [isMobile] = useIsMobile();
 
   const { open: openPageSelectModal } = usePageSelectModalActions();
 
@@ -166,7 +168,7 @@ export const PagePathHeader = memo((props: Props): JSX.Element => {
       </div>
 
       <div
-        className={`page-path-header-buttons d-flex align-items-center ms-2 ${isHover && !isRenameInputShown ? '' : 'invisible'}`}
+        className={`page-path-header-buttons d-flex align-items-center ms-2 ${(isMobile || isHover) && !isRenameInputShown ? '' : 'invisible'}`}
       >
         <button
           type="button"

--- a/apps/app/src/client/components/PageList/PageListItemS.tsx
+++ b/apps/app/src/client/components/PageList/PageListItemS.tsx
@@ -15,10 +15,17 @@ type PageListItemSProps = {
   noLink?: boolean;
   pageTitle?: string;
   isNarrowView?: boolean;
+  hidePageListMeta?: boolean;
 };
 
 export const PageListItemS = (props: PageListItemSProps): JSX.Element => {
-  const { page, noLink = false, pageTitle, isNarrowView = false } = props;
+  const {
+    page,
+    noLink = false,
+    pageTitle,
+    isNarrowView = false,
+    hidePageListMeta = false,
+  } = props;
 
   const path = pageTitle != null ? pageTitle : page.path;
 
@@ -47,9 +54,11 @@ export const PageListItemS = (props: PageListItemSProps): JSX.Element => {
       ) : (
         pagePathElement
       )}
-      <span className="ms-1">
-        <PageListMeta page={page} shouldSpaceOutIcon />
-      </span>
+      {!hidePageListMeta && (
+        <span className="ms-1">
+          <PageListMeta page={page} shouldSpaceOutIcon />
+        </span>
+      )}
     </>
   );
 };

--- a/apps/app/src/client/components/Sidebar/PageTreeItem/PageTreeItem.tsx
+++ b/apps/app/src/client/components/Sidebar/PageTreeItem/PageTreeItem.tsx
@@ -22,6 +22,7 @@ import { useCurrentPagePath, useFetchCurrentPage } from '~/states/page';
 import { usePageDeleteModalActions } from '~/states/ui/modal/page-delete';
 import type { IPageForPageDuplicateModal } from '~/states/ui/modal/page-duplicate';
 import { usePageDuplicateModalActions } from '~/states/ui/modal/page-duplicate';
+import { useSidebarMode } from '~/states/ui/sidebar';
 import { mutateAllPageInfo } from '~/stores/page';
 import { mutatePageList, mutatePageTree } from '~/stores/page-listing';
 import { mutateSearching } from '~/stores/search';

--- a/apps/app/src/client/components/Sidebar/PageTreeItem/PageTreeItem.tsx
+++ b/apps/app/src/client/components/Sidebar/PageTreeItem/PageTreeItem.tsx
@@ -134,6 +134,7 @@ export const PageTreeItem: FC<TreeItemProps> = ({
   );
 
   const { isDrawerMode } = useSidebarMode();
+  const drawerMode = isDrawerMode();
 
   const { Control } = usePageItemControl();
 
@@ -143,6 +144,8 @@ export const PageTreeItem: FC<TreeItemProps> = ({
   // Page create feature
   const { cancelCreating, CreateButton, isCreatingPlaceholder } =
     usePageCreate();
+
+  const pageControls = [Control, CreateButton];
 
   // Manage placeholder renaming mode (auto-start, track, and cancel on Esc)
   usePlaceholderRenameEffect({
@@ -182,15 +185,9 @@ export const PageTreeItem: FC<TreeItemProps> = ({
       onToggle={onToggle}
       onClickDuplicateMenuItem={onClickDuplicateMenuItem}
       onClickDeleteMenuItem={onClickDeleteMenuItem}
-      customEndComponents={
-        isDrawerMode() ? undefined : [CountBadgeForPageTreeItem]
-      }
-      customHoveredEndComponents={
-        isDrawerMode() ? undefined : [Control, CreateButton]
-      }
-      customPinnedEndComponents={
-        isDrawerMode() ? [Control, CreateButton] : undefined
-      }
+      customEndComponents={drawerMode ? undefined : [CountBadgeForPageTreeItem]}
+      customHoveredEndComponents={drawerMode ? undefined : pageControls}
+      customPinnedEndComponents={drawerMode ? pageControls : undefined}
       showAlternativeContent={isRenaming(item) || isCreatingPlaceholder(item)}
       customAlternativeComponents={[TreeNameInput]}
     />

--- a/apps/app/src/client/components/Sidebar/PageTreeItem/PageTreeItem.tsx
+++ b/apps/app/src/client/components/Sidebar/PageTreeItem/PageTreeItem.tsx
@@ -19,10 +19,10 @@ import { TreeItemLayout, TreeNameInput } from '~/features/page-tree/components';
 import type { IPageForItem } from '~/interfaces/page';
 import type { OnDeletedFunction, OnDuplicatedFunction } from '~/interfaces/ui';
 import { useCurrentPagePath, useFetchCurrentPage } from '~/states/page';
+import { useIsMobile } from '~/states/ui/device';
 import { usePageDeleteModalActions } from '~/states/ui/modal/page-delete';
 import type { IPageForPageDuplicateModal } from '~/states/ui/modal/page-duplicate';
 import { usePageDuplicateModalActions } from '~/states/ui/modal/page-duplicate';
-import { useSidebarMode } from '~/states/ui/sidebar';
 import { mutateAllPageInfo } from '~/stores/page';
 import { mutatePageList, mutatePageTree } from '~/stores/page-listing';
 import { mutateSearching } from '~/stores/search';
@@ -133,8 +133,7 @@ export const PageTreeItem: FC<TreeItemProps> = ({
     ],
   );
 
-  const { isDrawerMode } = useSidebarMode();
-  const drawerMode = isDrawerMode();
+  const [isMobile] = useIsMobile();
 
   const { Control } = usePageItemControl();
 
@@ -185,9 +184,9 @@ export const PageTreeItem: FC<TreeItemProps> = ({
       onToggle={onToggle}
       onClickDuplicateMenuItem={onClickDuplicateMenuItem}
       onClickDeleteMenuItem={onClickDeleteMenuItem}
-      customEndComponents={drawerMode ? undefined : [CountBadgeForPageTreeItem]}
-      customHoveredEndComponents={drawerMode ? undefined : pageControls}
-      customPinnedEndComponents={drawerMode ? pageControls : undefined}
+      customEndComponents={isMobile ? undefined : [CountBadgeForPageTreeItem]}
+      customHoveredEndComponents={isMobile ? undefined : pageControls}
+      customPinnedEndComponents={isMobile ? pageControls : undefined}
       showAlternativeContent={isRenaming(item) || isCreatingPlaceholder(item)}
       customAlternativeComponents={[TreeNameInput]}
     />

--- a/apps/app/src/features/page-tree/components/TreeItemLayout.tsx
+++ b/apps/app/src/features/page-tree/components/TreeItemLayout.tsx
@@ -96,6 +96,7 @@ export const TreeItemLayout = (props: TreeItemLayoutProps): JSX.Element => {
 
   const EndComponents = props.customEndComponents;
   const HoveredEndComponents = props.customHoveredEndComponents;
+  const PinnedEndComponents = props.customPinnedEndComponents;
   const AlternativeComponents = props.customAlternativeComponents;
 
   if (!isWipPageShown && page.wip) {
@@ -155,6 +156,12 @@ export const TreeItemLayout = (props: TreeItemLayoutProps): JSX.Element => {
               {HoveredEndComponents?.map((HoveredEndContent, index) => (
                 // biome-ignore lint/suspicious/noArrayIndexKey: static component list
                 <HoveredEndContent key={index} {...toolProps} />
+              ))}
+            </div>
+            <div className="d-flex">
+              {PinnedEndComponents?.map((PinnedEndContent, index) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: static component list
+                <PinnedEndContent key={index} {...toolProps} />
               ))}
             </div>
           </>

--- a/apps/app/src/features/page-tree/interfaces/index.ts
+++ b/apps/app/src/features/page-tree/interfaces/index.ts
@@ -32,6 +32,7 @@ export type TreeItemProps = TreeItemBaseProps & {
   customHoveredEndComponents?: Array<
     React.FunctionComponent<TreeItemToolProps>
   >;
+  customPinnedEndComponents?: Array<React.FunctionComponent<TreeItemToolProps>>;
   customHeadOfChildrenComponents?: Array<
     React.FunctionComponent<TreeItemToolProps>
   >;


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/182764
<img width="996" height="388" alt="スクリーンショット 2026-05-08 160956" src="https://github.com/user-attachments/assets/e45a7437-8a4f-4a83-9479-4f3b7e88e979" />

編集モードのページパスヘッダーに表示される「親ページ編集」「ページ場所選択」ボタンが、モバイルでは操作不能になっていた問題を修正しました。

useIsMobile で、モバイル時は hover 状態に関わらずボタンを常時表示するよう変更

