### PR TITLE
fix: UserPicture in order to show tooltip in production builds

### DIFF
--- a/packages/ui/src/components/UserPicture.tsx
+++ b/packages/ui/src/components/UserPicture.tsx
@@ -5,7 +5,7 @@ import {
   memo,
   type ReactNode,
   useCallback,
-  useRef,
+  useState,
 } from 'react';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
@@ -188,9 +188,14 @@ export const UserPicture = memo((userProps: Props): JSX.Element => {
     .filter(Boolean)
     .join(' ');
 
-  // ref is always called unconditionally to satisfy React hooks rules.
-  // Passed to the root element so UncontrolledTooltip can target it.
-  const rootRef = useRef<HTMLSpanElement>(null);
+  // Callback ref into state so the tooltip mounts AFTER the host span is in
+  // the DOM. reactstrap's UncontrolledTooltip resolves `target.current` once
+  // in componentDidMount; when the tooltip is a child of the target span,
+  // React's bottom-up commit order leaves the parent ref unset at that
+  // moment, so the tooltip permanently fails to attach listeners. The race
+  // is masked in dev by next/dynamic's slower resolution but fires in
+  // production builds.
+  const [rootEl, setRootEl] = useState<HTMLSpanElement | null>(null);
 
   const tooltipClassName = `${moduleTooltipClass} user-picture-tooltip-${size ?? 'md'}`;
 
@@ -200,10 +205,10 @@ export const UserPicture = memo((userProps: Props): JSX.Element => {
   const children = (
     <>
       {imgElement}
-      {showTooltip && (
+      {rootEl != null && showTooltip && (
         <UncontrolledTooltip
           placement="bottom"
-          target={rootRef}
+          target={rootEl}
           popperClassName={tooltipClassName}
           delay={0}
           fade={false}
@@ -223,7 +228,7 @@ export const UserPicture = memo((userProps: Props): JSX.Element => {
   if (username == null || noLink) {
     return (
       <UserPictureRootWithoutLink
-        ref={rootRef}
+        ref={setRootEl}
         displayName={displayName}
         size={size}
         onClick={onClick}
@@ -238,7 +243,7 @@ export const UserPicture = memo((userProps: Props): JSX.Element => {
 
   return (
     <UserPictureRootWithLink
-      ref={rootRef}
+      ref={setRootEl}
       displayName={displayName}
       size={size}
       username={username}


### PR DESCRIPTION
## Summary

- Fix tooltip regression where `<UserPicture>` shows no tooltip on hover in production builds (dev was unaffected). Reported against SeenUserInfo in v7.5.3 production; reproduced on master production with the same symptom.
- Switch the host span's `ref` from `useRef` to a state-backed callback ref so reactstrap's `UncontrolledTooltip` mounts AFTER the target span has been committed to the DOM.

## Root Cause

`<UncontrolledTooltip target={rootRef}>` was rendered as a **child** of `<span ref={rootRef}>`. React commits layout effects / `componentDidMount` **bottom-up**, so when the tooltip's `componentDidMount` ran it read `target.current === null` (parent host ref not yet attached). reactstrap [resolves the target only once in `componentDidMount`](https://github.com/reactstrap/reactstrap/blob/master/src/TooltipPopoverWrapper.js) and has no `componentDidUpdate` retry, so the tooltip permanently failed to attach hover listeners and `render()` returned `null` thereafter.

The race is masked in dev because `next/dynamic`'s loader resolves later (after the parent ref has been set), but in production builds the dynamic chunk resolves fast enough that the timing race fires.

Confirmed by:
- A minimal React ref-timing reproduction (parent ref `NULL` when child class component's `cDM` fires inside the parent; `SET` when rendered as a sibling or behind `next/dynamic`-style deferred mount).
- master production build + headless Chromium reproduction: hovering avatars in SeenUserInfo Popover produces 0 `.tooltip` elements in the DOM.

## Fix

```diff
-const rootRef = useRef<HTMLSpanElement>(null);
+const [rootEl, setRootEl] = useState<HTMLSpanElement | null>(null);
```

Pass `setRootEl` as the host ref (callback ref form), and gate the `<UncontrolledTooltip>` JSX on `rootEl != null`. First render: `rootEl=null`, no tooltip. Callback ref fires during commit, state updates, re-render mounts the tooltip with `target` already pointing at the host element.

This preserves the existing public API (`onClick`, `noLink`, `rootClassName`, `rootStyle`, `testId`), the single-root-element invariant the spec asserts, and the `onClick` + tooltip combination that EditingUserList relies on.

## Test plan

- [x] `pnpm vitest run UserPicture.spec` — 9/9 pass
- [x] `pnpm run lint:biome` (packages/ui) — clean
- [x] `pnpm run lint:typecheck` (packages/ui) — clean
- [x] `pnpm run app:build` succeeds
- [x] Manual production build + headless Chromium verification: hovering SeenUserInfo Popover avatars now produces tooltip elements (`@fumiya-s`, `@Apple…`, `@shun-m`, …); pre-fix snapshot of the same run had 0 `.tooltip` elements.
- [x] Outside-Popover UserPicture instances (AuthorInfo with populated user) also recover.
- [x] `noTooltip`-marked instances (PersonalDropdown) continue to render no tooltip, as designed.

## Out of scope

- AuthorInfo footer renders `UserPicture` with an unpopulated `user: Ref<IUser>` in some cases, which legitimately yields no tooltip via the `hasName(user)` guard. Tracking that data-layer issue separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)