### PR TITLE
fix: fix color

### DIFF
--- a/apps/app/src/client/components/Bookmarks/BookmarkFolderTree.module.scss
+++ b/apps/app/src/client/components/Bookmarks/BookmarkFolderTree.module.scss
@@ -1,3 +1,5 @@
+@use '@growi/core-styles/scss/bootstrap/init' as bs;
+
 $grw-foldertree-item-padding-left: 15px;
 $grw-bookmark-item-padding-left: 35px;
 
@@ -19,6 +21,17 @@ $grw-bookmark-item-padding-left: 35px;
     margin: 1rem;
     border-style: dashed !important;
     border-width: 0.15rem !important;
+  }
+}
+
+@include bs.color-mode(light) {
+  .grw-foldertree {
+    :global(.list-group-item) {
+      :global(.grw-foldertree-triangle-btn),
+      :global(.btn-page-item-control) {
+        --bs-btn-color: var(--bs-tertiary-color);
+      }
+    }
   }
 }
 

--- a/apps/app/src/client/components/Sidebar/PageTreeItem/PageTreeItem.module.scss
+++ b/apps/app/src/client/components/Sidebar/PageTreeItem/PageTreeItem.module.scss
@@ -27,6 +27,7 @@
   .page-tree-item {
     :global(.list-group-item-action) {
       :global(.btn-page-item-control) {
+        --bs-btn-color: var(--bs-tertiary-color);
         --bs-btn-bg: transparent;
         --bs-btn-hover-bg: var(--grw-primary-200);
         --bs-btn-active-bg: var(--grw-primary-300);


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/182771

## 概要
サイドバーのページツリー・ブックマークにおいて、`⋮` と `+` のアイコン色が arrow_right と異なっていた問題を修正。
ライトモードで --bs-btn-color: var(--bs-tertiary-color) を設定した。

arrow_right は TreeItemLayout.module.scss で --bs-btn-color: var(--bs-tertiary-color) が既に設定済みだったが、`⋮` と `+` は未設定のままで Bootstrap のデフォルト色を継承していた。
<img width="552" height="591" alt="スクリーンショット 2026-05-22 203937" src="https://github.com/user-attachments/assets/50b12642-812e-4aa4-8be2-325bbfee0b99" />
<img width="561" height="537" alt="スクリーンショット 2026-05-22 203947" src="https://github.com/user-attachments/assets/faa5418c-1889-47ce-813f-025947305c4d" />
