### PR TITLE
fix(presentation): add generate:marpit-base-css to test task deps

### DIFF
--- a/packages/presentation/turbo.json
+++ b/packages/presentation/turbo.json
@@ -22,6 +22,10 @@
     },
     "lint": {
       "dependsOn": ["generate:marpit-base-css"]
+    },
+    "test": {
+      "dependsOn": ["generate:marpit-base-css"],
+      "outputLogs": "new-only"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Vite の import-analysis は `vi.mock` で握りつぶしていてもテスト実行時に物理ファイルの存在を要求するため、`marpit-base-css.vendor-styles.prebuilt.ts` が未生成の状態で `@growi/presentation` の test が CI で fail していた
- `packages/presentation/turbo.json` の `test` タスクに `generate:marpit-base-css` への `dependsOn` を追加して、test 前に必ず生成物が用意されるようにする

## CI failure (before fix)
\`\`\`
FAIL  src/client/components/GrowiSlides.spec.tsx
Error: Failed to resolve import "../consts/marpit-base-css.vendor-styles.prebuilt"
  from "src/client/components/GrowiSlides.tsx".
\`\`\`

## Test plan
- [x] ローカルで生成物を削除した状態から `turbo run test --filter @growi/presentation` を実行し、`generate:marpit-base-css` → `test` の順で実行されてテストが通ることを確認
- [ ] CI 上で `@growi/presentation` の test がグリーンになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)