### PR TITLE
imprv(otel): Drop growi.installedAt resource attributes

### DIFF
--- a/apps/app/src/features/opentelemetry/server/custom-resource-attributes/application-resource-attributes.spec.ts
+++ b/apps/app/src/features/opentelemetry/server/custom-resource-attributes/application-resource-attributes.spec.ts
@@ -27,8 +27,6 @@ describe('getApplicationResourceAttributes', () => {
       deploymentType: 'standalone',
       additionalInfo: {
         attachmentType: 'local',
-        installedAt: new Date('2023-01-01T00:00:00.000Z'),
-        installedAtByOldestUser: new Date('2023-01-01T00:00:00.000Z'),
       },
     };
 
@@ -40,11 +38,9 @@ describe('getApplicationResourceAttributes', () => {
       'growi.service.type': 'app',
       'growi.deployment.type': 'standalone',
       'growi.attachment.type': 'local',
-      'growi.installedAt': '2023-01-01T00:00:00.000Z',
-      'growi.installedAt.by_oldest_user': '2023-01-01T00:00:00.000Z',
     });
     expect(mockGrowiInfoService.getGrowiInfo).toHaveBeenCalledWith({
-      includeInstalledInfo: true,
+      includeAttachmentInfo: true,
     });
   });
 
@@ -63,8 +59,6 @@ describe('getApplicationResourceAttributes', () => {
       'growi.service.type': 'app',
       'growi.deployment.type': 'standalone',
       'growi.attachment.type': undefined,
-      'growi.installedAt': undefined,
-      'growi.installedAt.by_oldest_user': undefined,
     });
   });
 
@@ -76,28 +70,5 @@ describe('getApplicationResourceAttributes', () => {
     const result = await getApplicationResourceAttributes();
 
     expect(result).toEqual({});
-  });
-
-  it('should handle partial additionalInfo data', async () => {
-    const mockGrowiInfo = {
-      type: 'app',
-      deploymentType: 'docker',
-      additionalInfo: {
-        attachmentType: 'gridfs',
-        // Missing installedAt and installedAtByOldestUser
-      },
-    };
-
-    mockGrowiInfoService.getGrowiInfo.mockResolvedValue(mockGrowiInfo);
-
-    const result = await getApplicationResourceAttributes();
-
-    expect(result).toEqual({
-      'growi.service.type': 'app',
-      'growi.deployment.type': 'docker',
-      'growi.attachment.type': 'gridfs',
-      'growi.installedAt': undefined,
-      'growi.installedAt.by_oldest_user': undefined,
-    });
   });
 });

--- a/apps/app/src/features/opentelemetry/server/custom-resource-attributes/application-resource-attributes.ts
+++ b/apps/app/src/features/opentelemetry/server/custom-resource-attributes/application-resource-attributes.ts
@@ -18,7 +18,7 @@ export async function getApplicationResourceAttributes(): Promise<Attributes> {
     const { growiInfoService } = await import('~/server/service/growi-info');
 
     const growiInfo = await growiInfoService.getGrowiInfo({
-      includeInstalledInfo: true,
+      includeAttachmentInfo: true,
     });
 
     const attributes: Attributes = {
@@ -26,11 +26,6 @@ export async function getApplicationResourceAttributes(): Promise<Attributes> {
       'growi.service.type': growiInfo.type,
       'growi.deployment.type': growiInfo.deploymentType,
       'growi.attachment.type': growiInfo.additionalInfo?.attachmentType,
-
-      // Installation information (fixed values)
-      'growi.installedAt': growiInfo.additionalInfo?.installedAt?.toISOString(),
-      'growi.installedAt.by_oldest_user':
-        growiInfo.additionalInfo?.installedAtByOldestUser?.toISOString(),
     };
 
     logger.info({ attributes }, 'Application resource attributes collected');

--- a/apps/app/src/features/opentelemetry/server/node-sdk.spec.ts
+++ b/apps/app/src/features/opentelemetry/server/node-sdk.spec.ts
@@ -31,8 +31,6 @@ vi.mock('~/server/service/growi-info', () => ({
       deploymentType: 'standalone',
       additionalInfo: {
         attachmentType: 'local',
-        installedAt: new Date('2023-01-01T00:00:00.000Z'),
-        installedAtByOldestUser: new Date('2023-01-01T00:00:00.000Z'),
       },
     }),
   },


### PR DESCRIPTION
## Summary
- Remove `growi.installedAt` and `growi.installedAt.by_oldest_user` from the application resource attributes
- These timestamp-valued attributes increase time-series cardinality on the metrics backend, which provides little observability benefit
- Switch the `getGrowiInfo()` call to `{ includeAttachmentInfo: true }` since installation info is no longer needed (attachment type is still emitted)

## Test plan
- [x] `pnpm vitest run application-resource-attributes.spec node-sdk.spec` passes (13/13)
- [ ] Verify in a running instance that `growi.service.type`, `growi.deployment.type`, `growi.attachment.type` are still emitted as resource attributes
- [ ] Verify that `growi.installedAt*` no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)