### PR TITLE
fix(client): right-align ModalHeader close content wrapped in a custom element

### DIFF
--- a/apps/app/src/client/components/DescendantsPageListModal/DescendantsPageListModal.tsx
+++ b/apps/app/src/client/components/DescendantsPageListModal/DescendantsPageListModal.tsx
@@ -112,7 +112,7 @@ const DescendantsPageListModalSubstance = ({
 
   const buttons = useMemo(
     () => (
-      <span className="me-3">
+      <span className="ms-auto me-3">
         <ExpandOrContractButton
           isWindowExpanded={isWindowExpanded}
           expandWindow={expandWindow}

--- a/apps/app/src/client/components/PageAccessoriesModal/PageAccessoriesModal.tsx
+++ b/apps/app/src/client/components/PageAccessoriesModal/PageAccessoriesModal.tsx
@@ -118,7 +118,7 @@ const PageAccessoriesModalSubstance = ({
 
   const buttons = useMemo(
     () => (
-      <span className="me-3">
+      <span className="ms-auto me-3">
         <ExpandOrContractButton
           isWindowExpanded={isWindowExpanded}
           expandWindow={expandWindow}

--- a/apps/app/src/client/components/PageEditor/ConflictDiffModal/ConflictDiffModal.tsx
+++ b/apps/app/src/client/components/PageEditor/ConflictDiffModal/ConflictDiffModal.tsx
@@ -100,7 +100,7 @@ const ConflictDiffModalSubstance = (
 
   const headerButtons = useMemo(
     () => (
-      <div className="d-flex align-items-center">
+      <div className="d-flex align-items-center ms-auto">
         <button
           type="button"
           className="btn"

--- a/apps/app/src/client/components/PageEditor/EditorNavbarBottom/GrantSelector.tsx
+++ b/apps/app/src/client/components/PageEditor/EditorNavbarBottom/GrantSelector.tsx
@@ -377,7 +377,7 @@ export const GrantSelector = (props: Props): JSX.Element => {
     return (
       <button
         type="button"
-        className="btn border-0 text-muted"
+        className="btn border-0 text-muted ms-auto"
         onClick={() => setIsSelectGroupModalShown(false)}
       >
         <span className="material-symbols-outlined">close</span>

--- a/apps/app/src/client/components/PageEditor/HandsontableModal/HandsontableModal.tsx
+++ b/apps/app/src/client/components/PageEditor/HandsontableModal/HandsontableModal.tsx
@@ -489,7 +489,7 @@ const HandsontableModalSubstance = (
   });
 
   const closeButton = (
-    <span>
+    <span className="ms-auto">
       <ExpandOrContractButton
         isWindowExpanded={isWindowExpanded}
         contractWindow={contractWindow}

--- a/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHeader.tsx
+++ b/apps/app/src/features/openai/client/components/AiAssistant/AiAssistantManagementModal/AiAssistantManagementHeader.tsx
@@ -29,7 +29,7 @@ export const AiAssistantManagementHeader = (props: Props): JSX.Element => {
     <ModalHeader
       tag="h4"
       close={
-        <button type="button" className="btn p-0" onClick={close}>
+        <button type="button" className="btn p-0 ms-auto" onClick={close}>
           <span className="material-symbols-outlined">close</span>
         </button>
       }


### PR DESCRIPTION
## 概要

`ModalHeader` の `close` prop に **wrapper 要素**(`span`/`div`、またはカスタムアイコンボタン)を渡しているモーダルで、close ボタン群が右寄せされず**モーダルタイトルのすぐ右**に表示される問題を修正します。

## 原因

Bootstrap 5.3 で `.modal-header` から `justify-content: space-between` が削除され、ヘッダー内 close 要素の右寄せは「**`.modal-header` の直接の flex 子要素であり `margin-left: auto` を持つこと**」だけに依存するようになりました。Bootstrap はこの `margin-left: auto` を `.btn-close` にのみ付与します。

reactstrap の `ModalHeader` は次の DOM を生成します:

```html
<div class="modal-header">
  <h5 class="modal-title">…title…</h5>   <!-- children -->
  {close}                                 <!-- close prop -->
</div>
```

`close={...}` に `.btn-close` そのものではなく wrapper 要素(`ExpandOrContractButton` + close をまとめた `span`/`div` や、material-symbols のカスタムボタン)を渡している場合、その要素は `.btn-close` ではないため `margin-left: auto` が効かず、タイトル直後に表示されていました。

> 補足: turbopack 化が原因ではありません。当時の scss 変換(`:global` 記法の変更)は挙動を変えておらず、Bootstrap も以前から 5.3.x です。`space-between` に暗黙的に依存していた潜在的なレイアウト不備が顕在化したものです。

## 修正

影響する各モーダルの close wrapper に `ms-auto`(= `margin-left: auto`)を付与し、flex item として右端へ寄せます(navbar 等で使う Bootstrap の定石)。小デバイス時(タイトル非表示で close が唯一の子になるケース)の左寄りも同時に解消されます。

## 影響範囲(修正したモーダル)

| モーダル | close の中身 |
|---|---|
| DescendantsPageListModal | `span` ラッパ + ExpandOrContractButton/btn-close |
| PageAccessoriesModal | `span` ラッパ + ExpandOrContractButton/btn-close |
| HandsontableModal | `span` ラッパ + ExpandOrContractButton/btn-close |
| ConflictDiffModal | `div.d-flex` ラッパ + カスタムボタン |
| AiAssistantManagementHeader | カスタムボタン(`.btn-close` ではない) |
| GrantSelector(グループ選択) | カスタムボタン(`.btn-close` ではない) |

`close` を指定せず `toggle` のみのモーダルは、デフォルトの `.btn-close` が直接の子になるため影響ありません。

## 確認

- biome lint: 本変更による新規エラーなし(既存の warning/info のみ)
- 既存テスト: `DescendantsPageListModal.spec` パス
- CSS レイアウトのため jsdom では自動検証不可 → 実画面での目視確認を推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)
