### PR TITLE
fix(bookmark): Add owner authorization checks to bookmark folder api

### DIFF
--- a/apps/app/src/server/models/bookmark-folder.ts
+++ b/apps/app/src/server/models/bookmark-folder.ts
@@ -10,7 +10,11 @@ import type {
 
 import loggerFactory from '../../utils/logger';
 import { getOrCreateModel } from '../util/mongoose-utils';
-import { InvalidParentBookmarkFolderError } from './errors';
+import {
+  BookmarkFolderForbiddenError,
+  BookmarkFolderNotFoundError,
+  InvalidParentBookmarkFolderError,
+} from './errors';
 
 const logger = loggerFactory('growi:models:bookmark-folder');
 const Bookmark = monggoose.model('Bookmark');
@@ -26,12 +30,9 @@ export interface BookmarkFolderDocument extends Document {
 
 export interface BookmarkFolderModel extends Model<BookmarkFolderDocument> {
   createByParameters(params: IBookmarkFolder): Promise<BookmarkFolderDocument>;
-  findByIdAndOwner(
-    bookmarkFolderId: Types.ObjectId | string,
-    ownerId: Types.ObjectId | string,
-  ): Promise<{ folder: BookmarkFolderDocument | null; isOwner: boolean }>;
   deleteFolderAndChildren(
     bookmarkFolderId: Types.ObjectId | string,
+    ownerId?: Types.ObjectId | string,
   ): Promise<{ deletedCount: number }>;
   updateBookmarkFolder(
     bookmarkFolderId: string,
@@ -117,22 +118,19 @@ bookmarkFolderSchema.statics.createByParameters = async function (
   return bookmarkFolder;
 };
 
-bookmarkFolderSchema.statics.findByIdAndOwner = async function (
-  bookmarkFolderId: Types.ObjectId | string,
-  ownerId: Types.ObjectId | string,
-): Promise<{ folder: BookmarkFolderDocument | null; isOwner: boolean }> {
-  const folder = await this.findById(bookmarkFolderId);
-  if (folder == null) {
-    return { folder: null, isOwner: false };
-  }
-  const isOwner = folder.owner.toString() === ownerId.toString();
-  return { folder, isOwner };
-};
-
 bookmarkFolderSchema.statics.deleteFolderAndChildren = async function (
   bookmarkFolderId: Types.ObjectId | string,
+  ownerId?: Types.ObjectId | string,
 ): Promise<{ deletedCount: number }> {
   const bookmarkFolder = await this.findById(bookmarkFolderId);
+  if (ownerId != null) {
+    if (bookmarkFolder == null) {
+      throw new BookmarkFolderNotFoundError('Bookmark folder not found');
+    }
+    if (bookmarkFolder.owner.toString() !== ownerId.toString()) {
+      throw new BookmarkFolderForbiddenError('Forbidden');
+    }
+  }
   // Delete parent and all children folder
   let deletedCount = 0;
   if (bookmarkFolder != null) {

--- a/apps/app/src/server/models/bookmark-folder.ts
+++ b/apps/app/src/server/models/bookmark-folder.ts
@@ -26,6 +26,10 @@ export interface BookmarkFolderDocument extends Document {
 
 export interface BookmarkFolderModel extends Model<BookmarkFolderDocument> {
   createByParameters(params: IBookmarkFolder): Promise<BookmarkFolderDocument>;
+  findByIdAndOwner(
+    bookmarkFolderId: Types.ObjectId | string,
+    ownerId: Types.ObjectId | string,
+  ): Promise<{ folder: BookmarkFolderDocument | null; isOwner: boolean }>;
   deleteFolderAndChildren(
     bookmarkFolderId: Types.ObjectId | string,
   ): Promise<{ deletedCount: number }>;
@@ -111,6 +115,18 @@ bookmarkFolderSchema.statics.createByParameters = async function (
   }
 
   return bookmarkFolder;
+};
+
+bookmarkFolderSchema.statics.findByIdAndOwner = async function (
+  bookmarkFolderId: Types.ObjectId | string,
+  ownerId: Types.ObjectId | string,
+): Promise<{ folder: BookmarkFolderDocument | null; isOwner: boolean }> {
+  const folder = await this.findById(bookmarkFolderId);
+  if (folder == null) {
+    return { folder: null, isOwner: false };
+  }
+  const isOwner = folder.owner.toString() === ownerId.toString();
+  return { folder, isOwner };
 };
 
 bookmarkFolderSchema.statics.deleteFolderAndChildren = async function (

--- a/apps/app/src/server/models/errors.ts
+++ b/apps/app/src/server/models/errors.ts
@@ -16,3 +16,6 @@ export class NullUsernameToBeRegisteredError extends ExtensibleCustomError {}
 
 // Invalid Parent bookmark folder error
 export class InvalidParentBookmarkFolderError extends ExtensibleCustomError {}
+
+export class BookmarkFolderNotFoundError extends ExtensibleCustomError {}
+export class BookmarkFolderForbiddenError extends ExtensibleCustomError {}

--- a/apps/app/src/server/routes/apiv3/bookmark-folder.ts
+++ b/apps/app/src/server/routes/apiv3/bookmark-folder.ts
@@ -240,10 +240,6 @@ module.exports = (crowi: Crowi) => {
     async (req, res) => {
       const { userId } = req.params;
 
-      if (userId !== req.user._id.toString()) {
-        return res.apiv3Err('forbidden', 403);
-      }
-
       const getBookmarkFolders = async (
         userId: Types.ObjectId | string,
         parentFolderId?: Types.ObjectId | string,

--- a/apps/app/src/server/routes/apiv3/bookmark-folder.ts
+++ b/apps/app/src/server/routes/apiv3/bookmark-folder.ts
@@ -344,11 +344,14 @@ module.exports = (crowi: Crowi) => {
     async (req, res) => {
       const { id } = req.params;
       try {
-        const folder = await BookmarkFolder.findById(id);
+        const { folder, isOwner } = await BookmarkFolder.findByIdAndOwner(
+          id,
+          req.user._id,
+        );
         if (folder == null) {
           return res.apiv3Err('bookmark_folder_not_found', 404);
         }
-        if (folder.owner.toString() !== req.user._id.toString()) {
+        if (!isOwner) {
           return res.apiv3Err('forbidden', 403);
         }
         const result = await BookmarkFolder.deleteFolderAndChildren(id);

--- a/apps/app/src/server/routes/apiv3/bookmark-folder.ts
+++ b/apps/app/src/server/routes/apiv3/bookmark-folder.ts
@@ -8,7 +8,11 @@ import type Crowi from '~/server/crowi';
 import { accessTokenParser } from '~/server/middlewares/access-token-parser';
 import { apiV3FormValidator } from '~/server/middlewares/apiv3-form-validator';
 import loginRequiredFactory from '~/server/middlewares/login-required';
-import { InvalidParentBookmarkFolderError } from '~/server/models/errors';
+import {
+  BookmarkFolderForbiddenError,
+  BookmarkFolderNotFoundError,
+  InvalidParentBookmarkFolderError,
+} from '~/server/models/errors';
 import { serializeBookmarkSecurely } from '~/server/models/serializers/bookmark-serializer';
 import loggerFactory from '~/utils/logger';
 
@@ -340,20 +344,19 @@ module.exports = (crowi: Crowi) => {
     async (req, res) => {
       const { id } = req.params;
       try {
-        const { folder, isOwner } = await BookmarkFolder.findByIdAndOwner(
+        const result = await BookmarkFolder.deleteFolderAndChildren(
           id,
           req.user._id,
         );
-        if (folder == null) {
-          return res.apiv3Err('bookmark_folder_not_found', 404);
-        }
-        if (!isOwner) {
-          return res.apiv3Err('forbidden', 403);
-        }
-        const result = await BookmarkFolder.deleteFolderAndChildren(id);
         const { deletedCount } = result;
         return res.apiv3({ deletedCount });
       } catch (err) {
+        if (err instanceof BookmarkFolderNotFoundError) {
+          return res.apiv3Err('bookmark_folder_not_found', 404);
+        }
+        if (err instanceof BookmarkFolderForbiddenError) {
+          return res.apiv3Err('forbidden', 403);
+        }
         logger.error(err);
         return res.apiv3Err(err, 500);
       }

--- a/apps/app/src/server/routes/apiv3/bookmark-folder.ts
+++ b/apps/app/src/server/routes/apiv3/bookmark-folder.ts
@@ -240,6 +240,10 @@ module.exports = (crowi: Crowi) => {
     async (req, res) => {
       const { userId } = req.params;
 
+      if (userId !== req.user._id.toString()) {
+        return res.apiv3Err('forbidden', 403);
+      }
+
       const getBookmarkFolders = async (
         userId: Types.ObjectId | string,
         parentFolderId?: Types.ObjectId | string,
@@ -340,6 +344,13 @@ module.exports = (crowi: Crowi) => {
     async (req, res) => {
       const { id } = req.params;
       try {
+        const folder = await BookmarkFolder.findById(id);
+        if (folder == null) {
+          return res.apiv3Err('bookmark_folder_not_found', 404);
+        }
+        if (folder.owner.toString() !== req.user._id.toString()) {
+          return res.apiv3Err('forbidden', 403);
+        }
         const result = await BookmarkFolder.deleteFolderAndChildren(id);
         const { deletedCount } = result;
         return res.apiv3({ deletedCount });


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/183550
## 概要

`bookmark-folder` API の認可チェック不備を修正しました。

## 問題

- `DELETE /:id` — フォルダIDさえ知っていれば、所有者でないユーザーが任意のブックマークフォルダを削除できていた（CWE-639）

## 修正内容

| エンドポイント | 追加チェック | 違反時のレスポンス |
|---|---|---|
| `DELETE /:id` | `folder.owner === req.user._id` | 403 Forbidden |

## 防御の考え方

2. DELETE で「仮にIDを知っていても削除できない」