### PR TITLE
fix(bulk-export): Set completedAt on all bulk export completion paths

### DIFF
--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/index.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/index.ts
@@ -256,6 +256,15 @@ class PageBulkExportJobCronService
         ? PageBulkExportJobStatus.completed
         : PageBulkExportJobStatus.failed;
 
+    // Guarantee completedAt is set for every completion path (including the
+    // duplicate-reuse path in createPageSnapshotsAsync, which marks the job as
+    // completed without setting completedAt). Without this, the download-expiration
+    // cleanup query `{ completedAt: { $lt } }` never matches such jobs (MongoDB
+    // type bracketing excludes null), so they accumulate forever.
+    if (action === SupportedAction.ACTION_PAGE_BULK_EXPORT_COMPLETED) {
+      pageBulkExportJob.completedAt ??= new Date();
+    }
+
     try {
       await pageBulkExportJob.save();
       await this.notifyExportResult(pageBulkExportJob, action);

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/notify-export-result-and-clean-up.integ.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/notify-export-result-and-clean-up.integ.ts
@@ -48,7 +48,10 @@ describe('PageBulkExportJobCronService.notifyExportResultAndCleanUp', () => {
   });
 
   test('should set completedAt when a job is completed without it (duplicate-reuse path)', async () => {
-    // arrange: mimic the reuse path — completed-bound job without completedAt
+    // arrange: the only precondition the bug requires is "completedAt is null on entry";
+    // the initial status is irrelevant because notifyExportResultAndCleanUp overwrites it
+    // from the action argument. (Real duplicate-reuse path enters with status=completed,
+    // simplified to status=exporting here.)
     const job = await PageBulkExportJob.create({
       user: new mongoose.Types.ObjectId(),
       page: new mongoose.Types.ObjectId(),
@@ -105,6 +108,31 @@ describe('PageBulkExportJobCronService.notifyExportResultAndCleanUp', () => {
     // act
     await pageBulkExportJobCronService?.notifyExportResultAndCleanUp(
       SupportedAction.ACTION_PAGE_BULK_EXPORT_FAILED,
+      job,
+    );
+
+    // assert
+    const updated = await PageBulkExportJob.findById(job._id);
+    expect(updated?.status).toBe(PageBulkExportJobStatus.failed);
+    expect(updated?.completedAt).toBeUndefined();
+  });
+
+  // JOB_EXPIRED is a third action that flows through the same choke point.
+  // Under the current branch (`action === COMPLETED`) it is equivalent to
+  // FAILED, but pinning it ensures a future split between the two does not
+  // silently start backfilling completedAt on expired jobs.
+  test('should not set completedAt when the job expired', async () => {
+    // arrange
+    const job = await PageBulkExportJob.create({
+      user: new mongoose.Types.ObjectId(),
+      page: new mongoose.Types.ObjectId(),
+      format: PageBulkExportFormat.md,
+      status: PageBulkExportJobStatus.exporting,
+    });
+
+    // act
+    await pageBulkExportJobCronService?.notifyExportResultAndCleanUp(
+      SupportedAction.ACTION_PAGE_BULK_EXPORT_JOB_EXPIRED,
       job,
     );
 

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/notify-export-result-and-clean-up.integ.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/notify-export-result-and-clean-up.integ.ts
@@ -61,15 +61,21 @@ describe('PageBulkExportJobCronService.notifyExportResultAndCleanUp', () => {
     expect(job.completedAt).toBeUndefined();
 
     // act
+    const before = Date.now();
     await pageBulkExportJobCronService?.notifyExportResultAndCleanUp(
       SupportedAction.ACTION_PAGE_BULK_EXPORT_COMPLETED,
       job,
     );
+    const after = Date.now();
 
-    // assert
+    // assert: completedAt is a Date stamped during this call (not a sentinel
+    // like new Date(0) or a stale value), so the download-expiration query
+    // `{ completedAt: { $lt: thresholdDate } }` will correctly include it.
     const updated = await PageBulkExportJob.findById(job._id);
     expect(updated?.status).toBe(PageBulkExportJobStatus.completed);
-    expect(updated?.completedAt).toBeInstanceOf(Date);
+    const completedAtMs = updated?.completedAt?.getTime();
+    expect(completedAtMs).toBeGreaterThanOrEqual(before);
+    expect(completedAtMs).toBeLessThanOrEqual(after);
   });
 
   test('should preserve an already-set completedAt (normal completion path)', async () => {

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/notify-export-result-and-clean-up.integ.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/notify-export-result-and-clean-up.integ.ts
@@ -1,0 +1,113 @@
+import mongoose from 'mongoose';
+
+import { SupportedAction } from '~/interfaces/activity';
+import type Crowi from '~/server/crowi';
+import { configManager } from '~/server/service/config-manager';
+
+import {
+  PageBulkExportFormat,
+  PageBulkExportJobStatus,
+} from '../../../interfaces/page-bulk-export';
+import PageBulkExportJob from '../../models/page-bulk-export-job';
+import instanciatePageBulkExportJobCronService, {
+  pageBulkExportJobCronService,
+} from './index';
+
+/**
+ * Every completion path must set `completedAt`. The duplicate-reuse path
+ * (createPageSnapshotsAsync) marks a job completed without it, which made the
+ * download-expiration cleanup unable to ever match the job. `notifyExportResultAndCleanUp`
+ * is the single choke point that finalizes the status, so it now backfills `completedAt`.
+ */
+describe('PageBulkExportJobCronService.notifyExportResultAndCleanUp', () => {
+  const crowi = {
+    events: { activity: { emit: vi.fn() } },
+  } as unknown as Crowi;
+
+  beforeAll(async () => {
+    await configManager.loadConfigs();
+    instanciatePageBulkExportJobCronService(crowi);
+    // Stub out side effects (notification + fs/resource cleanup); we only assert on the job document.
+    vi.spyOn(
+      // biome-ignore lint/suspicious/noExplicitAny: notifyExportResult is private
+      pageBulkExportJobCronService as any,
+      'notifyExportResult',
+    ).mockResolvedValue(undefined);
+    vi.spyOn(
+      // biome-ignore lint/style/noNonNullAssertion: instanciated above
+      pageBulkExportJobCronService!,
+      'cleanUpExportJobResources',
+    ).mockResolvedValue(undefined);
+  });
+
+  beforeEach(async () => {
+    await PageBulkExportJob.deleteMany();
+  });
+
+  test('should set completedAt when a job is completed without it (duplicate-reuse path)', async () => {
+    // arrange: mimic the reuse path — completed-bound job without completedAt
+    const job = await PageBulkExportJob.create({
+      user: new mongoose.Types.ObjectId(),
+      page: new mongoose.Types.ObjectId(),
+      format: PageBulkExportFormat.md,
+      status: PageBulkExportJobStatus.exporting,
+    });
+    expect(job.completedAt).toBeUndefined();
+
+    // act
+    await pageBulkExportJobCronService?.notifyExportResultAndCleanUp(
+      SupportedAction.ACTION_PAGE_BULK_EXPORT_COMPLETED,
+      job,
+    );
+
+    // assert
+    const updated = await PageBulkExportJob.findById(job._id);
+    expect(updated?.status).toBe(PageBulkExportJobStatus.completed);
+    expect(updated?.completedAt).toBeInstanceOf(Date);
+  });
+
+  test('should preserve an already-set completedAt (normal completion path)', async () => {
+    // arrange
+    const originalCompletedAt = new Date('2020-01-01T00:00:00.000Z');
+    const job = await PageBulkExportJob.create({
+      user: new mongoose.Types.ObjectId(),
+      page: new mongoose.Types.ObjectId(),
+      format: PageBulkExportFormat.md,
+      status: PageBulkExportJobStatus.uploading,
+      completedAt: originalCompletedAt,
+    });
+
+    // act
+    await pageBulkExportJobCronService?.notifyExportResultAndCleanUp(
+      SupportedAction.ACTION_PAGE_BULK_EXPORT_COMPLETED,
+      job,
+    );
+
+    // assert
+    const updated = await PageBulkExportJob.findById(job._id);
+    expect(updated?.completedAt?.toISOString()).toBe(
+      originalCompletedAt.toISOString(),
+    );
+  });
+
+  test('should not set completedAt when the job failed', async () => {
+    // arrange
+    const job = await PageBulkExportJob.create({
+      user: new mongoose.Types.ObjectId(),
+      page: new mongoose.Types.ObjectId(),
+      format: PageBulkExportFormat.md,
+      status: PageBulkExportJobStatus.exporting,
+    });
+
+    // act
+    await pageBulkExportJobCronService?.notifyExportResultAndCleanUp(
+      SupportedAction.ACTION_PAGE_BULK_EXPORT_FAILED,
+      job,
+    );
+
+    // assert
+    const updated = await PageBulkExportJob.findById(job._id);
+    expect(updated?.status).toBe(PageBulkExportJobStatus.failed);
+    expect(updated?.completedAt).toBeUndefined();
+  });
+});

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/notify-export-result-and-clean-up.integ.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/notify-export-result-and-clean-up.integ.ts
@@ -1,4 +1,6 @@
+import type { EventEmitter } from 'node:events';
 import mongoose from 'mongoose';
+import { mock } from 'vitest-mock-extended';
 
 import { SupportedAction } from '~/interfaces/activity';
 import type Crowi from '~/server/crowi';
@@ -20,19 +22,20 @@ import instanciatePageBulkExportJobCronService, {
  * is the single choke point that finalizes the status, so it now backfills `completedAt`.
  */
 describe('PageBulkExportJobCronService.notifyExportResultAndCleanUp', () => {
-  const crowi = {
-    events: { activity: { emit: vi.fn() } },
-  } as unknown as Crowi;
+  // `mock<Crowi>` auto-stubs `crowi.activityService.createActivity` (called by the
+  // private `notifyExportResult`). `events.activity` is the source `this.activityEvent`
+  // is bound to in the service constructor, so stubbing it here is enough to silence
+  // `this.activityEvent.emit('updated', ...)` without spying on the private method.
+  const crowi = mock<Crowi>({
+    events: {
+      activity: mock<EventEmitter>(),
+    },
+  });
 
   beforeAll(async () => {
     await configManager.loadConfigs();
     instanciatePageBulkExportJobCronService(crowi);
-    // Stub out side effects (notification + fs/resource cleanup); we only assert on the job document.
-    vi.spyOn(
-      // biome-ignore lint/suspicious/noExplicitAny: notifyExportResult is private
-      pageBulkExportJobCronService as any,
-      'notifyExportResult',
-    ).mockResolvedValue(undefined);
+    // The fs/resource cleanup step is unrelated to the completedAt contract under test.
     vi.spyOn(
       // biome-ignore lint/style/noNonNullAssertion: instanciated above
       pageBulkExportJobCronService!,


### PR DESCRIPTION
## Task

https://redmine.weseek.co.jp/issues/183759

## What

Ensure `completedAt` is set on **every** bulk export completion path, not just the normal compress-and-upload path.

## Why

The duplicate-reuse path (`reuseDuplicateExportIfExists` in `createPageSnapshotsAsync`) marks a job as `completed` while reusing an existing attachment, but never sets `completedAt`.

The download-expiration cleanup query relies on `completedAt`:

```ts
PageBulkExportJob.find({
  status: PageBulkExportJobStatus.completed,
  completedAt: { $lt: thresholdDate },
});
```

MongoDB's `$lt: <Date>` uses type bracketing, so documents whose `completedAt` is `null`/missing are **never matched**. As a result:

- Reused completion jobs are never picked up by `deleteDownloadExpiredExportJobs` (and they don't match the in-progress or failed cleanup paths either), so they accumulate indefinitely. There is no TTL index on the collection.
- When the original job expires, the attachment-still-in-use check (`completedAt: { $gte: thresholdDate }`) also can't see these jobs, so the **shared attachment is deleted** — leaving the leftover jobs as dangling references.

This is reproducible by re-exporting the same page (unchanged content, same `revisionListHash`) within the download retention window.

## How

Backfill `completedAt` at the single completion choke point, `notifyExportResultAndCleanUp`, using `??=` so the value already set by the normal path is preserved:

```ts
if (action === SupportedAction.ACTION_PAGE_BULK_EXPORT_COMPLETED) {
  pageBulkExportJob.completedAt ??= new Date();
}
```

This covers the reuse path and any future completion path that routes through the choke point.

## Scope

- This PR stops **new** orphan jobs from being created. Cleanup of any **pre-existing** `completed` + `completedAt == null` jobs (migration or query hardening) is intentionally out of scope and tracked separately.

## Tests

Added `notify-export-result-and-clean-up.integ.ts` (3 cases):
- completed job without `completedAt` → gets set
- completed job with existing `completedAt` → preserved
- failed job → `completedAt` not set

Verified: new test passes, existing `page-bulk-export-job-clean-up-cron.integ` passes, Biome and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)