### PR TITLE
モバイルでページ編集時に公開範囲が勝手に「公開」に切り替わらないようにする

### DIFF
--- a/apps/app/src/client/components/PageEditor/PageEditor.tsx
+++ b/apps/app/src/client/components/PageEditor/PageEditor.tsx
@@ -28,6 +28,7 @@ import {
 import { uploadAttachments } from '~/client/services/upload-attachments';
 import { toastError, toastSuccess, toastWarning } from '~/client/util/toastr';
 import { useIsEnableUnifiedMergeView } from '~/features/openai/client/states';
+import { UserGroupPageGrantStatus } from '~/interfaces/page';
 import { useShouldExpandContent } from '~/services/layout/use-should-expand-content';
 import { useCurrentPathname, useCurrentUser } from '~/states/global';
 import {
@@ -108,7 +109,7 @@ export const PageEditorSubstance = (props: Props): JSX.Element => {
   const currentPagePath = useCurrentPagePath();
   const currentPathname = useCurrentPathname();
   const currentPage = useCurrentPageData();
-  const [selectedGrant] = useSelectedGrant();
+  const [selectedGrant, setSelectedGrant] = useSelectedGrant();
   const editingMarkdown = useEditingMarkdown();
   const isEnabledAttachTitleHeader = useAtomValue(
     isEnabledAttachTitleHeaderAtom,
@@ -125,9 +126,24 @@ export const PageEditorSubstance = (props: Props): JSX.Element => {
   const defaultIndentSize = useAtomValue(defaultIndentSizeAtom);
   const acceptedUploadFileType = useAcceptedUploadFileType();
   const { data: editorSettings } = useEditorSettings();
-  const { mutate: mutateIsGrantNormalized } = useSWRxCurrentGrantData(
-    currentPage?._id,
-  );
+  const { data: grantData, mutate: mutateIsGrantNormalized } =
+    useSWRxCurrentGrantData(currentPage?._id);
+
+  // sync current page grant to selectedGrantAtom (especially for mobile where GrantSelector may not be mounted)
+  useEffect(() => {
+    const currentPageGrant = grantData?.grantData.currentPageGrant;
+    if (currentPageGrant == null) return;
+
+    const userRelatedGrantedGroups =
+      currentPageGrant.groupGrantData?.userRelatedGroups
+        .filter((group) => group.status === UserGroupPageGrantStatus.isGranted)
+        ?.map((group) => ({ item: group.id, type: group.type })) ?? [];
+    setSelectedGrant({
+      grant: currentPageGrant.grant,
+      userRelatedGrantedGroups,
+    });
+  }, [grantData, setSelectedGrant]);
+
   const user = useCurrentUser();
   const setEditingClients = useSetEditingClients();
   const setScrollToRemoteCursor = useSetScrollToRemoteCursor();

--- a/apps/app/src/states/ui/editor/selected-grant.ts
+++ b/apps/app/src/states/ui/editor/selected-grant.ts
@@ -1,3 +1,4 @@
+import { PageGrant } from '@growi/core/dist/interfaces';
 import { atom, useAtom } from 'jotai';
 
 import type { IPageSelectedGrant } from '~/interfaces/page';
@@ -6,7 +7,9 @@ import type { IPageSelectedGrant } from '~/interfaces/page';
  * Atom for selected grant in page editor
  * Stores temporary grant selection before it's applied to the page
  */
-const selectedGrantAtom = atom<IPageSelectedGrant | null>(null);
+const selectedGrantAtom = atom<IPageSelectedGrant | null>({
+  grant: PageGrant.GRANT_PUBLIC,
+});
 
 /**
  * Hook for managing selected grant in page editor

--- a/apps/app/src/states/ui/editor/selected-grant.ts
+++ b/apps/app/src/states/ui/editor/selected-grant.ts
@@ -1,4 +1,3 @@
-import { PageGrant } from '@growi/core/dist/interfaces';
 import { atom, useAtom } from 'jotai';
 
 import type { IPageSelectedGrant } from '~/interfaces/page';
@@ -7,9 +6,7 @@ import type { IPageSelectedGrant } from '~/interfaces/page';
  * Atom for selected grant in page editor
  * Stores temporary grant selection before it's applied to the page
  */
-const selectedGrantAtom = atom<IPageSelectedGrant | null>({
-  grant: PageGrant.GRANT_PUBLIC,
-});
+const selectedGrantAtom = atom<IPageSelectedGrant | null>(null);
 
 /**
  * Hook for managing selected grant in page editor


### PR DESCRIPTION
以下のバグのような挙動に対しての修正。直接PRが出せなかったのでこちらに作成。  

https://github.com/growilabs/growi/issues/11272

手元での動作確認では意図した挙動になった。
用意されているテスト類は問題なかったです。関連機能のデグレ等の確認は出来ていません。