### PR TITLE
fix(page-grant): guard against TypeError when grantedUsers is empty in calcApplicableGrantData

### DIFF
--- a/apps/app/src/server/service/page-grant.ts
+++ b/apps/app/src/server/service/page-grant.ts
@@ -850,11 +850,13 @@ class PageGrantService implements IPageGrantService {
         applicableGroups: userRelatedGroups,
       };
     } else if (grant === PageGrant.GRANT_OWNER) {
-      const grantedUser = grantedUsers[0];
+      const grantedUser = grantedUsers?.[0];
 
-      const isUserApplicable = grantedUser.toString() === user._id.toString();
-
-      if (isUserApplicable) {
+      // grantedUsers may be empty due to data inconsistency; guard against TypeError
+      if (
+        grantedUser != null &&
+        grantedUser.toString() === user._id.toString()
+      ) {
         data[PageGrant.GRANT_OWNER] = null;
       }
     } else if (grant === PageGrant.GRANT_USER_GROUP) {


### PR DESCRIPTION
## Summary

- `calcApplicableGrantData` の `GRANT_OWNER` 分岐で `grantedUsers[0]` に null チェックを追加し、空配列の場合に TypeError で 500 エラーになるのを防ぐ

## Root Cause

`apps/app/src/server/service/page-grant.ts:852-855` において、親ページが `GRANT_OWNER` かつ `grantedUsers` が空配列の場合（グラント上書きサイクルによるデータ不整合が原因）、`grantedUsers[0]` が `undefined` になり `.toString()` で TypeError が発生し HTTP 500 を引き起こしていた。

```typescript
// Before (バグ):
const grantedUser = grantedUsers[0];               // ← 空配列で undefined
const isUserApplicable = grantedUser.toString() === user._id.toString(); // ← TypeError!

// After (修正):
const grantedUser = grantedUsers?.[0];
if (grantedUser != null && grantedUser.toString() === user._id.toString()) {
    data[PageGrant.GRANT_OWNER] = null;
}
```

## Changes

- `apps/app/src/server/service/page-grant.ts`: `calcApplicableGrantData` 内の `GRANT_OWNER` 分岐に null ガードを追加

## Test Plan

- [ ] 親ページを「自分のみ」→「リンクを知っている人のみ」＋配下上書き → 再度「自分のみ」＋配下上書きの手順で子ページにアクセスできることを確認
- [ ] 正常状態（親が GRANT_OWNER かつ grantedUsers が正しく設定されている場合）の動作が変わらないことを確認
- [ ] `pnpm vitest run page-grant.integ` で既存の統合テストがパスすることを確認

Closes #9067

---
_Generated by [Claude Code](https://claude.ai/code/session_012rkDirDVCqYdE3Hz1NGtaA)_