### PR TITLE
fix(admin): stop infinite render loop on G2G data transfer page

### DIFF
--- a/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
+++ b/apps/app/src/client/components/Admin/G2GDataTransfer.tsx
@@ -54,13 +54,16 @@ const G2GDataTransfer = (): JSX.Element => {
   // const [gcsBucket, setGcsBucket] = useState('');
   // const [gcsUploadNamespace, setGcsUploadNamespace] = useState('');
 
-  const updateSelectedCollections = (newSelectedCollections: Set<string>) => {
-    setSelectedCollections(newSelectedCollections);
-  };
+  const updateSelectedCollections = useCallback(
+    (newSelectedCollections: Set<string>) => {
+      setSelectedCollections(newSelectedCollections);
+    },
+    [],
+  );
 
-  const updateOptionsMap = (newOptionsMap: any) => {
+  const updateOptionsMap = useCallback((newOptionsMap: any) => {
     setOptionsMap(newOptionsMap);
-  };
+  }, []);
 
   const onChangeTransferKeyHandler = useCallback((e) => {
     setStartTransferKey(e.target.value);


### PR DESCRIPTION
## Summary

管理画面「データ移行」ページを開くとコンテンツ領域がフリーズし、他メニューに遷移できなくなる問題を修正します。

## Root Cause

ブラウザコンソールに `Maximum update depth exceeded` の警告が出ており、`G2GDataTransfer` と `G2GDataTransferExportForm` 間の **関数参照の不安定性による無限 setState ループ** が原因でした。

### 関数参照の毎レンダ更新

親 `G2GDataTransfer.tsx` の `updateSelectedCollections` / `updateOptionsMap` は `useCallback` でラップされていない素の関数で、親が再レンダされるたびに新しい関数オブジェクトが生成されていました。JavaScript では関数リテラルは毎回別の参照になります（`(() => {}) === (() => {})` は `false`）。

### React deps の参照比較を介した連鎖

React の `useCallback` / `useEffect` の deps 比較は `Object.is` であり、参照が変われば「依存変化」として再生成 / 再実行されます。子 `G2GDataTransferExportForm.tsx` には次のチェーンがあります:

```tsx
const setInitialOptionsMap = useCallback(() => {
  // ...
  updateOptionsMap(initialOptionsMap);
}, [allCollectionNames, updateOptionsMap]);  // ← updateOptionsMap が deps に含まれる

useEffect(() => {
  setInitialOptionsMap();
}, [setInitialOptionsMap]);                  // ← setInitialOptionsMap が deps に含まれる
```

このため次のループが発生していました:

1. 子 mount → `useEffect` 発火 → `updateOptionsMap(initialOptionsMap)` → 親 `setOptionsMap` → 親 re-render
2. 親 re-render で `updateOptionsMap` の **新しい関数オブジェクトが生成される**
3. 子に新参照が props で渡る → `setInitialOptionsMap` の `useCallback` deps 変化 → 新参照
4. `useEffect` の deps (`setInitialOptionsMap`) も変化 → effect 再実行
5. 1 に戻る → 無限ループ → ブラウザフリーズ

`Maximum update depth exceeded` は React が同期的な setState 連鎖を一定回数で打ち切るセーフティで、本質的にはブラウザのタブが CPU を食い尽くす前に React 側で止めている状態でした。報告された「データ移行の画面から動かなくなる（他の項目を選択しリロードすれば直る）」はこの結果です。

## Why `useCallback` with empty deps works

修正は deps を追加しているのではなく、**親側の関数参照を安定化させ、子側の既存 deps が誤って "変化した" と判定されるのを止める** ものです。

- `useCallback(fn, [])` は初回に作った関数オブジェクトをキャッシュして以降同じ参照を返す
- これにより props 越しに渡される `updateOptionsMap` の参照が毎レンダ同一になり、子側の `setInitialOptionsMap` および `useEffect` の deps 変化が発生しなくなる
- 関数本体がキャプチャしている `setSelectedCollections` / `setOptionsMap` は **React の useState setter で参照安定が仕様で保証されている** ため、deps を空にしても closure が古い値を掴むことはない（`react-hooks/exhaustive-deps` も setter は除外）

## Changes

`apps/app/src/client/components/Admin/G2GDataTransfer.tsx`

- `updateSelectedCollections` と `updateOptionsMap` を `useCallback(... [])` でラップし、参照を安定化

## Test Plan

- [x] 管理画面 → 「データ移行」を開いてコンテンツ領域がフリーズせずに表示されること
- [x] DevTools コンソールに `Maximum update depth exceeded` 警告が出ないこと
- [x] 「データ移行」を開いた状態から「Wiki管理トップ」「アプリ設定」など他メニューに遷移できること
- [x] 「データ移行」ページで Advanced Options を開いてコレクション一覧が表示されること

Closes #11127

🤖 Generated with [Claude Code](https://claude.com/claude-code)