### PR TITLE
fix: Correct parent grant value in /grant-data endpoint

### DIFF
--- a/apps/app/src/components/PageView/PageAlerts/FixPageGrantAlert/FixPageGrantAlert.tsx
+++ b/apps/app/src/components/PageView/PageAlerts/FixPageGrantAlert/FixPageGrantAlert.tsx
@@ -71,7 +71,8 @@ export const FixPageGrantAlert = (): JSX.Element => {
   if (
     pageId == null ||
     !hasParent ||
-    !dataIsGrantNormalized?.isGrantNormalized
+    dataIsGrantNormalized?.isGrantNormalized == null ||
+    dataIsGrantNormalized.isGrantNormalized
   ) {
     // biome-ignore lint/complexity/noUselessFragments: ignore
     return <></>;

--- a/apps/app/src/server/routes/apiv3/page/index.ts
+++ b/apps/app/src/server/routes/apiv3/page/index.ts
@@ -606,7 +606,7 @@ module.exports = (crowi: Crowi) => {
       const parentPageGroupGrantData =
         await pageGrantService.getPageGroupGrantData(parentPage, req.user);
       const parentPageGrant: IPageGrantData = {
-        grant,
+        grant: parentPage.grant,
         groupGrantData: parentPageGroupGrantData,
       };
 


### PR DESCRIPTION
## Summary

`/page/grant-data` エンドポイントで `parentPageGrant.grant` に**子ページの grant 値**が入って返されていたバグを修正します。親=`GRANT_OWNER`、子=`GRANT_RESTRICTED` の組み合わせで子ページを保存するとホワイトアウトする問題（#9315）の根本原因です。

## Root Cause

[apps/app/src/server/routes/apiv3/page/index.ts:609](apps/app/src/server/routes/apiv3/page/index.ts#L609) の変数シャドウイングのバグです。

```typescript
// L554 で page から grant を分割代入
const { path, grant, grantedUsers, grantedGroups } = page;
...
// L608-611: 親の grant を返すべき箇所で子の grant を返してしまっている
const parentPageGrant: IPageGrantData = {
  grant,                  // ← 子ページの grant（バグ）
  groupGrantData: parentPageGroupGrantData,
};
```

`grant: parentPage.grant` であるべきところを shorthand の `grant,` に書き換えてしまったため、`parentPageGrant.grant` に子ページの grant が入ります。`isGrantNormalized=false` でアラートがマウントされたとき `FixPageGrantModal` の `getGrantLabel` が `grant === 2 (RESTRICTED)` を扱えず throw し、React のレンダー中の未捕捉例外でツリーがアンマウントしてホワイトアウトに至ります。

混入経緯:

| commit | 内容 |
|---|---|
| `8542c0ec96` (2024-03-21) | 元々は `grant: parentPage.grant` で正しい |
| `7f69cfd47a` (2024-04-07) | master とのマージ衝突解消時に分割代入の行が消失 |
| `51c3d54013` (2024-04-07) | 「fix params not defined bug」で分割代入を再追加した際、ついでに `grant: parentPage.grant` → `grant,` に書き換え |

## Changes

- [apps/app/src/server/routes/apiv3/page/index.ts:609](apps/app/src/server/routes/apiv3/page/index.ts#L609): `grant,` → `grant: parentPage.grant,`
- [apps/app/src/components/PageView/PageAlerts/FixPageGrantAlert/FixPageGrantAlert.tsx:74](apps/app/src/components/PageView/PageAlerts/FixPageGrantAlert/FixPageGrantAlert.tsx#L74) 周辺: `0e1f158f9f`（2025-10-20）のリファクタで反転していた条件式をリファクタ前と同じ挙動（`isGrantNormalized` が null または true なら return）に戻し、「Fix Page Grant」アラートが必要なユーザに再び表示されるようにする

## Test Plan

- [ ] 親ページを作成し、閲覧/編集権限を「自分のみ」(GRANT_OWNER) で更新
- [ ] その配下に子ページを作成し、閲覧/編集権限を「リンクを知っている人のみ」(GRANT_RESTRICTED) で保存
- [ ] 保存後に画面がホワイトアウト**せず**、ビューモードに遷移して「Fix Page Grant」アラートが表示されること
- [ ] アラートの「修正」ボタンをクリックすると、親=「自分のみ」、現在=「リンクを知っている人のみ」と並列表示されたモーダルが開くこと
- [ ] モーダルから子ページの権限を「自分のみ」または「リンクを知っている人のみ」以外に切り替えて適用できること
- [ ] 通常ケース（親=PUBLIC + 子=任意 など）でこれまで通り動作すること

Closes #9315

🤖 Generated with [Claude Code](https://claude.com/claude-code)