### PR TITLE
support: Verify initial pages are created with content after installation

### DIFF
--- a/apps/app/playwright/10-installer/install.spec.ts
+++ b/apps/app/playwright/10-installer/install.spec.ts
@@ -52,4 +52,16 @@ test('Installer', async ({ page }) => {
 
   await page.waitForURL('/', { timeout: 20000 });
   await expect(page).toHaveTitle(/\/ - GROWI/);
+
+  // Verify / page has content from welcome.md
+  await expect(
+    page.getByRole('heading', { name: /Welcome to GROWI/ }),
+  ).toBeVisible();
+
+  // Verify /Sandbox page was created with content from sandbox.md
+  await page.goto('/Sandbox');
+  await expect(page).toHaveTitle(/Sandbox/);
+  await expect(
+    page.getByRole('heading', { name: /GROWI Sandbox/ }),
+  ).toBeVisible();
 });

--- a/apps/app/playwright/10-installer/install.spec.ts
+++ b/apps/app/playwright/10-installer/install.spec.ts
@@ -55,13 +55,16 @@ test('Installer', async ({ page }) => {
 
   // Verify / page has content from welcome.md
   await expect(
-    page.getByRole('heading', { name: /Welcome to GROWI/ }),
+    page.getByRole('heading', { level: 1, name: /Welcome to GROWI/ }),
   ).toBeVisible();
 
   // Verify /Sandbox page was created with content from sandbox.md
   await page.goto('/Sandbox');
   await expect(page).toHaveTitle(/Sandbox/);
   await expect(
-    page.getByRole('heading', { name: /GROWI Sandbox/ }),
+    page.getByRole('heading', {
+      level: 1,
+      name: /Welcome to the GROWI Sandbox/,
+    }),
   ).toBeVisible();
 });


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/183945

## 概要

インストーラーの Playwright テストに、初期ページのコンテンツ存在確認を追加。

## 背景

v7.5.0 でインストール時に初期ページ（`/`・`/Sandbox`）が自動生成されない問題が発生した。
原因は production build での markdown ファイル除外。
既存のインストーラーテストは `/` へのリダイレクトとタイトルのみ確認しており、
ページ本文が空でもテストが通過してしまっていた。

## 変更内容

`playwright/10-installer/install.spec.ts` に以下を追加：

- インストール完了後、`/` ページに `welcome.md` 由来の見出し（`Welcome to GROWI`）が表示されることを確認
- `/Sandbox` ページに `sandbox.md` 由来の見出し（`GROWI Sandbox`）が表示されることを確認