### PR TITLE
fix: always show page path header buttons on mobile

### DIFF
--- a/apps/app/src/client/components/PageHeader/PagePathHeader.tsx
+++ b/apps/app/src/client/components/PageHeader/PagePathHeader.tsx
@@ -14,6 +14,7 @@ import {
 } from '~/client/util/use-input-validator';
 import type { IPageForItem } from '~/interfaces/page';
 import { LinkedPagePath } from '~/models/linked-page-path';
+import { useIsMobile } from '~/states/ui/device';
 import { usePageSelectModalActions } from '~/states/ui/modal/page-select';
 
 import { PagePathHierarchicalLink } from '../../../components/Common/PagePathHierarchicalLink';
@@ -45,6 +46,7 @@ export const PagePathHeader = memo((props: Props): JSX.Element => {
 
   const [isRenameInputShown, setRenameInputShown] = useState(false);
   const [isHover, setHover] = useState(false);
+  const [isMobile] = useIsMobile();
 
   const { open: openPageSelectModal } = usePageSelectModalActions();
 
@@ -166,7 +168,7 @@ export const PagePathHeader = memo((props: Props): JSX.Element => {
       </div>
 
       <div
-        className={`page-path-header-buttons d-flex align-items-center ms-2 ${isHover && !isRenameInputShown ? '' : 'invisible'}`}
+        className={`page-path-header-buttons d-flex align-items-center ms-2 ${(isMobile || isHover) && !isRenameInputShown ? '' : 'invisible'}`}
       >
         <button
           type="button"


### PR DESCRIPTION
### redmine
https://redmine.weseek.co.jp/issues/182764

### ↓のFB対応
https://github.com/growilabs/growi/pull/11090#pullrequestreview-4270068601

https://github.com/growilabs/growi/pull/11075
↑の差分が含まれてしまっていたので、正しい差分のプルリクを作り直しました

https://redmine.weseek.co.jp/issues/182764
<img width="996" height="388" alt="スクリーンショット 2026-05-08 160956" src="https://github.com/user-attachments/assets/e45a7437-8a4f-4a83-9479-4f3b7e88e979" />

### 説明
編集モードのページパスヘッダーに表示される「親ページ編集」「ページ場所選択」ボタンが、モバイルでは操作不能になっていた問題を修正しました。

useIsMobile で、モバイル時は hover 状態に関わらずボタンを常時表示するよう変更

