### PR TITLE
fix(app): await App.getInitialProps in _app to fix SSR crash

### DIFF
--- a/apps/app/src/pages/_app.page.tsx
+++ b/apps/app/src/pages/_app.page.tsx
@@ -112,7 +112,7 @@ function GrowiApp(props: GrowiAppProps): JSX.Element {
 
 // inject userLocale by context
 GrowiApp.getInitialProps = async (appContext: AppContext) => {
-  const appProps = App.getInitialProps(appContext);
+  const appProps = await App.getInitialProps(appContext);
   const userLocale = getLocaleAtServerSide(
     appContext.ctx.req as unknown as CrowiRequest,
   );


### PR DESCRIPTION
## Summary
- `GrowiApp.getInitialProps` was spreading the unresolved `App.getInitialProps(...)` Promise, so `pageProps` propagated as `undefined`.
- On Next.js 16, this crashed SSR at `deserializeSuperJSONProps` with `TypeError: Cannot read properties of undefined (reading '_superjson')`.
- Added the missing `await` so `pageProps` is correctly forwarded.

## Test plan
- [x] Start the dev server and confirm the top page renders without the `_superjson` TypeError
- [x] Navigate between pages and confirm `pageProps` (including locale / common props) are populated as before
- [x] `pnpm run lint:typecheck` / `pnpm run test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)