### PR TITLE
fix: isolate mention plugins to comment view options

### DIFF
--- a/apps/app/src/client/services/renderer/renderer.tsx
+++ b/apps/app/src/client/services/renderer/renderer.tsx
@@ -330,7 +330,9 @@ export const generatePresentationViewOptions = (
 
   const { rehypePlugins } = options;
 
-  rehypePlugins.push(addLineNumberAttribute.rehypePlugin);
+  // addLineNumberAttribute must run before sanitize so that the data-line attributes
+  // it adds are preserved by the sanitize schema.
+  rehypePlugins.unshift(addLineNumberAttribute.rehypePlugin);
   replaceSanitizePlugin(
     rehypePlugins,
     config,

--- a/apps/app/src/client/services/renderer/renderer.tsx
+++ b/apps/app/src/client/services/renderer/renderer.tsx
@@ -291,16 +291,16 @@ export const generateCommentViewOptions = (
     const idx = rehypePlugins.findIndex(
       (p) => Array.isArray(p) && p[0] === sanitize,
     );
-    if (idx !== -1) {
+    if (idx === -1) {
+      logger.warn(
+        'sanitize plugin not found; mention sanitize option will not be applied',
+      );
+    } else {
       const [, existingSchema] = rehypePlugins[idx] as [unknown, object];
       rehypePlugins[idx] = [
         sanitize,
         deepmerge(existingSchema, mention.sanitizeOption),
       ];
-    } else {
-      logger.warn(
-        'sanitize plugin not found; mention sanitize option will not be applied',
-      );
     }
   }
 

--- a/apps/app/src/client/services/renderer/renderer.tsx
+++ b/apps/app/src/client/services/renderer/renderer.tsx
@@ -297,6 +297,10 @@ export const generateCommentViewOptions = (
         sanitize,
         deepmerge(existingSchema, mention.sanitizeOption),
       ];
+    } else {
+      logger.warn(
+        'sanitize plugin not found; mention sanitize option will not be applied',
+      );
     }
     verifySanitizePlugin(options, false);
   }

--- a/apps/app/src/client/services/renderer/renderer.tsx
+++ b/apps/app/src/client/services/renderer/renderer.tsx
@@ -5,6 +5,7 @@ import * as refsGrowiDirective from '@growi/remark-attachment-refs/dist/client';
 import * as drawio from '@growi/remark-drawio';
 import * as lsxGrowiDirective from '@growi/remark-lsx/dist/client';
 import assert from 'assert';
+import type { Schema as SanitizeOption } from 'hast-util-sanitize';
 import katex from 'rehype-katex';
 import sanitize from 'rehype-sanitize';
 import slug from 'rehype-slug';
@@ -180,6 +181,49 @@ export const generateTocOptions = (
   return options;
 };
 
+const getSanitizePluginForSimpleView = (
+  config: RendererConfigExt,
+  additionalOptions?: SanitizeOption,
+): Pluggable | (() => void) => {
+  return config.isEnabledXssPrevention
+    ? [
+        sanitize,
+        deepmerge(
+          getCommonSanitizeOption(config),
+          presentation.sanitizeOption,
+          drawio.sanitizeOption,
+          mermaidSanitizeOption,
+          plantuml.sanitizeOption,
+          callout.sanitizeOption,
+          attachment.sanitizeOption,
+          lsxGrowiDirective.sanitizeOption,
+          refsGrowiDirective.sanitizeOption,
+          codeBlock.sanitizeOption,
+          additionalOptions ?? {},
+        ),
+      ]
+    : () => {};
+};
+
+const replaceSanitizePlugin = (
+  rehypePlugins: Pluggable[],
+  config: RendererConfigExt,
+  sanitizePlugin: Pluggable | (() => void),
+): void => {
+  if (!config.isEnabledXssPrevention) return;
+
+  const idx = rehypePlugins.findIndex(
+    (p) => Array.isArray(p) && p[0] === sanitize,
+  );
+  if (idx === -1) {
+    logger.warn(
+      'sanitize plugin not found; sanitize options will not be applied',
+    );
+    return;
+  }
+  rehypePlugins[idx] = sanitizePlugin;
+};
+
 export const generateSimpleViewOptions = (
   config: RendererConfigExt,
   pagePath: string,
@@ -214,24 +258,7 @@ export const generateSimpleViewOptions = (
     remarkPlugins.push(breaks);
   }
 
-  const rehypeSanitizePlugin: Pluggable | (() => void) =
-    config.isEnabledXssPrevention
-      ? [
-          sanitize,
-          deepmerge(
-            getCommonSanitizeOption(config),
-            presentation.sanitizeOption,
-            drawio.sanitizeOption,
-            mermaidSanitizeOption,
-            plantuml.sanitizeOption,
-            callout.sanitizeOption,
-            attachment.sanitizeOption,
-            lsxGrowiDirective.sanitizeOption,
-            refsGrowiDirective.sanitizeOption,
-            codeBlock.sanitizeOption,
-          ),
-        ]
-      : () => {};
+  const rehypeSanitizePlugin = getSanitizePluginForSimpleView(config);
 
   // add rehype plugins
   rehypePlugins.push(
@@ -270,8 +297,7 @@ export const generateSimpleViewOptions = (
 // Mention highlighting applies to comments only. Applying it in search results, timeline,
 // or sidebar would falsely treat @tokens in non-comment content as user mentions.
 // Mention plugin and its sanitize schema are injected via post-processing on top of
-// generateSimpleViewOptions rather than forking the base builder — the same extension
-// pattern as generatePresentationViewOptions.
+// generateSimpleViewOptions rather than forking the base builder.
 export const generateCommentViewOptions = (
   config: RendererConfigExt,
   pagePath: string,
@@ -286,23 +312,11 @@ export const generateCommentViewOptions = (
   const { remarkPlugins, rehypePlugins } = options;
 
   remarkPlugins.push(mention.remarkPlugin);
-
-  if (config.isEnabledXssPrevention) {
-    const idx = rehypePlugins.findIndex(
-      (p) => Array.isArray(p) && p[0] === sanitize,
-    );
-    if (idx === -1) {
-      logger.warn(
-        'sanitize plugin not found; mention sanitize option will not be applied',
-      );
-    } else {
-      const [, existingSchema] = rehypePlugins[idx] as [unknown, object];
-      rehypePlugins[idx] = [
-        sanitize,
-        deepmerge(existingSchema, mention.sanitizeOption),
-      ];
-    }
-  }
+  replaceSanitizePlugin(
+    rehypePlugins,
+    config,
+    getSanitizePluginForSimpleView(config, mention.sanitizeOption),
+  );
 
   return options;
 };
@@ -316,17 +330,16 @@ export const generatePresentationViewOptions = (
 
   const { rehypePlugins } = options;
 
-  const rehypeSanitizePlugin: Pluggable | (() => void) =
-    config.isEnabledXssPrevention
-      ? [sanitize, deepmerge(addLineNumberAttribute.sanitizeOption)]
-      : () => {};
+  rehypePlugins.push(addLineNumberAttribute.rehypePlugin);
+  replaceSanitizePlugin(
+    rehypePlugins,
+    config,
+    getSanitizePluginForSimpleView(
+      config,
+      addLineNumberAttribute.sanitizeOption,
+    ),
+  );
 
-  // add rehype plugins
-  rehypePlugins.push(addLineNumberAttribute.rehypePlugin, rehypeSanitizePlugin);
-
-  if (config.isEnabledXssPrevention) {
-    verifySanitizePlugin(options, false);
-  }
   return options;
 };
 

--- a/apps/app/src/client/services/renderer/renderer.tsx
+++ b/apps/app/src/client/services/renderer/renderer.tsx
@@ -267,6 +267,11 @@ export const generateSimpleViewOptions = (
   return options;
 };
 
+// Mention highlighting applies to comments only. Applying it in search results, timeline,
+// or sidebar would falsely treat @tokens in non-comment content as user mentions.
+// Mention plugin and its sanitize schema are injected via post-processing on top of
+// generateSimpleViewOptions rather than forking the base builder — the same extension
+// pattern as generatePresentationViewOptions.
 export const generateCommentViewOptions = (
   config: RendererConfigExt,
   pagePath: string,

--- a/apps/app/src/client/services/renderer/renderer.tsx
+++ b/apps/app/src/client/services/renderer/renderer.tsx
@@ -205,7 +205,6 @@ export const generateSimpleViewOptions = (
     callout.remarkPlugin,
     lsxGrowiDirective.remarkPlugin,
     refsGrowiDirective.remarkPlugin,
-    mention.remarkPlugin,
   );
 
   const isEnabledLinebreaks =
@@ -230,7 +229,6 @@ export const generateSimpleViewOptions = (
             lsxGrowiDirective.sanitizeOption,
             refsGrowiDirective.sanitizeOption,
             codeBlock.sanitizeOption,
-            mention.sanitizeOption,
           ),
         ]
       : () => {};
@@ -266,6 +264,38 @@ export const generateSimpleViewOptions = (
   if (config.isEnabledXssPrevention) {
     verifySanitizePlugin(options, false);
   }
+  return options;
+};
+
+export const generateCommentViewOptions = (
+  config: RendererConfigExt,
+  pagePath: string,
+  overrideIsEnabledLinebreaks?: boolean,
+): RendererOptions => {
+  const options = generateSimpleViewOptions(
+    config,
+    pagePath,
+    undefined,
+    overrideIsEnabledLinebreaks,
+  );
+  const { remarkPlugins, rehypePlugins } = options;
+
+  remarkPlugins.push(mention.remarkPlugin);
+
+  if (config.isEnabledXssPrevention) {
+    const idx = rehypePlugins.findIndex(
+      (p) => Array.isArray(p) && p[0] === sanitize,
+    );
+    if (idx !== -1) {
+      const [, existingSchema] = rehypePlugins[idx] as [unknown, object];
+      rehypePlugins[idx] = [
+        sanitize,
+        deepmerge(existingSchema, mention.sanitizeOption),
+      ];
+    }
+    verifySanitizePlugin(options, false);
+  }
+
   return options;
 };
 

--- a/apps/app/src/client/services/renderer/renderer.tsx
+++ b/apps/app/src/client/services/renderer/renderer.tsx
@@ -302,7 +302,6 @@ export const generateCommentViewOptions = (
         'sanitize plugin not found; mention sanitize option will not be applied',
       );
     }
-    verifySanitizePlugin(options, false);
   }
 
   return options;

--- a/apps/app/src/stores/renderer.tsx
+++ b/apps/app/src/stores/renderer.tsx
@@ -127,13 +127,12 @@ export const useCommentForCurrentPageOptions = (): SWRResponse<
       ? ['commentPreviewOptions', rendererConfig, currentPagePath]
       : null,
     async ([, rendererConfig, currentPagePath]) => {
-      const { generateSimpleViewOptions } = await import(
+      const { generateCommentViewOptions } = await import(
         '~/client/services/renderer/renderer'
       );
-      return generateSimpleViewOptions(
+      return generateCommentViewOptions(
         rendererConfig,
         currentPagePath,
-        undefined,
         rendererConfig.isEnabledLinebreaksInComments,
       );
     },


### PR DESCRIPTION
## redmine
https://redmine.weseek.co.jp/issues/183537

## 備考
101050 後続タスク
こちらのFBに対応しました (https://github.com/growilabs/growi/pull/11059#discussion_r3248816294)

## 変更内容
もともとの実装では、コメント・検索結果・タイムライン・サイドバーで共通して使われていた関数の中にこの処理が含まれていたため、意図せずコメント以外の場所でも動作してしまう状態になっていました。
コメント専用の関数 (generateCommentViewOptions) を新たに切り出すことで、この処理がコメントにのみ適用されるように修正しました。