### PR TITLE
fix: escape </style> breakout in renderCustomCss

### DIFF
--- a/apps/app/src/pages/_document.page.tsx
+++ b/apps/app/src/pages/_document.page.tsx
@@ -10,6 +10,7 @@ import type { CrowiRequest } from '~/interfaces/crowi-request';
 import loggerFactory from '~/utils/logger';
 
 import { getLocaleAtServerSide } from './utils/locale';
+import { sanitizeCustomCss } from './utils/sanitize-css';
 
 const _logger = loggerFactory('growi:page:_document');
 
@@ -104,8 +105,12 @@ class GrowiDocument extends Document<GrowiDocumentInitialProps> {
     if (customCss == null || customCss.length === 0) {
       return <></>;
     }
-    // biome-ignore lint/security/noDangerouslySetInnerHtml: ignore
-    return <style dangerouslySetInnerHTML={{ __html: customCss }} />;
+    return (
+      <style
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: ignore
+        dangerouslySetInnerHTML={{ __html: sanitizeCustomCss(customCss) }}
+      />
+    );
   }
 
   renderCustomNoscript(customNoscript: string | undefined): JSX.Element {

--- a/apps/app/src/pages/utils/sanitize-css.spec.ts
+++ b/apps/app/src/pages/utils/sanitize-css.spec.ts
@@ -1,0 +1,32 @@
+import { sanitizeCustomCss } from './sanitize-css';
+
+describe('sanitizeCustomCss', () => {
+  it('passes normal CSS through unchanged', () => {
+    const css = 'body { color: red; } h1 { font-size: 2em; }';
+    expect(sanitizeCustomCss(css)).toBe(css);
+  });
+
+  it('neutralizes </style> breakout', () => {
+    expect(sanitizeCustomCss('</style><script>alert(1)</script>')).toBe(
+      '<\\/style><script>alert(1)</script>',
+    );
+  });
+
+  it('handles case variant </Style>', () => {
+    expect(sanitizeCustomCss('</Style>')).toBe('<\\/Style>');
+  });
+
+  it('handles case variant </STYLE>', () => {
+    expect(sanitizeCustomCss('</STYLE>')).toBe('<\\/STYLE>');
+  });
+
+  it('handles whitespace variant </style >', () => {
+    expect(sanitizeCustomCss('</style >')).toBe('<\\/style >');
+  });
+
+  it('handles multiple occurrences', () => {
+    expect(sanitizeCustomCss('</style>a</STYLE>b')).toBe(
+      '<\\/style>a<\\/STYLE>b',
+    );
+  });
+});

--- a/apps/app/src/pages/utils/sanitize-css.ts
+++ b/apps/app/src/pages/utils/sanitize-css.ts
@@ -1,0 +1,3 @@
+// Prevent </style> from terminating the element prematurely; <\/ is not recognized as an HTML end tag.
+export const sanitizeCustomCss = (css: string): string =>
+  css.replace(/<\/(style)/gi, '<\\/$1');


### PR DESCRIPTION
## Summary

- Neutralize the `</style>` closing-tag sequence in `renderCustomCss` to prevent premature termination of the `<style>` element
- Extract `sanitizeCustomCss()` as a pure utility function in `pages/utils/sanitize-css.ts` for isolated testing
- Add co-located unit tests covering normal CSS, breakout input, and case/whitespace variants

## Root Cause

`renderCustomCss()` in `apps/app/src/pages/_document.page.tsx` passed `customCss` directly to `dangerouslySetInnerHTML` without escaping the `</style>` sequence. A `</style>` inside the custom CSS terminates the `<style>` element prematurely, allowing any HTML following it (including `<script>` tags) to be rendered in the document body for every visitor.

Since custom CSS is an admin-only setting, this is a **defense-in-depth** fix rather than a privilege escalation — a legitimate admin can already execute JS via Custom Script. The fix limits blast radius if an admin account is compromised and keeps the CSS field strictly a CSS field.

## Changes

- `apps/app/src/pages/utils/sanitize-css.ts` — new pure utility: `sanitizeCustomCss()` replaces `</style` with `<\/style` (the `<\/` sequence is not recognized as an HTML end tag by the parser)
- `apps/app/src/pages/utils/sanitize-css.spec.ts` — unit tests: normal CSS passthrough, breakout, case variants (`</Style>`, `</STYLE>`), whitespace variant (`</style >`)
- `apps/app/src/pages/_document.page.tsx` — `renderCustomCss()` now calls `sanitizeCustomCss()` before rendering

## Test Plan

- [x] Unit tests pass (`pnpm vitest run sanitize-css.spec` — 6/6)
- [x] Biome lint passes
- [x] Manually set custom CSS containing `</style><script>alert(1)</script>` in admin settings and verify the script does not execute

Closes #11278

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWJjvLP7TWXd32dPukTa7y)_