### PR TITLE
fix: Remove uglifycss to preserve CSS Color Level 4 syntax

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -280,7 +280,6 @@
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "tslib": "^2.8.0",
-    "uglifycss": "^0.0.29",
     "uid-safe": "^2.1.5",
     "umzug": "^3.8.2",
     "unified": "^11.0.0",

--- a/apps/app/src/server/service/customize.ts
+++ b/apps/app/src/server/service/customize.ts
@@ -6,7 +6,6 @@ import {
   PresetThemesMetadatas,
 } from '@growi/preset-themes';
 import path from 'path';
-import uglifycss from 'uglifycss';
 
 import { growiPluginService } from '~/features/growi-plugin/server/services';
 import loggerFactory from '~/utils/logger';
@@ -94,8 +93,7 @@ export class CustomizeService implements S2sMessageHandlable {
   initCustomCss() {
     const rawCss = configManager.getConfig('customize:css') || '';
 
-    // uglify and store
-    this.customCss = uglifycss.processString(rawCss);
+    this.customCss = rawCss;
 
     this.lastLoadedAt = new Date();
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -797,9 +797,6 @@ importers:
       tslib:
         specifier: ^2.8.0
         version: 2.8.1
-      uglifycss:
-        specifier: ^0.0.29
-        version: 0.0.29
       uid-safe:
         specifier: ^2.1.5
         version: 2.1.5
@@ -13521,11 +13518,6 @@ packages:
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
-    hasBin: true
-
-  uglifycss@0.0.29:
-    resolution: {integrity: sha512-J2SQ2QLjiknNGbNdScaNZsXgmMGI0kYNrXaDlr4obnPW9ni1jljb1NeEVWAiTgZ8z+EBWP2ozfT9vpy03rjlMQ==}
-    engines: {node: '>=6.4.0'}
     hasBin: true
 
   uid-safe@2.1.5:
@@ -28815,8 +28807,6 @@ snapshots:
 
   uglify-js@3.19.3:
     optional: true
-
-  uglifycss@0.0.29: {}
 
   uid-safe@2.1.5:
     dependencies:


### PR DESCRIPTION
## Summary

- Remove `uglifycss.processString()` from `CustomizeService.initCustomCss()` and store raw CSS as-is
- Remove the `uglifycss` package dependency entirely

## Root Cause

`uglifycss` v0.0.29 (unmaintained since 2019) does not support CSS Color Level 4 space-separated `rgb()` syntax without an alpha channel. It attempts to convert the value to hex but produces a truncated, invalid result:

| Input | Output | Valid? |
|-------|--------|--------|
| `rgb(0 0 255)` | `#00` | ❌ Invalid — truncated hex, ignored by browsers |
| `rgb(0, 0, 255)` | `#00f` | ✅ Correct |
| `rgb(0 0 255 / 0.2)` | `rgb(0 0 255 / .2)` | ✅ Preserved |

## Changes

- `apps/app/src/server/service/customize.ts`: Remove `uglifycss` import and replace `uglifycss.processString(rawCss)` with `rawCss` directly
- `apps/app/package.json`: Remove `uglifycss` dependency
- `pnpm-lock.yaml`: Remove `uglifycss` lockfile entries

Custom CSS entered by administrators is typically small, so the minification benefit is negligible compared to the risk of breaking valid modern CSS syntax.

## Test Plan

- [ ] Go to `/admin/customize` and enter a custom CSS rule using space-separated `rgb()` without alpha: `.wiki h1 { background-color: rgb(0 0 255); }`
- [ ] Save and reload a page containing an `h1` element
- [ ] Verify the background color is applied correctly (blue)
- [ ] Verify comma-separated `rgb(0, 0, 255)` and alpha form `rgb(0 0 255 / 0.5)` also still work

Closes #11274

---
_Generated by [Claude Code](https://claude.ai/code/session_013vrzWB8LDmBaQ2Sk4c6iPe)_