### PR TITLE
fix(attachment): deny direct access to /uploads to prevent stored XSS

### DIFF
--- a/apps/app/src/server/crowi/express-init.js
+++ b/apps/app/src/server/crowi/express-init.js
@@ -10,6 +10,7 @@ import {
 } from '../../features/growi-plugin/server/consts';
 import loggerFactory from '../../utils/logger';
 import CertifyOrigin from '../middlewares/certify-origin';
+import { denyUploadsDirectAccess } from '../middlewares/deny-uploads-direct-access';
 import registerSafeRedirectFactory from '../middlewares/safe-redirect';
 
 const logger = loggerFactory('growi:crowi:express-init');
@@ -92,6 +93,11 @@ module.exports = (crowi, app) => {
   app.set('port', crowi.port);
 
   const staticOption = crowi.node_env === 'production' ? { maxAge: '30d' } : {};
+  // Deny direct access to uploaded files (publicDir/uploads/**) BEFORE static
+  // serving. Uploads must be served only via the /attachment and /download
+  // routes, which apply authorization, Content-Disposition and CSP headers.
+  // see: src/server/middlewares/deny-uploads-direct-access.ts
+  app.use('/uploads', denyUploadsDirectAccess);
   app.use(express.static(crowi.publicDir, staticOption));
   app.use(
     '/static/preset-themes',

--- a/apps/app/src/server/middlewares/deny-uploads-direct-access.spec.ts
+++ b/apps/app/src/server/middlewares/deny-uploads-direct-access.spec.ts
@@ -1,0 +1,19 @@
+import type { Request, Response } from 'express';
+
+import { denyUploadsDirectAccess } from './deny-uploads-direct-access';
+
+describe('denyUploadsDirectAccess', () => {
+  test('responds with 403 Forbidden', () => {
+    const send = vi.fn();
+    const status = vi.fn().mockReturnValue({ send });
+    const req = {
+      originalUrl: '/uploads/attachment/evil.html',
+    } as unknown as Request;
+    const res = { status } as unknown as Response;
+
+    denyUploadsDirectAccess(req, res);
+
+    expect(status).toHaveBeenCalledWith(403);
+    expect(send).toHaveBeenCalledWith('Forbidden');
+  });
+});

--- a/apps/app/src/server/middlewares/deny-uploads-direct-access.spec.ts
+++ b/apps/app/src/server/middlewares/deny-uploads-direct-access.spec.ts
@@ -1,19 +1,21 @@
 import type { Request, Response } from 'express';
+import { mock } from 'vitest-mock-extended';
 
 import { denyUploadsDirectAccess } from './deny-uploads-direct-access';
 
 describe('denyUploadsDirectAccess', () => {
   test('responds with 403 Forbidden', () => {
-    const send = vi.fn();
-    const status = vi.fn().mockReturnValue({ send });
-    const req = {
-      originalUrl: '/uploads/attachment/evil.html',
-    } as unknown as Request;
-    const res = { status } as unknown as Response;
+    const req = mock<Request>();
+    req.originalUrl = '/uploads/attachment/evil.html';
+
+    const res = mock<Response>();
+    // res.status(...) returns `this` (Response) in Express, enabling the
+    // status().send() chain. Mirror that so the chained send() can be asserted.
+    res.status.mockReturnValue(res);
 
     denyUploadsDirectAccess(req, res);
 
-    expect(status).toHaveBeenCalledWith(403);
-    expect(send).toHaveBeenCalledWith('Forbidden');
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.send).toHaveBeenCalledWith('Forbidden');
   });
 });

--- a/apps/app/src/server/middlewares/deny-uploads-direct-access.ts
+++ b/apps/app/src/server/middlewares/deny-uploads-direct-access.ts
@@ -1,0 +1,25 @@
+import type { Request, Response } from 'express';
+
+import loggerFactory from '~/utils/logger';
+
+const logger = loggerFactory('growi:middleware:deny-uploads-direct-access');
+
+/**
+ * Deny direct access to uploaded files stored under `publicDir/uploads/**`.
+ *
+ * When the upload method is "Local", attachments are written under
+ * `publicDir/uploads/**`, which would otherwise be served directly by
+ * `express.static(publicDir)`. Serving them statically bypasses the
+ * `/attachment` and `/download` routes that apply authorization,
+ * `Content-Disposition` and `Content-Security-Policy` headers, enabling stored
+ * XSS and access-control bypass.
+ *
+ * This middleware blanket-denies the whole `/uploads` prefix (attachment, user,
+ * page-bulk-export, audit-log-bulk-export and any future subdirectory) so that
+ * adding a new storage prefix never silently re-opens the hole. It MUST be
+ * registered BEFORE `express.static(publicDir)`.
+ */
+export const denyUploadsDirectAccess = (req: Request, res: Response): void => {
+  logger.debug(`Blocked direct access to an uploaded file: ${req.originalUrl}`);
+  res.status(403).send('Forbidden');
+};


### PR DESCRIPTION
## Task
https://redmine.weseek.co.jp/issues/163621


## What

Local アップロード時に `publicDir/uploads/**` 配下のファイルへ直接アクセスできてしまう問題を修正します。

`express.static(crowi.publicDir)` が `publicDir` 全体を配信しているため、`/uploads/attachment/<fileName>` のような直アクセスが `/attachment`・`/download` ルートを経由せず、それらが付与している認証チェック・`Content-Disposition`・`Content-Security-Policy` を**すべてバイパス**して生ファイルを返していました。

これにより以下が可能でした:
- アップロードした HTML 等を CSP 無しでブラウザにレンダリング（XSS）
- `loginRequired` も通らないため、非公開ページの添付ファイルへのアクセス制御バイパス

## How

`/uploads` プレフィックス全体を `express.static` の**前**で 403 拒否する middleware を追加しました。

- 個別ディレクトリ（`attachment` / `user` / `page-bulk-export` / `audit-log-bulk-export`）を列挙するのではなく `/uploads` 全体を一括で拒否 → 将来 storage prefix が追加されても穴が再発しない
- 正規の配信経路（`/attachment/:id`・`/download/:id`・エクスポート DL）は別パスのため影響なし
- 副次的に、`/uploads` ディレクトリアクセス時に発生していた serve-static ↔ Next.js trailingSlash のリダイレクトループ（`ERR_TOO_MANY_REDIRECTS`）も解消されます

## Changes

- `apps/app/src/server/middlewares/deny-uploads-direct-access.ts` (new)
- `apps/app/src/server/middlewares/deny-uploads-direct-access.spec.ts` (new)
- `apps/app/src/server/crowi/express-init.js` — `express.static` の前に middleware を登録

## Test

- `pnpm vitest run deny-uploads-direct-access` ✅
- Biome: 変更箇所に警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
