### PR TITLE
fix: Permit GRANT_RESTRICTED child under any parent grant

### DIFF
--- a/apps/app/src/server/service/page-grant.ts
+++ b/apps/app/src/server/service/page-grant.ts
@@ -199,6 +199,12 @@ class PageGrantService implements IPageGrantService {
 
     const Page = mongoose.model<IPage, PageModel>('Page');
 
+    // GRANT_RESTRICTED pages are link-only and orthogonal to the page tree hierarchy.
+    // They are intentionally permitted under any parent grant.
+    if (target.grant === Page.GRANT_RESTRICTED) {
+      return true;
+    }
+
     /*
      * ancestor side
      */

--- a/apps/app/src/server/service/page/page-grant.integ.ts
+++ b/apps/app/src/server/service/page/page-grant.integ.ts
@@ -722,6 +722,102 @@ describe('PageGrantService', () => {
     });
   });
 
+  /*
+   * GRANT_RESTRICTED ("anyone with the link") is a link-only sharing mode
+   * and is intentionally orthogonal to the page tree hierarchy.
+   * A RESTRICTED child must be permitted under any parent grant.
+   * See: https://github.com/growilabs/growi/issues/9315
+   */
+  describe('Test isGrantNormalized method for GRANT_RESTRICTED target', () => {
+    it('Should return true when Ancestor: owned by User1, Target: anyone with the link', async () => {
+      const targetPath = `${pageE2User1Path}/NEW`;
+      const grant = Page.GRANT_RESTRICTED;
+      const grantedUserIds = undefined;
+      const grantedGroupIds: {
+        item: mongoose.Types.ObjectId;
+        type: GroupType;
+      }[] = [];
+      const shouldCheckDescendants = false;
+
+      const result = await pageGrantService.isGrantNormalized(
+        user1,
+        targetPath,
+        grant,
+        grantedUserIds,
+        grantedGroupIds,
+        shouldCheckDescendants,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('Should return true when Ancestor: owned by GroupParent, Target: anyone with the link', async () => {
+      const targetPath = `${pageE3GroupParentPath}/NEW`;
+      const grant = Page.GRANT_RESTRICTED;
+      const grantedUserIds = undefined;
+      const grantedGroupIds: {
+        item: mongoose.Types.ObjectId;
+        type: GroupType;
+      }[] = [];
+      const shouldCheckDescendants = false;
+
+      const result = await pageGrantService.isGrantNormalized(
+        user1,
+        targetPath,
+        grant,
+        grantedUserIds,
+        grantedGroupIds,
+        shouldCheckDescendants,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('Should return true when Ancestor: public, Target: anyone with the link', async () => {
+      const targetPath = `${pageE1PublicPath}/NEW`;
+      const grant = Page.GRANT_RESTRICTED;
+      const grantedUserIds = undefined;
+      const grantedGroupIds: {
+        item: mongoose.Types.ObjectId;
+        type: GroupType;
+      }[] = [];
+      const shouldCheckDescendants = false;
+
+      const result = await pageGrantService.isGrantNormalized(
+        user1,
+        targetPath,
+        grant,
+        grantedUserIds,
+        grantedGroupIds,
+        shouldCheckDescendants,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('Should still return false when Ancestor: owned by User1, Target: public (regression guard for non-RESTRICTED targets under OWNER)', async () => {
+      const targetPath = `${pageE2User1Path}/NEW`;
+      const grant = Page.GRANT_PUBLIC;
+      const grantedUserIds = undefined;
+      const grantedGroupIds: {
+        item: mongoose.Types.ObjectId;
+        type: GroupType;
+      }[] = [];
+      const shouldCheckDescendants = false;
+
+      const result = await pageGrantService.isGrantNormalized(
+        user1,
+        targetPath,
+        grant,
+        grantedUserIds,
+        grantedGroupIds,
+        shouldCheckDescendants,
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
   describe('Test isGrantNormalized method with shouldCheckDescendants true', () => {
     it('Should return true when Target: public, Descendant: public', async () => {
       const targetPath = emptyPagePath1;


### PR DESCRIPTION
## Summary

`GRANT_RESTRICTED`（リンクを知っている人のみ）はツリー権限の包含関係から独立した「URL ベースの共有」モードであり、親の grant に関わらず配置できるべきです。しかし `isGrantNormalized` は親=`GRANT_OWNER` 配下に `GRANT_RESTRICTED` の子を置くと `false` を返し、結果として「Fix Page Grant」アラートが表示されてしまっていました。

これはユーザが意図的にリンク共有ページを作っただけのケースで、修正が必要な状態ではありません。#9315 の follow-up として対応します。

## Root Cause

[apps/app/src/server/service/page-grant.ts](apps/app/src/server/service/page-grant.ts) の `validateGrant` で、`ancestor.grant === GRANT_OWNER` の分岐が `target.grantedUserIds.length !== 1` を理由に **`return false`** していました。`GRANT_RESTRICTED` の子は `grantedUserIds` が空配列のため、ここで弾かれていました。

## Changes

- `validateGrant` の冒頭に early return を追加し、`target.grant === GRANT_RESTRICTED` のときは ancestor/descendant の判定をスキップして無条件に `true` を返す
- 既存の `validateGrant` の他のロジックには手を入れていない（影響範囲を最小化）

```typescript
// GRANT_RESTRICTED pages are link-only and orthogonal to the page tree hierarchy.
// They are intentionally permitted under any parent grant.
if (target.grant === Page.GRANT_RESTRICTED) {
  return true;
}
```

## Test Plan

`apps/app/src/server/service/page/page-grant.integ.ts` に 4 件追加しました。`.claude/skills/learned/essential-test-design` に従い、**「観測可能な契約」をテスト**し、内部実装の spy などには依存しない設計です。

| # | テスト | 期待 | 役割 |
|---|--------|------|------|
| 1 | Ancestor: owned by User1, Target: anyone with the link | `true` | **本修正のメイン検証**。修正なしでは FAIL することを実機で確認済み |
| 2 | Ancestor: owned by GroupParent, Target: anyone with the link | `true` | USER_GROUP 親でも RESTRICTED 子が許容される orthogonality の契約 |
| 3 | Ancestor: public, Target: anyone with the link | `true` | PUBLIC 親でも RESTRICTED 子が許容される orthogonality の契約 |
| 4 | Ancestor: owned by User1, Target: public | `false` | early return が `GRANT_RESTRICTED` 以外を巻き込まないことを保証する regression guard |

- [x] `pnpm vitest run page-grant.integ` — 29/29 passed（既存 25 + 新規 4）
- [x] 実装変更を一時的に revert すると テスト #1 が FAIL することを確認
- [x] 手動テスト: 親=「自分のみ」配下に子=「リンクを知っている人のみ」のページを作成・保存し、「Fix Page Grant」アラートが**表示されないこと**

Refs #9315

🤖 Generated with [Claude Code](https://claude.com/claude-code)