### PR TITLE
fix(esm-migration): produce dist/migrations as ESM for production (spec task 3.8.b)

### DIFF
--- a/.kiro/specs/esm-migration/phase3-gate-evidence/3.8a-build-alone.txt
+++ b/.kiro/specs/esm-migration/phase3-gate-evidence/3.8a-build-alone.txt
@@ -1,0 +1,4 @@
+# 3.8.a build (turbo run build --filter @growi/app) — sandbox
+captured: 2026-06-14T03:51:23Z / commit: 04033e13
+
+ Tasks:    21 successful, 21 total

--- a/.kiro/specs/esm-migration/phase3-gate-evidence/3.8a-lint-alone.txt
+++ b/.kiro/specs/esm-migration/phase3-gate-evidence/3.8a-lint-alone.txt
@@ -1,0 +1,4 @@
+# 3.8.a lint (turbo run lint --filter @growi/app) — sandbox
+captured: 2026-06-14T03:51:23Z / commit: 04033e13
+
+ Tasks:    21 successful, 21 total

--- a/.kiro/specs/esm-migration/phase3-gate-evidence/3.8a-nocjs-unit.txt
+++ b/.kiro/specs/esm-migration/phase3-gate-evidence/3.8a-nocjs-unit.txt
@@ -1,0 +1,3 @@
+# 3.8.a lint:no-cjs + unit — sandbox
+no-cjs: route-top-level-guard OK (350 files)
+unit (vitest app-unit): 1951 passed / 8 skipped; 1 file env-fail (update-activity.spec.ts: mongodb-memory-server download 403 — sandbox-only, green in CI)

--- a/.kiro/specs/esm-migration/phase3-gate-evidence/3.8b-prod-migrations-fix.md
+++ b/.kiro/specs/esm-migration/phase3-gate-evidence/3.8b-prod-migrations-fix.md
@@ -88,3 +88,16 @@ target siblings exist in `dist/` (gridfs.js / nchan.js / search.js); NodeNext
 runtime probe `import(\`./dist/.../gridfs.js\`)` → resolves & loads. `rg` confirms
 0 remaining extensionless computed dynamic imports in src/server + features-server.
 Real-DB confirmation: re-dispatch `reusable-app-prod.yml` on the branch.
+
+### Correction: file-uploader is file-vs-directory, needs a static loader map
+The blanket `./${method}.js` was wrong for file-uploader: `aws`/`gcs` are
+**directories** (`aws/index.ts`), while `azure`/`gridfs`/`local`/`none` are
+sibling files. `./aws.js` does not match the `aws/` directory (a bare `./aws`
+only resolved under tsx's lenient dev resolution — `ci-app-launch-dev` defaults
+to `aws` and broke). Replaced the computed import with a static, statically
+analyzable loader map keyed by the resolved module name, each entry using the
+correct specifier (`./aws/index.js` vs `./gridfs.js`). The other 4 computed
+dynamic-import sites (s2s-messaging, slack-integration ×3) target flat files,
+so their `.js` suffix is correct and unchanged. Verified: tsgo/biome clean,
+`build:server` emits the literal map, dist targets (aws/index.js, gcs/index.js,
+gridfs.js, …) all present.

--- a/.kiro/specs/esm-migration/phase3-gate-evidence/3.8b-prod-migrations-fix.md
+++ b/.kiro/specs/esm-migration/phase3-gate-evidence/3.8b-prod-migrations-fix.md
@@ -1,0 +1,61 @@
+# 3.8.b — production migration regression caught & fixed
+
+## What the gate caught
+Dispatching the production CI (`reusable-app-prod.yml`, run 27496657144) ran
+`launch-prod` → `pnpm run server:ci` (= `preserver` → `migrate` →
+`migrate:migrate-mongo`) against a real MongoDB and failed:
+
+```
+ERROR: migrations directory does not exist: .../apps/app/dist/migrations/
+```
+
+`build-prod` itself was ✅ (production ESM build + assemble + check-next-symlinks
+all passed); the failure was purely the migration step, and the Playwright jobs
+failed only as a cascade of `launch-prod` not starting.
+
+## Root cause
+Task 2.1 added `src/migrations/**` to `tsconfig.build.server.json`'s `exclude`
+(to keep migrations out of the NodeNext flip). That stopped the server build
+from emitting them, so `dist/migrations/` — which production's
+`MIGRATIONS_DIR=dist/migrations/` points at — was never produced. Dev was
+unaffected (`MIGRATIONS_DIR=src/migrations/`, run via tsx), and
+`test-prod-node24` is skipped on `support/esm` PRs, so the regression stayed
+latent until this dispatch. Exactly the prod-only class of failure 3.8.b exists
+to catch.
+
+## Fix (option B — ESM migrations, user-approved)
+migrate-mongo reads `migration.up` / `migration.down` directly off the loaded
+module, so ESM migrations need **named** exports. The migrations were
+mixed-CJS (`module.exports = { up, down }` + a mix of `import` and `require`),
+runnable only because tsc used to compile them to CJS. Converted them to native
+ESM and folded them back into the normal build:
+
+- `tools/codemod/migrations-cjs-to-esm.cjs` (new): `require()` → `import`;
+  `module.exports = { async up(){…}, async down(){…} }` → `export async
+  function up/down`. Applied to all 48 migrations.
+- `add-import-extensions` applied to migrations (`.js` on relative/alias specifiers).
+- Removed `src/migrations/package.json` (`{type:commonjs}`) → migrations inherit
+  apps/app `type:module` (ESM) in both `src` (dev/tsx) and `dist` (prod).
+- Removed `src/migrations/**` from the server-build `exclude` → migrations
+  compile to `transpiled/src/migrations` → `dist/migrations` (ESM, `~/` resolved
+  to relative `../server/...js` by typescript-transform-paths).
+- Removed the now-obsolete `**/src/migrations/**` ignore from both codemod CLIs.
+- Updated the one migration `.integ.ts` (`migrateModule.default` → namespace).
+
+## Local verification (sandbox, no mongo)
+- `turbo run build --filter @growi/app` → **21/21**; `dist/migrations/` now has 48 `.js`.
+- Compiled `dist/migrations/*.js` is ESM: `import { Config } from "../server/models/config.js"`,
+  `export async function up()/down()`, **0** residual `module.exports`/`require`.
+- `import()` of a compiled migration → `keys: [down, up]`, both `function` (named exports OK for migrate-mongo).
+- Dev path: `import()` of a `src/migrations/*.js` under tsx → same named `up`/`down`.
+- **Regression closed**: prod `migrate-mongo up -f config/migrate-mongo-config.cjs`
+  with `NODE_ENV=production MIGRATIONS_DIR=dist/migrations/` now reaches the Mongo
+  connection (`ECONNREFUSED`/`ServerSelectionError`) instead of
+  "migrations directory does not exist".
+- `tsgo` typecheck clean; `biome` clean; `vitest --project=app-unit` 1951 passed
+  (1 file env-blocked: mongodb-memory-server 403, green in CI).
+
+## Remaining (needs real DB — CI)
+Re-dispatch `reusable-app-prod.yml` on `support/esm` to confirm `launch-prod`
+(`server:ci`) now boots through migrations on a real MongoDB and Playwright runs.
+The migration `.integ.ts` runs in `ci-app-test-integration` (real mongo).

--- a/.kiro/specs/esm-migration/phase3-gate-evidence/3.8b-prod-migrations-fix.md
+++ b/.kiro/specs/esm-migration/phase3-gate-evidence/3.8b-prod-migrations-fix.md
@@ -59,3 +59,32 @@ ESM and folded them back into the normal build:
 Re-dispatch `reusable-app-prod.yml` on `support/esm` to confirm `launch-prod`
 (`server:ci`) now boots through migrations on a real MongoDB and Playwright runs.
 The migration `.integ.ts` runs in `ci-app-test-integration` (real mongo).
+
+---
+
+## 3.8.b follow-on: extensionless computed dynamic imports (run 27503608537)
+
+With the migration fix in place, `launch-prod (8.0)` advanced **past migrations**
+(Passport / search-delegator init reached) and then failed at server boot:
+
+```
+ERR_MODULE_NOT_FOUND: Cannot find module '.../dist/server/service/file-uploader/gridfs'
+  imported from .../dist/server/service/file-uploader/index.js   (note: no .js)
+```
+
+Root cause: template-literal dynamic imports (`await import(\`./${x}\`)`) — the
+static extension codemod (task 3.4) cannot add extensions to non-literal
+specifiers, and NodeNext's runtime ESM resolver requires the `.js`. These fire
+only on prod NodeNext (tsx resolves extensionless leniently in dev), and several
+sit on conditional/runtime paths that `server:ci` boot may not even reach.
+
+Fixed all 5 computed dynamic-import sites by appending `.js`:
+- `src/server/service/file-uploader/index.ts` (`./${method}` → boot path; this is what failed)
+- `src/server/service/s2s-messaging/index.ts` (delegator load when pub/sub configured)
+- `src/server/service/slack-integration.ts` ×3 (`./slack-command-handler/${cmd}`)
+
+Verification (sandbox): `tsgo` clean; `build:server` emits `./${method}.js` etc.;
+target siblings exist in `dist/` (gridfs.js / nchan.js / search.js); NodeNext
+runtime probe `import(\`./dist/.../gridfs.js\`)` → resolves & loads. `rg` confirms
+0 remaining extensionless computed dynamic imports in src/server + features-server.
+Real-DB confirmation: re-dispatch `reusable-app-prod.yml` on the branch.

--- a/.kiro/specs/esm-migration/phase3-gate-evidence/3.8cd-gatescript-esm-preflight.txt
+++ b/.kiro/specs/esm-migration/phase3-gate-evidence/3.8cd-gatescript-esm-preflight.txt
@@ -1,0 +1,15 @@
+# 3.8.c/3.8.d gate-script ESM pre-flight (tsx) — sandbox
+captured: 2026-06-14T03:51:23Z / commit: 04033e13
+
+Goal: confirm the capture scripts (re-wired to tsx in task 3.7.b) LOAD under tsx and
+fail only at the mongo-connect point (no real ESM bug), so they are ready to run in
+the devcontainer where MongoDB exists.
+
+snapshot-routes        -> MongooseServerSelectionError (ReplicaSetNoPrimary, mongo:27017) = ESM-load OK, mongo absent
+authz-matrix:capture   -> MongooseServerSelectionError                                   = ESM-load OK, mongo absent
+ws-authz-matrix:capture-> ServerSelectionError                                            = ESM-load OK, mongo absent
+
+Note: a transient ERR_MODULE_NOT_FOUND can surface from the mongodb driver during
+connection-failure teardown in a no-mongo env; the deterministic terminal error is the
+mongoose ServerSelectionError. No script-level ESM defect. Same Crowi.setupDatabase path
+boots cleanly on real mongo (ci-app-launch-dev green on the merged commit).

--- a/.kiro/specs/esm-migration/phase3-gate-evidence/SANDBOX-STATUS.md
+++ b/.kiro/specs/esm-migration/phase3-gate-evidence/SANDBOX-STATUS.md
@@ -1,0 +1,72 @@
+# Phase 3 Gate (task 3.8) — execution status
+
+Branch: `claude/practical-volta-rrv5c8` (on `support/esm` after PR #11303 merge).
+Captured in the Claude Code **cloud sandbox**, which has **no MongoDB, no
+Elasticsearch, no Chromium**, and **different hardware** from the Phase 0.4/0.5
+baselines.
+
+Connectivity probe (this sandbox):
+
+```
+mongo:27017          ENOTFOUND
+127.0.0.1:27017      ECONNREFUSED
+localhost:27017      ECONNREFUSED
+elasticsearch:9200   ENOTFOUND
+```
+
+Task 3.8 mandates that **every** sub-gate run against the **production build
+output on a real MongoDB** (3.8.d also needs Chromium; 3.8.e needs the same
+host as the Phase 0.4/0.5 baselines). Therefore **3.8.b–3.8.e cannot be
+executed in this sandbox** and must run in the devcontainer (or CI). Per the
+spec's 迂回禁止 / Evidence-capture clauses, they remain **NOT DONE** — this file
+records only what was genuinely verifiable here, plus a ready-to-run handoff.
+
+## What was verified in the sandbox
+
+### 3.8.a basic quality gate — env-independent portions ✅
+- `turbo run build --filter @growi/app` → **21/21 success** (`3.8a-build-alone.txt`)
+- `turbo run lint --filter @growi/app` → **21/21 success** (`3.8a-lint-alone.txt`)
+- `lint:no-cjs` (import/no-commonjs equivalent on `src/server`) → **OK, 350 files** (`3.8a-nocjs-unit.txt`)
+- `vitest --project=app-unit` → **1951 passed / 8 skipped**; the single failing
+  file (`update-activity.spec.ts`) is the known mongodb-memory-server 403
+  download failure, a sandbox-only artifact — **green in CI**.
+- The `test` (integration) portion needs mongo+ES; it is **green on the merged
+  commit** via `ci-app-test` + `ci-app-test-integration` (PR #11303 run
+  `27462718877`, all jobs success).
+
+> Note: `turbo run build lint` **combined** in one invocation intermittently
+> fails locally with `TS2307: Cannot find module '@growi/logger'` — a turbo
+> task-orchestration race where `lint`'s dependency `dev` tasks rebuild a
+> dependency's `dist/` while `@growi/app:build` is reading it. Running them
+> **separately** (as CI does, in distinct jobs) is green. This is an
+> environmental orchestration artifact, not a code defect.
+
+### 3.8.c / 3.8.d capture-script ESM pre-flight ✅ (de-risks the devcontainer run)
+The three baseline/capture scripts were re-wired from ts-node to **tsx** in task
+3.7.b and had not been run since. Confirmed each **loads under tsx and reaches
+the mongo-connect point** (fails only with `MongooseServerSelectionError`), i.e.
+**no script-level ESM defect** — they are ready to run where mongo exists
+(`3.8cd-gatescript-esm-preflight.txt`).
+
+## What MUST run in the devcontainer (mongo + ES + Chromium) — NOT DONE
+
+Run from `apps/app/` against the **production build** unless noted.
+
+| Gate | Command(s) | Pass criterion |
+|---|---|---|
+| 3.8.b prod smoke | `pnpm run build` → assemble → `pnpm run server:ci`; then `node --import dotenv-flow/config.js dist/server/app.js` | exit 0; `/_api/v3/healthcheck`=200; 2 apiv3 endpoints expected status; SSR 200 of a page exercising drawio/LSX/footnote/math/mermaid/attachment-refs |
+| 3.8.c authz | `pnpm run snapshot-routes` then diff vs `route-middleware-baseline.json` (middleware names match, 0 anonymous); `pnpm run authz-matrix:verify` vs `authz-matrix-baseline.json` (all apiv3 × 4 persona statuses match) | zero diff |
+| 3.8.d WS | `curl -i -H 'Connection: Upgrade' -H 'Upgrade: websocket' .../socket.io/` → 101 or auth-4xx; Yjs 2-client Chromium sync < 2s; `pnpm run ws-authz-matrix:verify` vs `ws-authz-baseline.json` | zero diff; attach-before-listen log order |
+| 3.8.e perf | prod start wall time ×3 (median within ±20% of Phase 0.4); OTel p95 of 5 routes within ±25%; `pnpm dev` cold start ×3 (median within ±20% of Phase 0.5) | within gates; **must be the same host as the 0.4/0.5 baselines** |
+
+Evidence for each must be committed under this directory per the 3.8
+Evidence-capture clause.
+
+## Recommended path
+1. **3.8.b** can also be obtained on real infra by dispatching the production CI
+   (`reusable-app-prod.yml` / `test-prod-node24`: build-prod → `server:ci` →
+   check-next-symlinks → launch-prod + Playwright). This covers prod server:ci
+   smoke and part of E2E without a local devcontainer.
+2. **3.8.c / 3.8.d / 3.8.e** run in the devcontainer (the scripts are
+   pre-flighted ESM-ready above). 3.8.e specifically must use the Phase 0.4/0.5
+   baseline host for valid timing comparison.

--- a/.kiro/specs/esm-migration/tasks.md
+++ b/.kiro/specs/esm-migration/tasks.md
@@ -376,6 +376,15 @@ Phase 1 以降の検証に必要な比較基準と構造ガードを、移行前
 
 - [ ] 3.8 Phase 3 統合ゲート (MANDATORY — 迂回禁止)
 
+  > **サンドボックス実行状況 (2026-06-14, gate 未完)**: 本ゲートは全サブが本番出力 ×
+  > 実 MongoDB (3.8.d は Chromium、3.8.e は Phase 0.4/0.5 と同一ホスト) を要求するが、
+  > Claude Code クラウドサンドボックスには mongo/ES/Chromium が無いため **3.8.b〜3.8.e は
+  > 実行不可 = 未完**。env 非依存で実証できた範囲 (3.8.a の build/lint/no-cjs/unit green、
+  > および 3.8.c/3.8.d capture スクリプトが tsx で ESM ロード成立し mongo 接続地点まで到達
+  > = devcontainer 実行準備完了) と、devcontainer 向けの ready-to-run 手順を
+  > `.kiro/specs/esm-migration/phase3-gate-evidence/SANDBOX-STATUS.md` に記録。
+  > 残りは devcontainer / 本番 CI (`test-prod-node24` / reusable-app-prod) で実行すること。
+
   本ゲートは ESM 化の成否を決定する最重要検証であり、以下の項目すべてを **本番コンパイル出力** (`node --import dotenv-flow/config dist/server/app.js` ないし `pnpm run server:ci`) に対して実行する。`pnpm dev` (選定 TS ランナー経由) と Vitest と Node NodeNext は ESM 実装が異なるため、dev / test での pass は本ゲートの代替にはならない。
 
   **迂回禁止条項**: 下記 3.8.c (auth middleware snapshot diff) のいずれかの手順 — 特に `app._router.stack` の walk — が実装上の理由で失敗した場合、代替検証で代用したり「実害がなさそうだから」とスキップすることは **禁止** する。スクリプトが動作しないなら修正するまで Phase 4 には進まない。担当者はユーザーに対して明確に「ゲート 3.8.c を通過できないため Phase 4 に進めない」と報告し、対処方針の指示を仰ぐこと。これは他の 3.8.a / 3.8.b / 3.8.d / 3.8.e にも同様に適用される (Req 6.6 を厳格運用)。

--- a/apps/app/src/features/rate-limiter/middleware/consume-points.integ.ts
+++ b/apps/app/src/features/rate-limiter/middleware/consume-points.integ.ts
@@ -50,10 +50,12 @@ describe('consume-points.ts', async () => {
     const maxRequests = 500;
 
     await testRateLimitErrorWhenExceedingMaxRequests(method, key, maxRequests);
-    // 60s: this test issues `maxRequests + 1` (=501) sequential consumePoints
-    // round-trips to Mongo; the 5s default is inherently too tight and flakes
-    // under CI load (e.g. CPU contention while other workers run migrations).
-  }, 60_000);
+    // 10s (2x the 5s default): this test issues `maxRequests + 1` (=501)
+    // sequential consumePoints round-trips to Mongo. It passed at ~3s before
+    // the ESM runner switch; the regression is the dev runner's load cost, not
+    // this test (see esm-migration research.md §"dev runner bake-off"). Keep
+    // the bump modest — revert toward the default once the runner perf is fixed.
+  }, 10_000);
 
   it('Should trigger a rate limit error when maxRequest is exceeded (maxRequest: {random integer between 1 and 1000})', async () => {
     // setup
@@ -62,7 +64,7 @@ describe('consume-points.ts', async () => {
     const maxRequests = faker.number.int({ min: 1, max: 1000 });
 
     await testRateLimitErrorWhenExceedingMaxRequests(method, key, maxRequests);
-    // 60s: up to 1001 sequential consumePoints round-trips to Mongo — see the
+    // 10s (2x the 5s default): up to 1001 sequential round-trips — see the
     // maxRequest:500 case above.
-  }, 60_000);
+  }, 10_000);
 });

--- a/apps/app/src/features/rate-limiter/middleware/consume-points.integ.ts
+++ b/apps/app/src/features/rate-limiter/middleware/consume-points.integ.ts
@@ -50,7 +50,10 @@ describe('consume-points.ts', async () => {
     const maxRequests = 500;
 
     await testRateLimitErrorWhenExceedingMaxRequests(method, key, maxRequests);
-  });
+    // 60s: this test issues `maxRequests + 1` (=501) sequential consumePoints
+    // round-trips to Mongo; the 5s default is inherently too tight and flakes
+    // under CI load (e.g. CPU contention while other workers run migrations).
+  }, 60_000);
 
   it('Should trigger a rate limit error when maxRequest is exceeded (maxRequest: {random integer between 1 and 1000})', async () => {
     // setup
@@ -59,5 +62,7 @@ describe('consume-points.ts', async () => {
     const maxRequests = faker.number.int({ min: 1, max: 1000 });
 
     await testRateLimitErrorWhenExceedingMaxRequests(method, key, maxRequests);
-  });
+    // 60s: up to 1001 sequential consumePoints round-trips to Mongo — see the
+    // maxRequest:500 case above.
+  }, 60_000);
 });

--- a/apps/app/src/migrations/19700101000000-foremost-1000-20241123211930-remove-index-for-ns-from-configs.js
+++ b/apps/app/src/migrations/19700101000000-foremost-1000-20241123211930-remove-index-for-ns-from-configs.js
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:remove-index-for-ns-from-configs');
 
@@ -20,32 +20,30 @@ async function dropIndexIfExists(db, collectionName, indexName) {
   }
 }
 
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    // remove unnecessary data
-    // see: https://redmine.weseek.co.jp/issues/163527
-    await db.collection('configs').deleteMany({
-      ns: 'crowi',
-      key: {
-        $in: [
-          'notification:owner-page:isEnabled',
-          'notification:group-page:isEnabled',
-        ],
-      },
-    });
+  // remove unnecessary data
+  // see: https://redmine.weseek.co.jp/issues/163527
+  await db.collection('configs').deleteMany({
+    ns: 'crowi',
+    key: {
+      $in: [
+        'notification:owner-page:isEnabled',
+        'notification:group-page:isEnabled',
+      ],
+    },
+  });
 
-    // drop index
-    await dropIndexIfExists(db, 'configs', 'ns_1_key_1');
+  // drop index
+  await dropIndexIfExists(db, 'configs', 'ns_1_key_1');
 
-    // create index
-    const collection = await db.collection('configs');
-    await collection.createIndex({ key: 1 }, { unique: true });
-  },
+  // create index
+  const collection = await db.collection('configs');
+  await collection.createIndex({ key: 1 }, { unique: true });
+}
 
-  async down() {
-    // No rollback
-  },
-};
+export async function down() {
+  // No rollback
+}

--- a/apps/app/src/migrations/19700101000000-foremost-1010-20250109000000-generate-service-instance-id.js
+++ b/apps/app/src/migrations/19700101000000-foremost-1010-20250109000000-generate-service-instance-id.js
@@ -1,25 +1,23 @@
 import mongoose from 'mongoose';
 import { v4 as uuidv4 } from 'uuid';
 
-import { configManager } from '~/server/service/config-manager';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { configManager } from '~/server/service/config-manager/index.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:generate-service-instance-id');
 
-module.exports = {
-  async up(db) {
-    logger.info('Generate serviceInstanceId for the system');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Generate serviceInstanceId for the system');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    await configManager.loadConfigs();
+  await configManager.loadConfigs();
 
-    await configManager.updateConfig('app:serviceInstanceId', uuidv4(), {
-      skipPubsub: true,
-    });
-  },
+  await configManager.updateConfig('app:serviceInstanceId', uuidv4(), {
+    skipPubsub: true,
+  });
+}
 
-  async down() {
-    // No rollback
-  },
-};
+export async function down() {
+  // No rollback
+}

--- a/apps/app/src/migrations/20180926134048-make-email-unique.js
+++ b/apps/app/src/migrations/20180926134048-make-email-unique.js
@@ -1,45 +1,43 @@
 import mongoose from 'mongoose';
 
-import userModelFactory from '~/server/models/user';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import userModelFactory from '~/server/models/user/index.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:make-email-unique');
 
-module.exports = {
-  async up(db, next) {
-    logger.info('Start migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db, next) {
+  logger.info('Start migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const User = userModelFactory();
+  const User = userModelFactory();
 
-    // get all users who has 'deleted@deleted' email
-    const users = await User.find({ email: 'deleted@deleted' });
-    if (users.length > 0) {
-      logger.info(`${users.length} users found. Replace email...`, users);
-    }
+  // get all users who has 'deleted@deleted' email
+  const users = await User.find({ email: 'deleted@deleted' });
+  if (users.length > 0) {
+    logger.info(`${users.length} users found. Replace email...`, users);
+  }
 
-    // make email unique
-    const promises = users.map((user) => {
-      const now = new Date();
-      const deletedLabel = `deleted_at_${now.getTime()}`;
-      user.email = `${deletedLabel}@deleted`;
-      return user.save();
-    });
-    await Promise.all(promises);
+  // make email unique
+  const promises = users.map((user) => {
+    const now = new Date();
+    const deletedLabel = `deleted_at_${now.getTime()}`;
+    user.email = `${deletedLabel}@deleted`;
+    return user.save();
+  });
+  await Promise.all(promises);
 
-    // sync index
-    logger.info('Invoking syncIndexes');
-    await User.syncIndexes();
+  // sync index
+  logger.info('Invoking syncIndexes');
+  await User.syncIndexes();
 
-    await mongoose.disconnect();
+  await mongoose.disconnect();
 
-    logger.info('Migration has successfully terminated');
-    next();
-  },
+  logger.info('Migration has successfully terminated');
+  next();
+}
 
-  down(db, next) {
-    // do not rollback
-    next();
-  },
-};
+export function down(db, next) {
+  // do not rollback
+  next();
+}

--- a/apps/app/src/migrations/20180927102719-init-serverurl.js
+++ b/apps/app/src/migrations/20180927102719-init-serverurl.js
@@ -1,8 +1,8 @@
 import mongoose from 'mongoose';
 
-import { Config } from '~/server/models/config';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { Config } from '~/server/models/config.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:init-serverurl');
 
@@ -16,75 +16,73 @@ function isAllValuesSame(array) {
   });
 }
 
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    // find 'app:siteUrl'
-    const siteUrlConfig = await Config.findOne({
-      key: 'app:siteUrl',
-    });
-    // exit if exists
-    if (siteUrlConfig != null) {
-      logger.info(
-        "'app:siteUrl' is already exists. This migration terminates without any changes.",
-      );
-      return;
+  // find 'app:siteUrl'
+  const siteUrlConfig = await Config.findOne({
+    key: 'app:siteUrl',
+  });
+  // exit if exists
+  if (siteUrlConfig != null) {
+    logger.info(
+      "'app:siteUrl' is already exists. This migration terminates without any changes.",
+    );
+    return;
+  }
+
+  // find all callbackUrls
+  const configs = await Config.find({
+    $or: [
+      { key: 'security:passport-github:callbackUrl' },
+      { key: 'security:passport-google:callbackUrl' },
+      { key: 'security:passport-saml:callbackUrl' },
+    ],
+  });
+
+  // determine serverUrl
+  let siteUrl;
+  if (configs.length > 0) {
+    logger.info(`${configs.length} configs which has callbackUrl found: `);
+    logger.info(configs);
+
+    // extract domain
+    const siteUrls = configs
+      .map((config) => {
+        // see https://regex101.com/r/Q0Isjo/2
+        const match = config.value.match(/^"(https?:\/\/[^/]+).*"$/);
+        return match != null ? match[1] : null;
+      })
+      .filter((value) => {
+        return value != null;
+      });
+
+    // determine serverUrl if all values are same
+    if (siteUrls.length > 0 && isAllValuesSame(siteUrls)) {
+      siteUrl = siteUrls[0];
     }
+  }
 
-    // find all callbackUrls
-    const configs = await Config.find({
-      $or: [
-        { key: 'security:passport-github:callbackUrl' },
-        { key: 'security:passport-google:callbackUrl' },
-        { key: 'security:passport-saml:callbackUrl' },
-      ],
-    });
+  if (siteUrl != null) {
+    const key = 'app:siteUrl';
+    await Config.findOneAndUpdate(
+      { key },
+      { key, value: JSON.stringify(siteUrl) },
+      { upsert: true },
+    );
+    logger.info('Migration has successfully applied');
+  }
+}
 
-    // determine serverUrl
-    let siteUrl;
-    if (configs.length > 0) {
-      logger.info(`${configs.length} configs which has callbackUrl found: `);
-      logger.info(configs);
+export async function down(db) {
+  logger.info('Rollback migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-      // extract domain
-      const siteUrls = configs
-        .map((config) => {
-          // see https://regex101.com/r/Q0Isjo/2
-          const match = config.value.match(/^"(https?:\/\/[^/]+).*"$/);
-          return match != null ? match[1] : null;
-        })
-        .filter((value) => {
-          return value != null;
-        });
+  // remote 'app:siteUrl'
+  await Config.findOneAndDelete({
+    key: 'app:siteUrl',
+  });
 
-      // determine serverUrl if all values are same
-      if (siteUrls.length > 0 && isAllValuesSame(siteUrls)) {
-        siteUrl = siteUrls[0];
-      }
-    }
-
-    if (siteUrl != null) {
-      const key = 'app:siteUrl';
-      await Config.findOneAndUpdate(
-        { key },
-        { key, value: JSON.stringify(siteUrl) },
-        { upsert: true },
-      );
-      logger.info('Migration has successfully applied');
-    }
-  },
-
-  async down(db) {
-    logger.info('Rollback migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
-
-    // remote 'app:siteUrl'
-    await Config.findOneAndDelete({
-      key: 'app:siteUrl',
-    });
-
-    logger.info('Migration has been successfully rollbacked');
-  },
-};
+  logger.info('Migration has been successfully rollbacked');
+}

--- a/apps/app/src/migrations/20181019114028-abolish-page-group-relation.js
+++ b/apps/app/src/migrations/20181019114028-abolish-page-group-relation.js
@@ -1,9 +1,9 @@
 import mongoose from 'mongoose';
 
-import pageModelFactory from '~/server/models/page';
-import userGroupModelFactory from '~/server/models/user-group';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import pageModelFactory from '~/server/models/page.js';
+import userGroupModelFactory from '~/server/models/user-group.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:abolish-page-group-relation');
 
@@ -14,109 +14,93 @@ async function isCollectionExists(db, collectionName) {
   return collections.length > 0;
 }
 
-/**
- * BEFORE
- *   - 'pagegrouprelations' collection exists (related to models/page-group-relation.js)
- *     - schema:
- *       {
- *         "_id" : ObjectId("5bc9de4d745e137e0424ed89"),
- *         "targetPage" : ObjectId("5b028f13c1f7ba2e58d2fd21"),
- *         "relatedGroup" : ObjectId("5b07e6e6929bad5d3cce9995"),
- *         "__v" : 0
- *       }
- * AFTER
- *   - 'pagegrouprelations' collection is dropped and models/page-group-relation.js is removed
- *   - Page model has 'grantedGroup' field newly
- */
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const isPagegrouprelationsExists = await isCollectionExists(
-      db,
-      'pagegrouprelations',
-    );
-    if (!isPagegrouprelationsExists) {
-      logger.info("'pagegrouprelations' collection doesn't exist");
-      logger.info('Migration has successfully applied');
-      return;
-    }
-
-    const Page = pageModelFactory();
-    const UserGroup = userGroupModelFactory();
-
-    // retrieve all documents from 'pagegrouprelations'
-    const relations = await db
-      .collection('pagegrouprelations')
-      .find()
-      .toArray();
-
-    for (const relation of relations) {
-      // biome-ignore lint/performance/noAwaitInLoops: Allow for memory consumption control
-      const page = await Page.findOne({ _id: relation.targetPage });
-
-      // skip if grant mismatch
-      if (page.grant !== Page.GRANT_USER_GROUP) {
-        continue;
-      }
-
-      const userGroup = await UserGroup.findOne({ _id: relation.relatedGroup });
-
-      // skip if userGroup does not exist
-      if (userGroup == null) {
-        continue;
-      }
-
-      page.grantedGroup = userGroup;
-      await page.save();
-    }
-
-    // drop collection
-    await db.collection('pagegrouprelations').drop();
-
+  const isPagegrouprelationsExists = await isCollectionExists(
+    db,
+    'pagegrouprelations',
+  );
+  if (!isPagegrouprelationsExists) {
+    logger.info("'pagegrouprelations' collection doesn't exist");
     logger.info('Migration has successfully applied');
-  },
+    return;
+  }
 
-  async down(db) {
-    logger.info('Rollback migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+  const Page = pageModelFactory();
+  const UserGroup = userGroupModelFactory();
 
-    const Page = pageModelFactory();
-    const UserGroup = userGroupModelFactory();
+  // retrieve all documents from 'pagegrouprelations'
+  const relations = await db
+    .collection('pagegrouprelations')
+    .find()
+    .toArray();
 
-    // retrieve all Page documents which granted by UserGroup
-    const relatedPages = await Page.find({ grant: Page.GRANT_USER_GROUP });
-    const insertDocs = [];
-    for (const page of relatedPages) {
-      if (page.grantedGroup == null) {
-        continue;
-      }
+  for (const relation of relations) {
+    // biome-ignore lint/performance/noAwaitInLoops: Allow for memory consumption control
+    const page = await Page.findOne({ _id: relation.targetPage });
 
-      // biome-ignore lint/performance/noAwaitInLoops: Allow for memory consumption control
-      const userGroup = await UserGroup.findOne({ _id: page.grantedGroup });
-
-      // skip if userGroup does not exist
-      if (userGroup == null) {
-        continue;
-      }
-
-      // create a new document for 'pagegrouprelations' collection that is managed by mongoose
-      insertDocs.push({
-        targetPage: page._id,
-        relatedGroup: userGroup._id,
-        __v: 0,
-      });
-
-      // clear 'grantedGroup' field
-      page.grantedGroup = undefined;
-      await page.save();
+    // skip if grant mismatch
+    if (page.grant !== Page.GRANT_USER_GROUP) {
+      continue;
     }
 
-    if (insertDocs.length > 0) {
-      await db.collection('pagegrouprelations').insertMany(insertDocs);
+    const userGroup = await UserGroup.findOne({ _id: relation.relatedGroup });
+
+    // skip if userGroup does not exist
+    if (userGroup == null) {
+      continue;
     }
 
-    logger.info('Migration has been successfully rollbacked');
-  },
-};
+    page.grantedGroup = userGroup;
+    await page.save();
+  }
+
+  // drop collection
+  await db.collection('pagegrouprelations').drop();
+
+  logger.info('Migration has successfully applied');
+}
+
+export async function down(db) {
+  logger.info('Rollback migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
+
+  const Page = pageModelFactory();
+  const UserGroup = userGroupModelFactory();
+
+  // retrieve all Page documents which granted by UserGroup
+  const relatedPages = await Page.find({ grant: Page.GRANT_USER_GROUP });
+  const insertDocs = [];
+  for (const page of relatedPages) {
+    if (page.grantedGroup == null) {
+      continue;
+    }
+
+    // biome-ignore lint/performance/noAwaitInLoops: Allow for memory consumption control
+    const userGroup = await UserGroup.findOne({ _id: page.grantedGroup });
+
+    // skip if userGroup does not exist
+    if (userGroup == null) {
+      continue;
+    }
+
+    // create a new document for 'pagegrouprelations' collection that is managed by mongoose
+    insertDocs.push({
+      targetPage: page._id,
+      relatedGroup: userGroup._id,
+      __v: 0,
+    });
+
+    // clear 'grantedGroup' field
+    page.grantedGroup = undefined;
+    await page.save();
+  }
+
+  if (insertDocs.length > 0) {
+    await db.collection('pagegrouprelations').insertMany(insertDocs);
+  }
+
+  logger.info('Migration has been successfully rollbacked');
+}

--- a/apps/app/src/migrations/20190618055300-abolish-crowi-classic-auth.js
+++ b/apps/app/src/migrations/20190618055300-abolish-crowi-classic-auth.js
@@ -1,41 +1,39 @@
 import mongoose from 'mongoose';
 
-import { Config } from '~/server/models/config';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { Config } from '~/server/models/config.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:abolish-crowi-classic-auth');
 
-module.exports = {
-  async up(db, next) {
-    logger.info('Start migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db, next) {
+  logger.info('Start migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    // enable passport and delete configs for crowi classic auth
-    await Promise.all([
-      Config.findOneAndUpdate(
-        { key: 'security:isEnabledPassport' },
-        { key: 'security:isEnabledPassport', value: JSON.stringify(true) },
-        { upsert: true },
-      ),
-      Config.findOneAndUpdate(
-        { key: 'google:clientId' },
-        { key: 'google:clientId', value: JSON.stringify(null) },
-        { upsert: true },
-      ),
-      Config.findOneAndUpdate(
-        { key: 'google:clientSecret' },
-        { key: 'google:clientSecret', value: JSON.stringify(null) },
-        { upsert: true },
-      ),
-    ]);
+  // enable passport and delete configs for crowi classic auth
+  await Promise.all([
+    Config.findOneAndUpdate(
+      { key: 'security:isEnabledPassport' },
+      { key: 'security:isEnabledPassport', value: JSON.stringify(true) },
+      { upsert: true },
+    ),
+    Config.findOneAndUpdate(
+      { key: 'google:clientId' },
+      { key: 'google:clientId', value: JSON.stringify(null) },
+      { upsert: true },
+    ),
+    Config.findOneAndUpdate(
+      { key: 'google:clientSecret' },
+      { key: 'google:clientSecret', value: JSON.stringify(null) },
+      { upsert: true },
+    ),
+  ]);
 
-    logger.info('Migration has successfully terminated');
-    next();
-  },
+  logger.info('Migration has successfully terminated');
+  next();
+}
 
-  async down(db, next) {
-    // do not rollback
-    next();
-  },
-};
+export async function down(db, next) {
+  // do not rollback
+  next();
+}

--- a/apps/app/src/migrations/20190618104011-add-config-app-installed.js
+++ b/apps/app/src/migrations/20190618104011-add-config-app-installed.js
@@ -1,60 +1,50 @@
 import mongoose from 'mongoose';
 
-import { Config } from '~/server/models/config';
-import userModelFactory from '~/server/models/user';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { Config } from '~/server/models/config.js';
+import userModelFactory from '~/server/models/user/index.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:add-config-app-installed');
 
-/**
- * BEFORE
- *   - Config document { key: 'app:installed' } does not exist
- * AFTER
- *   - Config document { key: 'app:installed' } is created
- *     - value will be true if one or more users exist
- *     - value will be false if no users exist
- */
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const User = userModelFactory();
+  const User = userModelFactory();
 
-    // find 'app:installed'
-    const appInstalled = await Config.findOne({
+  // find 'app:installed'
+  const appInstalled = await Config.findOne({
+    key: 'app:installed',
+  });
+  // exit if exists
+  if (appInstalled != null) {
+    logger.info(
+      "'app:appInstalled' is already exists. This migration terminates without any changes.",
+    );
+    return;
+  }
+
+  const userCount = await User.count();
+
+  if (userCount > 0) {
+    await Config.create({
       key: 'app:installed',
+      value: true,
     });
-    // exit if exists
-    if (appInstalled != null) {
-      logger.info(
-        "'app:appInstalled' is already exists. This migration terminates without any changes.",
-      );
-      return;
-    }
+  }
 
-    const userCount = await User.count();
+  logger.info('Migration has successfully applied');
+}
 
-    if (userCount > 0) {
-      await Config.create({
-        key: 'app:installed',
-        value: true,
-      });
-    }
+export async function down(db) {
+  logger.info('Rollback migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    logger.info('Migration has successfully applied');
-  },
+  // remote 'app:siteUrl'
+  await Config.findOneAndDelete({
+    key: 'app:installed',
+  });
 
-  async down(db) {
-    logger.info('Rollback migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
-
-    // remote 'app:siteUrl'
-    await Config.findOneAndDelete({
-      key: 'app:installed',
-    });
-
-    logger.info('Migration has been successfully rollbacked');
-  },
-};
+  logger.info('Migration has been successfully rollbacked');
+}

--- a/apps/app/src/migrations/20190619055421-adjust-page-grant.js
+++ b/apps/app/src/migrations/20190619055421-adjust-page-grant.js
@@ -1,31 +1,29 @@
 import mongoose from 'mongoose';
 
-import getPageModel from '~/server/models/page';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import getPageModel from '~/server/models/page.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:adjust-page-grant');
 
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const Page = getPageModel();
+  const Page = getPageModel();
 
-    await Page.bulkWrite([
-      {
-        updateMany: {
-          filter: { grant: null },
-          update: { $set: { grant: Page.GRANT_PUBLIC } },
-        },
+  await Page.bulkWrite([
+    {
+      updateMany: {
+        filter: { grant: null },
+        update: { $set: { grant: Page.GRANT_PUBLIC } },
       },
-    ]);
+    },
+  ]);
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  down(db) {
-    // do not rollback
-  },
-};
+export function down(db) {
+  // do not rollback
+}

--- a/apps/app/src/migrations/20190624110950-fill-last-update-user.js
+++ b/apps/app/src/migrations/20190624110950-fill-last-update-user.js
@@ -1,49 +1,44 @@
 import mongoose from 'mongoose';
 
-import getPageModel from '~/server/models/page';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import getPageModel from '~/server/models/page.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:abolish-page-group-relation');
 
-/**
- * FIX https://github.com/growilabs/growi/issues/1067
- */
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const Page = getPageModel();
+  const Page = getPageModel();
 
-    // see https://stackoverflow.com/questions/3974985/update-mongodb-field-using-value-of-another-field/37280419#37280419
+  // see https://stackoverflow.com/questions/3974985/update-mongodb-field-using-value-of-another-field/37280419#37280419
 
-    // retrieve target data
-    const pages = await Page.find({
-      $or: [
-        { lastUpdateUser: { $exists: false } },
-        { lastUpdateUser: { $eq: null } },
-      ],
-    }).select('_id creator');
+  // retrieve target data
+  const pages = await Page.find({
+    $or: [
+      { lastUpdateUser: { $exists: false } },
+      { lastUpdateUser: { $eq: null } },
+    ],
+  }).select('_id creator');
 
-    // create requests for bulkWrite
-    const requests = pages.map((page) => {
-      return {
-        updateOne: {
-          filter: { _id: page._id },
-          update: { $set: { lastUpdateUser: page.creator } },
-        },
-      };
-    });
+  // create requests for bulkWrite
+  const requests = pages.map((page) => {
+    return {
+      updateOne: {
+        filter: { _id: page._id },
+        update: { $set: { lastUpdateUser: page.creator } },
+      },
+    };
+  });
 
-    if (requests.length > 0) {
-      await db.collection('pages').bulkWrite(requests);
-    }
+  if (requests.length > 0) {
+    await db.collection('pages').bulkWrite(requests);
+  }
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  down(db) {
-    // do not rollback
-  },
-};
+export function down(db) {
+  // do not rollback
+}

--- a/apps/app/src/migrations/20190629193445-make-root-page-public.js
+++ b/apps/app/src/migrations/20190629193445-make-root-page-public.js
@@ -1,31 +1,29 @@
 import mongoose from 'mongoose';
 
-import getPageModel from '~/server/models/page';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import getPageModel from '~/server/models/page.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:make-root-page-public');
 
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const Page = getPageModel();
+  const Page = getPageModel();
 
-    await Page.findOneAndUpdate(
-      { path: '/' },
-      {
-        grant: Page.GRANT_PUBLIC,
-        grantedUsers: [],
-        grantedGroup: null,
-      },
-    );
+  await Page.findOneAndUpdate(
+    { path: '/' },
+    {
+      grant: Page.GRANT_PUBLIC,
+      grantedUsers: [],
+      grantedGroup: null,
+    },
+  );
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  down(db) {
-    // do not rollback
-  },
-};
+export function down(db) {
+  // do not rollback
+}

--- a/apps/app/src/migrations/20191102223900-drop-configs-indices.js
+++ b/apps/app/src/migrations/20191102223900-drop-configs-indices.js
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:drop-configs-indices');
 
@@ -11,19 +11,17 @@ async function dropIndexIfExists(collection, indexName) {
   }
 }
 
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const collection = db.collection('configs');
-    await dropIndexIfExists(collection, 'ns_1');
-    await dropIndexIfExists(collection, 'key_1');
+  const collection = db.collection('configs');
+  await dropIndexIfExists(collection, 'ns_1');
+  await dropIndexIfExists(collection, 'key_1');
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  down(db) {
-    // do not rollback
-  },
-};
+export function down(db) {
+  // do not rollback
+}

--- a/apps/app/src/migrations/20191102223901-drop-pages-indices.js
+++ b/apps/app/src/migrations/20191102223901-drop-pages-indices.js
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:drop-pages-indices');
 
@@ -20,19 +20,17 @@ async function dropIndexIfExists(db, collectionName, indexName) {
   }
 }
 
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    await dropIndexIfExists(db, 'pages', 'lastUpdateUser_1');
-    await dropIndexIfExists(db, 'pages', 'liker_1');
-    await dropIndexIfExists(db, 'pages', 'seenUsers_1');
+  await dropIndexIfExists(db, 'pages', 'lastUpdateUser_1');
+  await dropIndexIfExists(db, 'pages', 'liker_1');
+  await dropIndexIfExists(db, 'pages', 'seenUsers_1');
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  down(db) {
-    // do not rollback
-  },
-};
+export function down(db) {
+  // do not rollback
+}

--- a/apps/app/src/migrations/20191126173016-adjust-pages-path.js
+++ b/apps/app/src/migrations/20191126173016-adjust-pages-path.js
@@ -1,41 +1,39 @@
 import { addHeadingSlash } from '@growi/core/dist/utils/path-utils';
 import mongoose from 'mongoose';
 
-import getPageModel from '~/server/models/page';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import getPageModel from '~/server/models/page.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:adjust-pages-path');
 
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const Page = getPageModel();
+  const Page = getPageModel();
 
-    // retrieve target data
-    const pages = await Page.find({ path: /^(?!\/)/ });
+  // retrieve target data
+  const pages = await Page.find({ path: /^(?!\/)/ });
 
-    // create requests for bulkWrite
-    const requests = pages.map((page) => {
-      const adjustedPath = addHeadingSlash(page.path);
-      return {
-        updateOne: {
-          filter: { _id: page._id },
-          update: { $set: { path: adjustedPath } },
-        },
-      };
-    });
+  // create requests for bulkWrite
+  const requests = pages.map((page) => {
+    const adjustedPath = addHeadingSlash(page.path);
+    return {
+      updateOne: {
+        filter: { _id: page._id },
+        update: { $set: { path: adjustedPath } },
+      },
+    };
+  });
 
-    if (requests.length > 0) {
-      await db.collection('pages').bulkWrite(requests);
-    }
+  if (requests.length > 0) {
+    await db.collection('pages').bulkWrite(requests);
+  }
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  down(db) {
-    // do not rollback
-  },
-};
+export function down(db) {
+  // do not rollback
+}

--- a/apps/app/src/migrations/20191127023815-drop-wrong-index-of-page-tag-relation.js
+++ b/apps/app/src/migrations/20191127023815-drop-wrong-index-of-page-tag-relation.js
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory(
   'growi:migrate:drop-wrong-index-of-page-tag-relation',
@@ -22,17 +22,15 @@ async function dropIndexIfExists(db, collectionName, indexName) {
   }
 }
 
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    await dropIndexIfExists(db, 'pagetagrelations', 'page_1_user_1');
+  await dropIndexIfExists(db, 'pagetagrelations', 'page_1_user_1');
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  down(db) {
-    // do not rollback
-  },
-};
+export function down(db) {
+  // do not rollback
+}

--- a/apps/app/src/migrations/20200402160380-remove-deleteduser-from-relationgroup.js
+++ b/apps/app/src/migrations/20200402160380-remove-deleteduser-from-relationgroup.js
@@ -1,34 +1,32 @@
 import mongoose from 'mongoose';
 
-import userModelFactory from '~/server/models/user';
-import UserGroupRelation from '~/server/models/user-group-relation';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import userModelFactory from '~/server/models/user/index.js';
+import UserGroupRelation from '~/server/models/user-group-relation.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory(
   'growi:migrate:remove-deleteduser-from-relationgroup',
 );
 
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const User = userModelFactory();
+  const User = userModelFactory();
 
-    const deletedUsers = await User.find({ status: 4 }); // deleted user
-    const requests = await UserGroupRelation.remove({
-      relatedUser: deletedUsers,
-    });
+  const deletedUsers = await User.find({ status: 4 }); // deleted user
+  const requests = await UserGroupRelation.remove({
+    relatedUser: deletedUsers,
+  });
 
-    if (requests.size === 0) {
-      return logger.info('This migration terminates without any changes.');
-    }
-    logger.info('Migration has successfully applied');
-  },
+  if (requests.size === 0) {
+    return logger.info('This migration terminates without any changes.');
+  }
+  logger.info('Migration has successfully applied');
+}
 
-  down(db, next) {
-    // do not rollback
-    next();
-  },
-};
+export function down(db, next) {
+  // do not rollback
+  next();
+}

--- a/apps/app/src/migrations/20200420160390-remove-crowi-layout.js
+++ b/apps/app/src/migrations/20200420160390-remove-crowi-layout.js
@@ -1,25 +1,23 @@
 import mongoose from 'mongoose';
 
-import { Config } from '~/server/models/config';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { Config } from '~/server/models/config.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:remove-crowi-lauout');
 
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const query = { key: 'customize:layout', value: JSON.stringify('crowi') };
+  const query = { key: 'customize:layout', value: JSON.stringify('crowi') };
 
-    await Config.findOneAndUpdate(query, { value: JSON.stringify('growi') }); // update layout
+  await Config.findOneAndUpdate(query, { value: JSON.stringify('growi') }); // update layout
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  down(db, next) {
-    // do not rollback
-    next();
-  },
-};
+export function down(db, next) {
+  // do not rollback
+  next();
+}

--- a/apps/app/src/migrations/20200512005851-remove-behavior-type.js
+++ b/apps/app/src/migrations/20200512005851-remove-behavior-type.js
@@ -1,33 +1,31 @@
 import mongoose from 'mongoose';
 
-import { Config } from '~/server/models/config';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { Config } from '~/server/models/config.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:remove-behavior-type');
 
-module.exports = {
-  async up(db, client) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db, client) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    await Config.findOneAndDelete({ key: 'customize:behavior' }); // remove behavior
+  await Config.findOneAndDelete({ key: 'customize:behavior' }); // remove behavior
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  async down(db, client) {
-    // do not rollback
-    logger.info('Rollback migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function down(db, client) {
+  // do not rollback
+  logger.info('Rollback migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const insertConfig = new Config({
-      key: 'customize:behavior',
-      value: JSON.stringify('growi'),
-    });
+  const insertConfig = new Config({
+    key: 'customize:behavior',
+    value: JSON.stringify('growi'),
+  });
 
-    await insertConfig.save();
+  await insertConfig.save();
 
-    logger.info('Migration has been successfully rollbacked');
-  },
-};
+  logger.info('Migration has been successfully rollbacked');
+}

--- a/apps/app/src/migrations/20200514001356-update-theme-color-for-dark.js
+++ b/apps/app/src/migrations/20200514001356-update-theme-color-for-dark.js
@@ -1,31 +1,29 @@
 import mongoose from 'mongoose';
 
-import { Config } from '~/server/models/config';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { Config } from '~/server/models/config.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:update-theme-color-for-dark');
 
-module.exports = {
-  async up(db, client) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db, client) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    await Promise.all([
-      await Config.findOneAndUpdate(
-        { key: 'customize:theme', value: JSON.stringify('default-dark') },
-        { value: JSON.stringify('default') },
-      ), // update default-dark
-      await Config.findOneAndUpdate(
-        { key: 'customize:theme', value: JSON.stringify('blue-night') },
-        { value: JSON.stringify('mono-blue') },
-      ), // update blue-night
-    ]);
+  await Promise.all([
+    await Config.findOneAndUpdate(
+      { key: 'customize:theme', value: JSON.stringify('default-dark') },
+      { value: JSON.stringify('default') },
+    ), // update default-dark
+    await Config.findOneAndUpdate(
+      { key: 'customize:theme', value: JSON.stringify('blue-night') },
+      { value: JSON.stringify('mono-blue') },
+    ), // update blue-night
+  ]);
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  async down(db, client) {
-    // do not rollback
-  },
-};
+export async function down(db, client) {
+  // do not rollback
+}

--- a/apps/app/src/migrations/20200620203632-normalize-locale-id.js
+++ b/apps/app/src/migrations/20200620203632-normalize-locale-id.js
@@ -1,41 +1,39 @@
 import mongoose from 'mongoose';
 
-import { Config } from '~/server/models/config';
-import userModelFactory from '~/server/models/user';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { Config } from '~/server/models/config.js';
+import userModelFactory from '~/server/models/user/index.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:normalize-locale-id');
 
-module.exports = {
-  async up(db, client) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db, client) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const User = userModelFactory();
+  const User = userModelFactory();
 
-    await Promise.all([
-      // update en-US -> en_US
-      Config.update(
-        { key: 'app:globalLang', value: JSON.stringify('en-US') },
-        { value: JSON.stringify('en_US') },
-      ),
-      // update ja -> ja_JP
-      Config.update(
-        { key: 'app:globalLang', value: JSON.stringify('ja') },
-        { value: JSON.stringify('ja_JP') },
-      ),
+  await Promise.all([
+    // update en-US -> en_US
+    Config.update(
+      { key: 'app:globalLang', value: JSON.stringify('en-US') },
+      { value: JSON.stringify('en_US') },
+    ),
+    // update ja -> ja_JP
+    Config.update(
+      { key: 'app:globalLang', value: JSON.stringify('ja') },
+      { value: JSON.stringify('ja_JP') },
+    ),
 
-      // update en-US -> en_US
-      User.updateMany({ lang: 'en-US' }, { lang: 'en_US' }),
-      // update ja -> ja_JP
-      User.updateMany({ lang: 'ja' }, { lang: 'ja_JP' }),
-    ]);
+    // update en-US -> en_US
+    User.updateMany({ lang: 'en-US' }, { lang: 'en_US' }),
+    // update ja -> ja_JP
+    User.updateMany({ lang: 'ja' }, { lang: 'ja_JP' }),
+  ]);
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  async down(db, client) {
-    // do not rollback
-  },
-};
+export async function down(db, client) {
+  // do not rollback
+}

--- a/apps/app/src/migrations/20200827045151-remove-layout-setting.js
+++ b/apps/app/src/migrations/20200827045151-remove-layout-setting.js
@@ -1,63 +1,61 @@
 import mongoose from 'mongoose';
 
-import { Config } from '~/server/models/config';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { Config } from '~/server/models/config.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:remove-layout-setting');
 
-module.exports = {
-  async up(db, client) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db, client) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const layoutType = await Config.findOne({ key: 'customize:layout' });
+  const layoutType = await Config.findOne({ key: 'customize:layout' });
 
-    if (layoutType == null) {
-      return;
-    }
+  if (layoutType == null) {
+    return;
+  }
 
-    const promise = [
-      // remove layout
-      Config.findOneAndDelete({ key: 'customize:layout' }),
-    ];
+  const promise = [
+    // remove layout
+    Config.findOneAndDelete({ key: 'customize:layout' }),
+  ];
 
-    if (layoutType.value === '"kibela"') {
-      promise.push(
-        Config.update(
-          { key: 'customize:theme' },
-          { value: JSON.stringify('kibela') },
-        ),
-      );
-    }
-
-    await Promise.all(promise);
-
-    logger.info('Migration has successfully applied');
-  },
-
-  async down(db, client) {
-    logger.info('Rollback migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
-
-    const theme = await Config.findOne({ key: 'customize:theme' });
-    const insertLayoutType = theme.value === '"kibela"' ? 'kibela' : 'growi';
-
-    const insertConfig = new Config({
-      key: 'customize:layout',
-      value: JSON.stringify(insertLayoutType),
-    });
-
-    const promise = [
-      insertConfig.save(),
+  if (layoutType.value === '"kibela"') {
+    promise.push(
       Config.update(
-        { key: 'customize:theme', value: JSON.stringify('kibela') },
-        { value: JSON.stringify('default') },
+        { key: 'customize:theme' },
+        { value: JSON.stringify('kibela') },
       ),
-    ];
+    );
+  }
 
-    await Promise.all(promise);
+  await Promise.all(promise);
 
-    logger.info('Migration has been successfully rollbacked');
-  },
-};
+  logger.info('Migration has successfully applied');
+}
+
+export async function down(db, client) {
+  logger.info('Rollback migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
+
+  const theme = await Config.findOne({ key: 'customize:theme' });
+  const insertLayoutType = theme.value === '"kibela"' ? 'kibela' : 'growi';
+
+  const insertConfig = new Config({
+    key: 'customize:layout',
+    value: JSON.stringify(insertLayoutType),
+  });
+
+  const promise = [
+    insertConfig.save(),
+    Config.update(
+      { key: 'customize:theme', value: JSON.stringify('kibela') },
+      { value: JSON.stringify('default') },
+    ),
+  ];
+
+  await Promise.all(promise);
+
+  logger.info('Migration has been successfully rollbacked');
+}

--- a/apps/app/src/migrations/20200828024025-copy-aws-setting.js
+++ b/apps/app/src/migrations/20200828024025-copy-aws-setting.js
@@ -1,64 +1,62 @@
 import mongoose from 'mongoose';
 
-import { Config } from '~/server/models/config';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { Config } from '~/server/models/config.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:remove-layout-setting');
 
-module.exports = {
-  async up(db, client) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db, client) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const [accessKeyId, secretAccessKey] = await Promise.all([
-      Config.findOne({ key: 'aws:accessKeyId' }),
-      Config.findOne({ key: 'aws:secretAccessKey' }),
-    ]);
+  const [accessKeyId, secretAccessKey] = await Promise.all([
+    Config.findOne({ key: 'aws:accessKeyId' }),
+    Config.findOne({ key: 'aws:secretAccessKey' }),
+  ]);
 
-    const request = [];
+  const request = [];
 
-    if (accessKeyId != null) {
-      if (accessKeyId.value != null) {
-        request.push({
-          insertOne: {
-            document: {
-              key: 'mail:sesAccessKeyId',
-              value: accessKeyId.value,
-            },
+  if (accessKeyId != null) {
+    if (accessKeyId.value != null) {
+      request.push({
+        insertOne: {
+          document: {
+            key: 'mail:sesAccessKeyId',
+            value: accessKeyId.value,
           },
-        });
-      }
+        },
+      });
     }
+  }
 
-    if (secretAccessKey != null) {
-      if (secretAccessKey.value != null) {
-        request.push({
-          insertOne: {
-            document: {
-              key: 'mail:sesSecretAccessKey',
-              value: secretAccessKey.value,
-            },
+  if (secretAccessKey != null) {
+    if (secretAccessKey.value != null) {
+      request.push({
+        insertOne: {
+          document: {
+            key: 'mail:sesSecretAccessKey',
+            value: secretAccessKey.value,
           },
-        });
-      }
+        },
+      });
     }
+  }
 
-    if (request.length > 0) {
-      await Config.bulkWrite(request);
-    }
+  if (request.length > 0) {
+    await Config.bulkWrite(request);
+  }
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  async down(db, client) {
-    logger.info('Rollback migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function down(db, client) {
+  logger.info('Rollback migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    await Config.deleteMany({
-      key: { $in: ['mail:sesAccessKeyId', 'mail:sesSecretAccessKey'] },
-    });
+  await Config.deleteMany({
+    key: { $in: ['mail:sesAccessKeyId', 'mail:sesSecretAccessKey'] },
+  });
 
-    logger.info('Migration has been successfully rollbacked');
-  },
-};
+  logger.info('Migration has been successfully rollbacked');
+}

--- a/apps/app/src/migrations/20200901034313-update-mail-transmission.js
+++ b/apps/app/src/migrations/20200901034313-update-mail-transmission.js
@@ -1,56 +1,54 @@
 import mongoose from 'mongoose';
 
-import { Config } from '~/server/models/config';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { Config } from '~/server/models/config.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:update-mail-transmission');
 
-module.exports = {
-  async up(db, client) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db, client) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const sesAccessKeyId = await Config.findOne({
-      key: 'mail:sesAccessKeyId',
-    });
-    const transmissionMethod = await Config.findOne({
-      key: 'mail:transmissionMethod',
-    });
+  const sesAccessKeyId = await Config.findOne({
+    key: 'mail:sesAccessKeyId',
+  });
+  const transmissionMethod = await Config.findOne({
+    key: 'mail:transmissionMethod',
+  });
 
-    if (sesAccessKeyId == null) {
-      return logger.info(
-        "The key 'mail:sesAccessKeyId' does not exist, value of transmission method will be set smtp automatically.",
-      );
-    }
-    if (transmissionMethod != null) {
-      return logger.info(
-        "The key 'mail:transmissionMethod' already exists, there is no need to migrate.",
-      );
-    }
+  if (sesAccessKeyId == null) {
+    return logger.info(
+      "The key 'mail:sesAccessKeyId' does not exist, value of transmission method will be set smtp automatically.",
+    );
+  }
+  if (transmissionMethod != null) {
+    return logger.info(
+      "The key 'mail:transmissionMethod' already exists, there is no need to migrate.",
+    );
+  }
 
-    const value =
-      sesAccessKeyId.value != null
-        ? JSON.stringify('ses')
-        : JSON.stringify('smtp');
+  const value =
+    sesAccessKeyId.value != null
+      ? JSON.stringify('ses')
+      : JSON.stringify('smtp');
 
-    await Config.create({
-      ns: 'crowi',
-      key: 'mail:transmissionMethod',
-      value,
-    });
-    logger.info('Migration has successfully applied');
-  },
+  await Config.create({
+    ns: 'crowi',
+    key: 'mail:transmissionMethod',
+    value,
+  });
+  logger.info('Migration has successfully applied');
+}
 
-  async down(db, client) {
-    logger.info('Rollback migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function down(db, client) {
+  logger.info('Rollback migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    // remote 'mail:transmissionMethod'
-    await Config.findOneAndDelete({
-      key: 'mail:transmissionMethod',
-    });
+  // remote 'mail:transmissionMethod'
+  await Config.findOneAndDelete({
+    key: 'mail:transmissionMethod',
+  });
 
-    logger.info('Migration has been successfully rollbacked');
-  },
-};
+  logger.info('Migration has been successfully rollbacked');
+}

--- a/apps/app/src/migrations/20200903080025-remove-timeline-type.js.js
+++ b/apps/app/src/migrations/20200903080025-remove-timeline-type.js.js
@@ -1,33 +1,31 @@
-import { Config } from '~/server/models/config';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { Config } from '~/server/models/config.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:remove-timeline-type');
 
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
 
-module.exports = {
-  async up(db, client) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db, client) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    await Config.findOneAndDelete({ key: 'customize:isEnabledTimeline' }); // remove timeline
+  await Config.findOneAndDelete({ key: 'customize:isEnabledTimeline' }); // remove timeline
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  async down(db, client) {
-    // do not rollback
-    logger.info('Rollback migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function down(db, client) {
+  // do not rollback
+  logger.info('Rollback migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const insertConfig = new Config({
-      key: 'customize:isEnabledTimeline',
-      value: true,
-    });
+  const insertConfig = new Config({
+    key: 'customize:isEnabledTimeline',
+    value: true,
+  });
 
-    await insertConfig.save();
+  await insertConfig.save();
 
-    logger.info('Migration has been successfully rollbacked');
-  },
-};
+  logger.info('Migration has been successfully rollbacked');
+}

--- a/apps/app/src/migrations/20200915035234-rename-s3-config.js
+++ b/apps/app/src/migrations/20200915035234-rename-s3-config.js
@@ -1,10 +1,10 @@
-import { Config } from '~/server/models/config';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { Config } from '~/server/models/config.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:remove-timeline-type');
 
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
 
 const awsConfigs = [
   {
@@ -29,40 +29,38 @@ const awsConfigs = [
   },
 ];
 
-module.exports = {
-  async up(db, client) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db, client) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const request = awsConfigs.map((awsConfig) => {
-      return {
-        updateOne: {
-          filter: { key: awsConfig.oldValue },
-          update: { key: awsConfig.newValue },
-        },
-      };
-    });
+  const request = awsConfigs.map((awsConfig) => {
+    return {
+      updateOne: {
+        filter: { key: awsConfig.oldValue },
+        update: { key: awsConfig.newValue },
+      },
+    };
+  });
 
-    await Config.bulkWrite(request);
+  await Config.bulkWrite(request);
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  async down(db, client) {
-    logger.info('Rollback migration');
+export async function down(db, client) {
+  logger.info('Rollback migration');
 
-    await mongoose.connect(getMongoUri(), mongoOptions);
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const request = awsConfigs.map((awsConfig) => {
-      return {
-        updateOne: {
-          filter: { key: awsConfig.newValue },
-          update: { key: awsConfig.oldValue },
-        },
-      };
-    });
+  const request = awsConfigs.map((awsConfig) => {
+    return {
+      updateOne: {
+        filter: { key: awsConfig.newValue },
+        update: { key: awsConfig.oldValue },
+      },
+    };
+  });
 
-    await Config.bulkWrite(request);
-    logger.info('Migration has been successfully rollbacked');
-  },
-};
+  await Config.bulkWrite(request);
+  logger.info('Migration has been successfully rollbacked');
+}

--- a/apps/app/src/migrations/20210420160380-convert-double-to-date.js
+++ b/apps/app/src/migrations/20210420160380-convert-double-to-date.js
@@ -1,43 +1,41 @@
 import mongoose from 'mongoose';
 
-import getPageModel from '~/server/models/page';
+import getPageModel from '~/server/models/page.js';
 import {
   getModelSafely,
   getMongoUri,
   mongoOptions,
-} from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+} from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:remove-crowi-lauout');
 
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const Page = getModelSafely('Page') || getPageModel();
+  const Page = getModelSafely('Page') || getPageModel();
 
-    const pages = await Page.find({ updatedAt: { $type: 'double' } });
+  const pages = await Page.find({ updatedAt: { $type: 'double' } });
 
-    if (pages.length === 0) {
-      return logger.info('The target page did not exist.');
-    }
+  if (pages.length === 0) {
+    return logger.info('The target page did not exist.');
+  }
 
-    const operations = pages.map((page) => {
-      return {
-        updateMany: {
-          filter: { _id: page._id },
-          update: { updatedAt: new Date(page.updatedAt) },
-        },
-      };
-    });
+  const operations = pages.map((page) => {
+    return {
+      updateMany: {
+        filter: { _id: page._id },
+        update: { updatedAt: new Date(page.updatedAt) },
+      },
+    };
+  });
 
-    await Page.bulkWrite(operations);
+  await Page.bulkWrite(operations);
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  down(db) {
-    // do not rollback
-  },
-};
+export function down(db) {
+  // do not rollback
+}

--- a/apps/app/src/migrations/20210830074539-update-configs-for-slackbot.js
+++ b/apps/app/src/migrations/20210830074539-update-configs-for-slackbot.js
@@ -1,8 +1,8 @@
 import mongoose from 'mongoose';
 
-import { Config } from '~/server/models/config';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { Config } from '~/server/models/config.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:update-configs-for-slackbot');
 
@@ -13,44 +13,42 @@ const keyMap = {
   'slackbot:signingSecret': 'slackbot:withoutProxy:signingSecret',
 };
 
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    for await (const [oldKey, newKey] of Object.entries(keyMap)) {
-      const isExist = (await Config.count({ key: newKey })) > 0;
+  for await (const [oldKey, newKey] of Object.entries(keyMap)) {
+    const isExist = (await Config.count({ key: newKey })) > 0;
 
-      // remove old key
-      if (isExist) {
-        await Config.findOneAndRemove({ key: oldKey });
-      }
-      // update with new key
-      else {
-        await Config.findOneAndUpdate({ key: oldKey }, { key: newKey });
-      }
+    // remove old key
+    if (isExist) {
+      await Config.findOneAndRemove({ key: oldKey });
     }
-
-    logger.info('Migration has successfully applied');
-  },
-
-  async down(db) {
-    logger.info('Rollback migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
-
-    for await (const [oldKey, newKey] of Object.entries(keyMap)) {
-      const isExist = (await Config.count({ key: oldKey })) > 0;
-
-      // remove new key
-      if (isExist) {
-        await Config.findOneAndRemove({ key: newKey });
-      }
-      // update with old key
-      else {
-        await Config.findOneAndUpdate({ key: newKey }, { key: oldKey });
-      }
+    // update with new key
+    else {
+      await Config.findOneAndUpdate({ key: oldKey }, { key: newKey });
     }
+  }
 
-    logger.info('Migration has successfully applied');
-  },
-};
+  logger.info('Migration has successfully applied');
+}
+
+export async function down(db) {
+  logger.info('Rollback migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
+
+  for await (const [oldKey, newKey] of Object.entries(keyMap)) {
+    const isExist = (await Config.count({ key: oldKey })) > 0;
+
+    // remove new key
+    if (isExist) {
+      await Config.findOneAndRemove({ key: newKey });
+    }
+    // update with old key
+    else {
+      await Config.findOneAndUpdate({ key: newKey }, { key: oldKey });
+    }
+  }
+
+  logger.info('Migration has successfully applied');
+}

--- a/apps/app/src/migrations/20210906194521-slack-app-integration-set-default-value.js
+++ b/apps/app/src/migrations/20210906194521-slack-app-integration-set-default-value.js
@@ -1,36 +1,34 @@
 import mongoose from 'mongoose';
 
-import slackAppIntegrationFactory from '~/server/models/slack-app-integration';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import slackAppIntegrationFactory from '~/server/models/slack-app-integration.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory(
   'growi:migrate:slack-app-integration-set-default-value',
 );
 
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const SlackAppIntegration = slackAppIntegrationFactory();
+  const SlackAppIntegration = slackAppIntegrationFactory();
 
-    // Add togetter command if supportedCommandsForBroadcastUse already exists
-    const slackAppIntegrations = await SlackAppIntegration.find();
-    slackAppIntegrations.forEach(async (doc) => {
-      if (
-        doc.supportedCommandsForSingleUse != null &&
-        !doc.supportedCommandsForSingleUse.includes('togetter')
-      ) {
-        doc.supportedCommandsForSingleUse.push('togetter');
-      }
-      await doc.save();
-    });
+  // Add togetter command if supportedCommandsForBroadcastUse already exists
+  const slackAppIntegrations = await SlackAppIntegration.find();
+  slackAppIntegrations.forEach(async (doc) => {
+    if (
+      doc.supportedCommandsForSingleUse != null &&
+      !doc.supportedCommandsForSingleUse.includes('togetter')
+    ) {
+      doc.supportedCommandsForSingleUse.push('togetter');
+    }
+    await doc.save();
+  });
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  async down() {
-    // no rollback
-  },
-};
+export async function down() {
+  // no rollback
+}

--- a/apps/app/src/migrations/20210913153942-migrate-slack-app-integration-schema.integ.ts
+++ b/apps/app/src/migrations/20210913153942-migrate-slack-app-integration-schema.integ.ts
@@ -7,11 +7,11 @@ describe('migrate-slack-app-integration-schema', () => {
   let migrate: any;
 
   beforeAll(async () => {
-    // Use dynamic import for ESM/CJS interop - Vitest handles the mixed syntax
+    // The migration module exposes named `up` / `down` ESM exports.
     const migrateModule = await import(
       './20210913153942-migrate-slack-app-integration-schema.js'
     );
-    migrate = migrateModule.default || migrateModule;
+    migrate = migrateModule;
     collection = mongoose.connection.collection('slackappintegrations');
 
     await collection.insertMany([

--- a/apps/app/src/migrations/20210913153942-migrate-slack-app-integration-schema.js
+++ b/apps/app/src/migrations/20210913153942-migrate-slack-app-integration-schema.js
@@ -4,9 +4,9 @@ import {
 } from '@growi/slack';
 import mongoose from 'mongoose';
 
-import slackAppIntegrationFactory from '~/server/models/slack-app-integration';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import slackAppIntegrationFactory from '~/server/models/slack-app-integration.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory(
   'growi:migrate:migrate-slack-app-integration-schema',
@@ -22,125 +22,123 @@ defaultSupportedCommandsNameForSingleUse.forEach((commandName) => {
   defaultDataForSingleUse[commandName] = false;
 });
 
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    // connect only if disconnected
-    // see: https://mongoosejs.com/docs/api/connection.html#connection_Connection-readyState
-    if (mongoose.connection.readyState === 0) {
-      await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Apply migration');
+  // connect only if disconnected
+  // see: https://mongoosejs.com/docs/api/connection.html#connection_Connection-readyState
+  if (mongoose.connection.readyState === 0) {
+    await mongoose.connect(getMongoUri(), mongoOptions);
+  }
+
+  const SlackAppIntegration = slackAppIntegrationFactory();
+
+  const slackAppIntegrations = await SlackAppIntegration.find();
+
+  if (slackAppIntegrations.length === 0) return;
+
+  // create operations
+  const operations = slackAppIntegrations.map((doc) => {
+    let copyForBroadcastUse = { ...defaultDataForBroadcastUse };
+    let copyForSingleUse = { ...defaultDataForSingleUse };
+    // when the document already has permissionsFor... colums
+    if (doc._doc.permissionsForBroadcastUseCommands != null) {
+      // merge
+      copyForBroadcastUse = {
+        ...defaultDataForBroadcastUse,
+        ...Object.fromEntries(doc._doc.permissionsForBroadcastUseCommands),
+      };
+      copyForSingleUse = {
+        ...defaultDataForSingleUse,
+        ...Object.fromEntries(doc._doc.permissionsForSingleUseCommands),
+      };
+    }
+    // when the document has supportedCommandsFor... columns
+    else if (doc._doc.supportedCommandsForBroadcastUse != null) {
+      // merge
+      doc._doc.supportedCommandsForBroadcastUse.forEach((commandName) => {
+        copyForBroadcastUse[commandName] = true;
+      });
+      doc._doc.supportedCommandsForSingleUse.forEach((commandName) => {
+        copyForSingleUse[commandName] = true;
+      });
+    }
+    // when the document does NOT have supportedCommandsFor... columns
+    else {
+      // turn on all
+      defaultSupportedCommandsNameForBroadcastUse.forEach((commandName) => {
+        copyForBroadcastUse[commandName] = true;
+      });
+      defaultSupportedCommandsNameForSingleUse.forEach((commandName) => {
+        copyForSingleUse[commandName] = true;
+      });
     }
 
-    const SlackAppIntegration = slackAppIntegrationFactory();
-
-    const slackAppIntegrations = await SlackAppIntegration.find();
-
-    if (slackAppIntegrations.length === 0) return;
-
-    // create operations
-    const operations = slackAppIntegrations.map((doc) => {
-      let copyForBroadcastUse = { ...defaultDataForBroadcastUse };
-      let copyForSingleUse = { ...defaultDataForSingleUse };
-      // when the document already has permissionsFor... colums
-      if (doc._doc.permissionsForBroadcastUseCommands != null) {
-        // merge
-        copyForBroadcastUse = {
-          ...defaultDataForBroadcastUse,
-          ...Object.fromEntries(doc._doc.permissionsForBroadcastUseCommands),
-        };
-        copyForSingleUse = {
-          ...defaultDataForSingleUse,
-          ...Object.fromEntries(doc._doc.permissionsForSingleUseCommands),
-        };
-      }
-      // when the document has supportedCommandsFor... columns
-      else if (doc._doc.supportedCommandsForBroadcastUse != null) {
-        // merge
-        doc._doc.supportedCommandsForBroadcastUse.forEach((commandName) => {
-          copyForBroadcastUse[commandName] = true;
-        });
-        doc._doc.supportedCommandsForSingleUse.forEach((commandName) => {
-          copyForSingleUse[commandName] = true;
-        });
-      }
-      // when the document does NOT have supportedCommandsFor... columns
-      else {
-        // turn on all
-        defaultSupportedCommandsNameForBroadcastUse.forEach((commandName) => {
-          copyForBroadcastUse[commandName] = true;
-        });
-        defaultSupportedCommandsNameForSingleUse.forEach((commandName) => {
-          copyForSingleUse[commandName] = true;
-        });
-      }
-
-      return {
-        updateOne: {
-          filter: { _id: doc._id },
-          update: {
-            $set: {
-              permissionsForBroadcastUseCommands: copyForBroadcastUse,
-              permissionsForSingleUseCommands: copyForSingleUse,
-            },
-            $unset: {
-              supportedCommandsForBroadcastUse: '',
-              supportedCommandsForSingleUse: '',
-            },
+    return {
+      updateOne: {
+        filter: { _id: doc._id },
+        update: {
+          $set: {
+            permissionsForBroadcastUseCommands: copyForBroadcastUse,
+            permissionsForSingleUseCommands: copyForSingleUse,
+          },
+          $unset: {
+            supportedCommandsForBroadcastUse: '',
+            supportedCommandsForSingleUse: '',
           },
         },
-      };
+      },
+    };
+  });
+
+  await db.collection('slackappintegrations').bulkWrite(operations);
+
+  logger.info('Migration has successfully applied');
+}
+
+export async function down(db, next) {
+  logger.info('Rollback migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
+
+  const SlackAppIntegration = slackAppIntegrationFactory();
+
+  const slackAppIntegrations = await SlackAppIntegration.find();
+
+  if (slackAppIntegrations.length === 0) return next();
+
+  // create operations
+  const operations = slackAppIntegrations.map((doc) => {
+    const dataForBroadcastUse = [];
+    const dataForSingleUse = [];
+    doc.permissionsForBroadcastUseCommands.forEach((value, commandName) => {
+      if (value === true) {
+        dataForBroadcastUse.push(commandName);
+      }
+    });
+    doc.permissionsForSingleUseCommands.forEach((value, commandName) => {
+      if (value === true) {
+        dataForSingleUse.push(commandName);
+      }
     });
 
-    await db.collection('slackappintegrations').bulkWrite(operations);
-
-    logger.info('Migration has successfully applied');
-  },
-
-  async down(db, next) {
-    logger.info('Rollback migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
-
-    const SlackAppIntegration = slackAppIntegrationFactory();
-
-    const slackAppIntegrations = await SlackAppIntegration.find();
-
-    if (slackAppIntegrations.length === 0) return next();
-
-    // create operations
-    const operations = slackAppIntegrations.map((doc) => {
-      const dataForBroadcastUse = [];
-      const dataForSingleUse = [];
-      doc.permissionsForBroadcastUseCommands.forEach((value, commandName) => {
-        if (value === true) {
-          dataForBroadcastUse.push(commandName);
-        }
-      });
-      doc.permissionsForSingleUseCommands.forEach((value, commandName) => {
-        if (value === true) {
-          dataForSingleUse.push(commandName);
-        }
-      });
-
-      return {
-        updateOne: {
-          filter: { _id: doc._id },
-          update: {
-            $set: {
-              supportedCommandsForBroadcastUse: dataForBroadcastUse,
-              supportedCommandsForSingleUse: dataForSingleUse,
-            },
-            $unset: {
-              permissionsForBroadcastUseCommands: '',
-              permissionsForSingleUseCommands: '',
-            },
+    return {
+      updateOne: {
+        filter: { _id: doc._id },
+        update: {
+          $set: {
+            supportedCommandsForBroadcastUse: dataForBroadcastUse,
+            supportedCommandsForSingleUse: dataForSingleUse,
+          },
+          $unset: {
+            permissionsForBroadcastUseCommands: '',
+            permissionsForSingleUseCommands: '',
           },
         },
-      };
-    });
+      },
+    };
+  });
 
-    await db.collection('slackappintegrations').bulkWrite(operations);
+  await db.collection('slackappintegrations').bulkWrite(operations);
 
-    next();
-    logger.info('Migration has successfully applied');
-  },
-};
+  next();
+  logger.info('Migration has successfully applied');
+}

--- a/apps/app/src/migrations/20210921173042-add-is-trashed-field.js
+++ b/apps/app/src/migrations/20210921173042-add-is-trashed-field.js
@@ -1,12 +1,12 @@
 import mongoose from 'mongoose';
 
-import getPageModel from '~/server/models/page';
+import getPageModel from '~/server/models/page.js';
 import {
   getModelSafely,
   getMongoUri,
   mongoOptions,
-} from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+} from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:add-column-is-trashed');
 
@@ -24,50 +24,48 @@ const updateIsPageTrashed = async (db, updateIdList) => {
     );
 };
 
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
-    const Page = getModelSafely('Page') || getPageModel();
+export async function up(db) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
+  const Page = getModelSafely('Page') || getPageModel();
 
-    let updateDeletedPageIds = [];
+  let updateDeletedPageIds = [];
 
-    // set isPageTrashed as false temporarily
+  // set isPageTrashed as false temporarily
+  await db
+    .collection('pagetagrelations')
+    .updateMany({}, { $set: { isPageTrashed: false } });
+
+  for await (const deletedPage of Page.find({ status: Page.STATUS_DELETED })
+    .select('_id')
+    .cursor()) {
+    updateDeletedPageIds.push(deletedPage._id);
+    // excute updateMany by one thousand ids
+    if (updateDeletedPageIds.length === LIMIT) {
+      await updateIsPageTrashed(db, updateDeletedPageIds);
+      updateDeletedPageIds = [];
+    }
+  }
+
+  // use ids that have not been updated
+  if (updateDeletedPageIds.length > 0) {
+    await updateIsPageTrashed(db, updateDeletedPageIds);
+  }
+
+  logger.info('Migration has successfully applied');
+}
+
+export async function down(db) {
+  logger.info('Rollback migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
+
+  try {
     await db
       .collection('pagetagrelations')
-      .updateMany({}, { $set: { isPageTrashed: false } });
-
-    for await (const deletedPage of Page.find({ status: Page.STATUS_DELETED })
-      .select('_id')
-      .cursor()) {
-      updateDeletedPageIds.push(deletedPage._id);
-      // excute updateMany by one thousand ids
-      if (updateDeletedPageIds.length === LIMIT) {
-        await updateIsPageTrashed(db, updateDeletedPageIds);
-        updateDeletedPageIds = [];
-      }
-    }
-
-    // use ids that have not been updated
-    if (updateDeletedPageIds.length > 0) {
-      await updateIsPageTrashed(db, updateDeletedPageIds);
-    }
-
-    logger.info('Migration has successfully applied');
-  },
-
-  async down(db) {
-    logger.info('Rollback migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
-
-    try {
-      await db
-        .collection('pagetagrelations')
-        .updateMany({}, { $unset: { isPageTrashed: '' } });
-      logger.info('Migration has been successfully rollbacked');
-    } catch (err) {
-      logger.error(err);
-      logger.info('Migration has failed');
-    }
-  },
-};
+      .updateMany({}, { $unset: { isPageTrashed: '' } });
+    logger.info('Migration has been successfully rollbacked');
+  } catch (err) {
+    logger.error(err);
+    logger.info('Migration has failed');
+  }
+}

--- a/apps/app/src/migrations/20211005120030-slack-app-integration-rename-keys.js
+++ b/apps/app/src/migrations/20211005120030-slack-app-integration-rename-keys.js
@@ -1,91 +1,89 @@
 import mongoose from 'mongoose';
 
-import slackAppIntegrationFactory from '~/server/models/slack-app-integration';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import slackAppIntegrationFactory from '~/server/models/slack-app-integration.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:slack-app-integration-rename-keys');
 
-module.exports = {
-  async up(db) {
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const SlackAppIntegration = slackAppIntegrationFactory();
+  const SlackAppIntegration = slackAppIntegrationFactory();
 
-    const slackAppIntegrations = await SlackAppIntegration.find();
+  const slackAppIntegrations = await SlackAppIntegration.find();
 
-    if (slackAppIntegrations.length === 0) return;
+  if (slackAppIntegrations.length === 0) return;
 
-    // create operations
-    const operations = slackAppIntegrations.map((doc) => {
-      const permissionsForSingleUseCommands =
-        doc._doc.permissionsForSingleUseCommands;
-      const createValue = permissionsForSingleUseCommands.get('create', false);
-      const togetterValue = permissionsForSingleUseCommands.get(
-        'togetter',
-        false,
-      );
+  // create operations
+  const operations = slackAppIntegrations.map((doc) => {
+    const permissionsForSingleUseCommands =
+      doc._doc.permissionsForSingleUseCommands;
+    const createValue = permissionsForSingleUseCommands.get('create', false);
+    const togetterValue = permissionsForSingleUseCommands.get(
+      'togetter',
+      false,
+    );
 
-      const newPermissionsForSingleUseCommands = {
-        note: createValue,
-        keep: togetterValue,
-      };
+    const newPermissionsForSingleUseCommands = {
+      note: createValue,
+      keep: togetterValue,
+    };
 
-      return {
-        updateOne: {
-          filter: { _id: doc._id },
-          update: {
-            $set: {
-              permissionsForSingleUseCommands:
-                newPermissionsForSingleUseCommands,
-            },
+    return {
+      updateOne: {
+        filter: { _id: doc._id },
+        update: {
+          $set: {
+            permissionsForSingleUseCommands:
+              newPermissionsForSingleUseCommands,
           },
         },
-      };
-    });
+      },
+    };
+  });
 
-    await db.collection('slackappintegrations').bulkWrite(operations);
+  await db.collection('slackappintegrations').bulkWrite(operations);
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  async down(db, next) {
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function down(db, next) {
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const SlackAppIntegration = slackAppIntegrationFactory();
+  const SlackAppIntegration = slackAppIntegrationFactory();
 
-    const slackAppIntegrations = await SlackAppIntegration.find();
+  const slackAppIntegrations = await SlackAppIntegration.find();
 
-    if (slackAppIntegrations.length === 0) return next();
+  if (slackAppIntegrations.length === 0) return next();
 
-    // create operations
-    const operations = slackAppIntegrations.map((doc) => {
-      const permissionsForSingleUseCommands =
-        doc._doc.permissionsForSingleUseCommands;
-      const noteValue = permissionsForSingleUseCommands.get('note', false);
-      const keepValue = permissionsForSingleUseCommands.get('keep', false);
+  // create operations
+  const operations = slackAppIntegrations.map((doc) => {
+    const permissionsForSingleUseCommands =
+      doc._doc.permissionsForSingleUseCommands;
+    const noteValue = permissionsForSingleUseCommands.get('note', false);
+    const keepValue = permissionsForSingleUseCommands.get('keep', false);
 
-      const newPermissionsForSingleUseCommands = {
-        create: noteValue,
-        togetter: keepValue,
-      };
+    const newPermissionsForSingleUseCommands = {
+      create: noteValue,
+      togetter: keepValue,
+    };
 
-      return {
-        updateOne: {
-          filter: { _id: doc._id },
-          update: {
-            $set: {
-              permissionsForSingleUseCommands:
-                newPermissionsForSingleUseCommands,
-            },
+    return {
+      updateOne: {
+        filter: { _id: doc._id },
+        update: {
+          $set: {
+            permissionsForSingleUseCommands:
+              newPermissionsForSingleUseCommands,
           },
         },
-      };
-    });
+      },
+    };
+  });
 
-    await db.collection('slackappintegrations').bulkWrite(operations);
+  await db.collection('slackappintegrations').bulkWrite(operations);
 
-    next();
-    logger.info('Migration rollback has successfully applied');
-  },
-};
+  next();
+  logger.info('Migration rollback has successfully applied');
+}

--- a/apps/app/src/migrations/20211005131430-config-without-proxy-command-permission-for-renaming.js
+++ b/apps/app/src/migrations/20211005131430-config-without-proxy-command-permission-for-renaming.js
@@ -1,112 +1,110 @@
 import mongoose from 'mongoose';
 
-import { Config } from '~/server/models/config';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { Config } from '~/server/models/config.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:slack-app-integration-rename-keys');
 
-module.exports = {
-  async up(db) {
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const isExist =
-      (await Config.count({ key: 'slackbot:withoutProxy:commandPermission' })) >
-      0;
-    if (!isExist) return;
+  const isExist =
+    (await Config.count({ key: 'slackbot:withoutProxy:commandPermission' })) >
+    0;
+  if (!isExist) return;
 
-    const commandPermissionValue = await Config.findOne({
-      key: 'slackbot:withoutProxy:commandPermission',
-    });
-    // do nothing if data is 'null' or null
-    if (
-      commandPermissionValue._doc.value === 'null' ||
-      commandPermissionValue._doc.value == null
-    )
-      return;
+  const commandPermissionValue = await Config.findOne({
+    key: 'slackbot:withoutProxy:commandPermission',
+  });
+  // do nothing if data is 'null' or null
+  if (
+    commandPermissionValue._doc.value === 'null' ||
+    commandPermissionValue._doc.value == null
+  )
+    return;
 
-    const commandPermission = JSON.parse(commandPermissionValue._doc.value);
+  const commandPermission = JSON.parse(commandPermissionValue._doc.value);
 
-    const newCommandPermission = {
-      note: false,
-      keep: false,
-    };
-    Object.entries(commandPermission).forEach((entry) => {
-      const [key, value] = entry;
-      switch (key) {
-        case 'create':
-          newCommandPermission.note = value;
-          break;
-        case 'togetter':
-          newCommandPermission.keep = value;
-          break;
-        default:
-          newCommandPermission[key] = value;
-          break;
-      }
-    });
+  const newCommandPermission = {
+    note: false,
+    keep: false,
+  };
+  Object.entries(commandPermission).forEach((entry) => {
+    const [key, value] = entry;
+    switch (key) {
+      case 'create':
+        newCommandPermission.note = value;
+        break;
+      case 'togetter':
+        newCommandPermission.keep = value;
+        break;
+      default:
+        newCommandPermission[key] = value;
+        break;
+    }
+  });
 
-    await Config.findOneAndUpdate(
-      { key: 'slackbot:withoutProxy:commandPermission' },
-      {
-        $set: {
-          value: JSON.stringify(newCommandPermission),
-        },
+  await Config.findOneAndUpdate(
+    { key: 'slackbot:withoutProxy:commandPermission' },
+    {
+      $set: {
+        value: JSON.stringify(newCommandPermission),
       },
-    );
+    },
+  );
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  async down(db, next) {
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function down(db, next) {
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const isExist =
-      (await Config.count({ key: 'slackbot:withoutProxy:commandPermission' })) >
-      0;
-    if (!isExist) return next();
+  const isExist =
+    (await Config.count({ key: 'slackbot:withoutProxy:commandPermission' })) >
+    0;
+  if (!isExist) return next();
 
-    const commandPermissionValue = await Config.findOne({
-      key: 'slackbot:withoutProxy:commandPermission',
-    });
-    // do nothing if data is 'null' or null
-    if (
-      commandPermissionValue._doc.value === 'null' ||
-      commandPermissionValue._doc.value == null
-    )
-      return next();
+  const commandPermissionValue = await Config.findOne({
+    key: 'slackbot:withoutProxy:commandPermission',
+  });
+  // do nothing if data is 'null' or null
+  if (
+    commandPermissionValue._doc.value === 'null' ||
+    commandPermissionValue._doc.value == null
+  )
+    return next();
 
-    const commandPermission = JSON.parse(commandPermissionValue._doc.value);
+  const commandPermission = JSON.parse(commandPermissionValue._doc.value);
 
-    const newCommandPermission = {
-      create: false,
-      togetter: false,
-    };
-    Object.entries(commandPermission).forEach((entry) => {
-      const [key, value] = entry;
-      switch (key) {
-        case 'note':
-          newCommandPermission.create = value;
-          break;
-        case 'keep':
-          newCommandPermission.togetter = value;
-          break;
-        default:
-          newCommandPermission[key] = value;
-          break;
-      }
-    });
+  const newCommandPermission = {
+    create: false,
+    togetter: false,
+  };
+  Object.entries(commandPermission).forEach((entry) => {
+    const [key, value] = entry;
+    switch (key) {
+      case 'note':
+        newCommandPermission.create = value;
+        break;
+      case 'keep':
+        newCommandPermission.togetter = value;
+        break;
+      default:
+        newCommandPermission[key] = value;
+        break;
+    }
+  });
 
-    await Config.findOneAndUpdate(
-      { key: 'slackbot:withoutProxy:commandPermission' },
-      {
-        $set: {
-          value: JSON.stringify(newCommandPermission),
-        },
+  await Config.findOneAndUpdate(
+    { key: 'slackbot:withoutProxy:commandPermission' },
+    {
+      $set: {
+        value: JSON.stringify(newCommandPermission),
       },
-    );
+    },
+  );
 
-    next();
-    logger.info('Migration rollback has successfully applied');
-  },
-};
+  next();
+  logger.info('Migration rollback has successfully applied');
+}

--- a/apps/app/src/migrations/20211129125654-initialize-private-legacy-pages-named-query.js
+++ b/apps/app/src/migrations/20211129125654-initialize-private-legacy-pages-named-query.js
@@ -1,57 +1,55 @@
 import mongoose from 'mongoose';
 
-import { SearchDelegatorName } from '~/interfaces/named-query';
-import NamedQuery from '~/server/models/named-query';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { SearchDelegatorName } from '~/interfaces/named-query.js';
+import NamedQuery from '~/server/models/named-query.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory(
   'growi:migrate:initialize-private-legacy-pages-named-query',
 );
 
-module.exports = {
-  async up(db, next) {
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db, next) {
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    try {
-      await NamedQuery.updateOne(
-        { name: SearchDelegatorName.PRIVATE_LEGACY_PAGES },
-        { delegatorName: SearchDelegatorName.PRIVATE_LEGACY_PAGES },
-        { upsert: true },
-      );
-    } catch (err) {
-      logger.error(
-        'Failed to migrate named query for private legacy pages search delagator.',
-        err,
-      );
-      throw err;
-    }
-
-    next();
-    logger.info(
-      'Successfully migrated named query for private legacy pages search delagator.',
+  try {
+    await NamedQuery.updateOne(
+      { name: SearchDelegatorName.PRIVATE_LEGACY_PAGES },
+      { delegatorName: SearchDelegatorName.PRIVATE_LEGACY_PAGES },
+      { upsert: true },
     );
-  },
-
-  async down(db, next) {
-    await mongoose.connect(getMongoUri(), mongoOptions);
-
-    try {
-      await NamedQuery.findOneAndDelete({
-        name: SearchDelegatorName.PRIVATE_LEGACY_PAGES,
-        delegatorName: SearchDelegatorName.PRIVATE_LEGACY_PAGES,
-      });
-    } catch (err) {
-      logger.error(
-        'Failed to delete named query for private legacy pages search delagator.',
-        err,
-      );
-      throw err;
-    }
-
-    next();
-    logger.info(
-      'Successfully deleted named query for private legacy pages search delagator.',
+  } catch (err) {
+    logger.error(
+      'Failed to migrate named query for private legacy pages search delagator.',
+      err,
     );
-  },
-};
+    throw err;
+  }
+
+  next();
+  logger.info(
+    'Successfully migrated named query for private legacy pages search delagator.',
+  );
+}
+
+export async function down(db, next) {
+  await mongoose.connect(getMongoUri(), mongoOptions);
+
+  try {
+    await NamedQuery.findOneAndDelete({
+      name: SearchDelegatorName.PRIVATE_LEGACY_PAGES,
+      delegatorName: SearchDelegatorName.PRIVATE_LEGACY_PAGES,
+    });
+  } catch (err) {
+    logger.error(
+      'Failed to delete named query for private legacy pages search delagator.',
+      err,
+    );
+    throw err;
+  }
+
+  next();
+  logger.info(
+    'Successfully deleted named query for private legacy pages search delagator.',
+  );
+}

--- a/apps/app/src/migrations/20211227060705-revision-path-to-page-id-schema-migration--fixed-8998.js
+++ b/apps/app/src/migrations/20211227060705-revision-path-to-page-id-schema-migration--fixed-8998.js
@@ -2,15 +2,15 @@ import { Writable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import mongoose from 'mongoose';
 
-import getPageModel from '~/server/models/page';
-import { Revision } from '~/server/models/revision';
-import { createBatchStream } from '~/server/util/batch-stream';
+import getPageModel from '~/server/models/page.js';
+import { Revision } from '~/server/models/revision.js';
+import { createBatchStream } from '~/server/util/batch-stream.js';
 import {
   getModelSafely,
   getMongoUri,
   mongoOptions,
-} from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+} from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory(
   'growi:migrate:revision-path-to-page-id-schema-migration--fixed-8998',
@@ -18,99 +18,92 @@ const logger = loggerFactory(
 
 const LIMIT = 300;
 
-/**
- * @see https://dev.growi.org/69301054963f68dfcf2b7111
- */
-module.exports = {
-  // path => pageId
-  async up(db, client) {
-    await mongoose.connect(getMongoUri(), mongoOptions);
-    const Page = getModelSafely('Page') || getPageModel();
+export async function up(db, client) {
+  await mongoose.connect(getMongoUri(), mongoOptions);
+  const Page = getModelSafely('Page') || getPageModel();
 
-    const pagesStream = await Page.find(
-      { revision: { $ne: null } },
-      { _id: 1, path: 1 },
-    ).cursor({ batch_size: LIMIT });
-    const batchStrem = createBatchStream(LIMIT);
+  const pagesStream = await Page.find(
+    { revision: { $ne: null } },
+    { _id: 1, path: 1 },
+  ).cursor({ batch_size: LIMIT });
+  const batchStrem = createBatchStream(LIMIT);
 
-    const migratePagesStream = new Writable({
-      objectMode: true,
-      async write(pages, _encoding, callback) {
-        const updateManyOperations = pages.map((page) => {
-          return {
-            updateMany: {
-              filter: {
-                $and: [{ path: page.path }, { pageId: { $exists: false } }],
-              },
-              update: [
-                {
-                  $unset: ['path'],
-                },
-                {
-                  $set: { pageId: page._id },
-                },
-              ],
+  const migratePagesStream = new Writable({
+    objectMode: true,
+    async write(pages, _encoding, callback) {
+      const updateManyOperations = pages.map((page) => {
+        return {
+          updateMany: {
+            filter: {
+              $and: [{ path: page.path }, { pageId: { $exists: false } }],
             },
-          };
-        });
-
-        await Revision.bulkWrite(updateManyOperations, { strict: false });
-
-        callback();
-      },
-      final(callback) {
-        callback();
-      },
-    });
-
-    await pipeline(pagesStream, batchStrem, migratePagesStream);
-
-    logger.info('Migration has successfully applied');
-  },
-
-  // pageId => path
-  async down(db, client) {
-    await mongoose.connect(getMongoUri(), mongoOptions);
-    const Page = getModelSafely('Page') || getPageModel();
-
-    const pagesStream = await Page.find(
-      { revision: { $ne: null } },
-      { _id: 1, path: 1 },
-    ).cursor({ batch_size: LIMIT });
-    const batchStrem = createBatchStream(LIMIT);
-
-    const migratePagesStream = new Writable({
-      objectMode: true,
-      async write(pages, _encoding, callback) {
-        const updateManyOperations = pages.map((page) => {
-          return {
-            updateMany: {
-              filter: {
-                $and: [{ pageId: page._id }, { path: { $exists: false } }],
+            update: [
+              {
+                $unset: ['path'],
               },
-              update: [
-                {
-                  $unset: ['pageId'],
-                },
-                {
-                  $set: { path: page.path },
-                },
-              ],
+              {
+                $set: { pageId: page._id },
+              },
+            ],
+          },
+        };
+      });
+
+      await Revision.bulkWrite(updateManyOperations, { strict: false });
+
+      callback();
+    },
+    final(callback) {
+      callback();
+    },
+  });
+
+  await pipeline(pagesStream, batchStrem, migratePagesStream);
+
+  logger.info('Migration has successfully applied');
+}
+
+export async function down(db, client) {
+  await mongoose.connect(getMongoUri(), mongoOptions);
+  const Page = getModelSafely('Page') || getPageModel();
+
+  const pagesStream = await Page.find(
+    { revision: { $ne: null } },
+    { _id: 1, path: 1 },
+  ).cursor({ batch_size: LIMIT });
+  const batchStrem = createBatchStream(LIMIT);
+
+  const migratePagesStream = new Writable({
+    objectMode: true,
+    async write(pages, _encoding, callback) {
+      const updateManyOperations = pages.map((page) => {
+        return {
+          updateMany: {
+            filter: {
+              $and: [{ pageId: page._id }, { path: { $exists: false } }],
             },
-          };
-        });
+            update: [
+              {
+                $unset: ['pageId'],
+              },
+              {
+                $set: { path: page.path },
+              },
+            ],
+          },
+        };
+      });
 
-        await Revision.bulkWrite(updateManyOperations, { strict: false });
+      await Revision.bulkWrite(updateManyOperations, { strict: false });
 
-        callback();
-      },
-      final(callback) {
-        callback();
-      },
-    });
+      callback();
+    },
+    final(callback) {
+      callback();
+    },
+  });
 
-    await pipeline(pagesStream, batchStrem, migratePagesStream);
+  await pipeline(pagesStream, batchStrem, migratePagesStream);
 
-    logger.info('Migration down has successfully applied');
-  },
-};
+  logger.info('Migration down has successfully applied');
+}

--- a/apps/app/src/migrations/20220131001218-convert-redirect-to-pages-to-page-redirect-documents.js
+++ b/apps/app/src/migrations/20220131001218-convert-redirect-to-pages-to-page-redirect-documents.js
@@ -1,13 +1,13 @@
 import mongoose from 'mongoose';
 
-import PageRedirectModel from '~/server/models/page-redirect';
-import { createBatchStream } from '~/server/util/batch-stream';
+import PageRedirectModel from '~/server/models/page-redirect.js';
+import { createBatchStream } from '~/server/util/batch-stream.js';
 import {
   getModelSafely,
   getMongoUri,
   mongoOptions,
-} from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+} from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory(
   'growi:migrate:convert-redirect-to-pages-to-page-redirect-documents',
@@ -15,79 +15,77 @@ const logger = loggerFactory(
 
 const BATCH_SIZE = 100;
 
-module.exports = {
-  async up(db, client) {
-    await mongoose.connect(getMongoUri(), mongoOptions);
-    const pageCollection = await db.collection('pages');
-    const PageRedirect = getModelSafely('PageRedirect') || PageRedirectModel;
+export async function up(db, client) {
+  await mongoose.connect(getMongoUri(), mongoOptions);
+  const pageCollection = await db.collection('pages');
+  const PageRedirect = getModelSafely('PageRedirect') || PageRedirectModel;
 
-    const cursor = pageCollection
-      .find(
-        { redirectTo: { $exists: true, $ne: null } },
-        { path: 1, redirectTo: 1, _id: 0 },
-      )
-      .stream();
-    const batchStream = createBatchStream(BATCH_SIZE);
+  const cursor = pageCollection
+    .find(
+      { redirectTo: { $exists: true, $ne: null } },
+      { path: 1, redirectTo: 1, _id: 0 },
+    )
+    .stream();
+  const batchStream = createBatchStream(BATCH_SIZE);
 
-    // redirectTo => PageRedirect
-    for await (const pages of cursor.pipe(batchStream)) {
-      const insertPageRedirectOperations = pages.map((page) => {
-        return {
-          insertOne: {
-            document: {
-              fromPath: page.path,
-              toPath: page.redirectTo,
-            },
+  // redirectTo => PageRedirect
+  for await (const pages of cursor.pipe(batchStream)) {
+    const insertPageRedirectOperations = pages.map((page) => {
+      return {
+        insertOne: {
+          document: {
+            fromPath: page.path,
+            toPath: page.redirectTo,
           },
-        };
-      });
+        },
+      };
+    });
 
-      try {
-        await PageRedirect.bulkWrite(insertPageRedirectOperations);
-      } catch (err) {
-        if (err.code !== 11000) {
-          throw Error(`Failed to migrate: ${err}`);
-        }
+    try {
+      await PageRedirect.bulkWrite(insertPageRedirectOperations);
+    } catch (err) {
+      if (err.code !== 11000) {
+        throw Error(`Failed to migrate: ${err}`);
       }
     }
+  }
 
-    await pageCollection.deleteMany({ redirectTo: { $ne: null } });
+  await pageCollection.deleteMany({ redirectTo: { $ne: null } });
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  async down(db, client) {
-    await mongoose.connect(getMongoUri(), mongoOptions);
-    const pageCollection = await db.collection('pages');
-    const PageRedirect = getModelSafely('PageRedirect') || PageRedirectModel;
+export async function down(db, client) {
+  await mongoose.connect(getMongoUri(), mongoOptions);
+  const pageCollection = await db.collection('pages');
+  const PageRedirect = getModelSafely('PageRedirect') || PageRedirectModel;
 
-    const cursor = PageRedirect.find().lean().cursor();
-    const batchStream = createBatchStream(BATCH_SIZE);
+  const cursor = PageRedirect.find().lean().cursor();
+  const batchStream = createBatchStream(BATCH_SIZE);
 
-    // PageRedirect => redirectTo
-    for await (const pageRedirects of cursor.pipe(batchStream)) {
-      const insertPageOperations = pageRedirects.map((pageRedirect) => {
-        return {
-          insertOne: {
-            document: {
-              path: pageRedirect.fromPath,
-              redirectTo: pageRedirect.toPath,
-            },
+  // PageRedirect => redirectTo
+  for await (const pageRedirects of cursor.pipe(batchStream)) {
+    const insertPageOperations = pageRedirects.map((pageRedirect) => {
+      return {
+        insertOne: {
+          document: {
+            path: pageRedirect.fromPath,
+            redirectTo: pageRedirect.toPath,
           },
-        };
-      });
+        },
+      };
+    });
 
-      try {
-        await pageCollection.bulkWrite(insertPageOperations);
-      } catch (err) {
-        if (err.code !== 11000) {
-          throw Error(`Failed to migrate: ${err}`);
-        }
+    try {
+      await pageCollection.bulkWrite(insertPageOperations);
+    } catch (err) {
+      if (err.code !== 11000) {
+        throw Error(`Failed to migrate: ${err}`);
       }
     }
+  }
 
-    await PageRedirect.deleteMany();
+  await PageRedirect.deleteMany();
 
-    logger.info('Migration down has successfully applied');
-  },
-};
+  logger.info('Migration down has successfully applied');
+}

--- a/apps/app/src/migrations/20220311011114-convert-page-delete-config.js
+++ b/apps/app/src/migrations/20220311011114-convert-page-delete-config.js
@@ -3,58 +3,56 @@ import mongoose from 'mongoose';
 import {
   PageRecursiveDeleteCompConfigValue,
   PageRecursiveDeleteConfigValue,
-} from '~/interfaces/page-delete-config';
-import { Config } from '~/server/models/config';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+} from '~/interfaces/page-delete-config.js';
+import { Config } from '~/server/models/config.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:convert-page-delete-config');
 
-module.exports = {
-  async up(db, client) {
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db, client) {
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const isNewConfigExists =
-      (await Config.count({
-        key: 'security:pageDeletionAuthority',
-      })) > 0;
+  const isNewConfigExists =
+    (await Config.count({
+      key: 'security:pageDeletionAuthority',
+    })) > 0;
 
-    if (isNewConfigExists) {
-      logger.info('This migration is skipped because new configs are existed.');
-      logger.info('Migration has successfully applied');
-      return;
-    }
-
-    const oldConfig = await Config.findOne({
-      key: 'security:pageCompleteDeletionAuthority',
-    });
-
-    const oldValue = oldConfig?.value ?? '"anyOne"';
-
-    try {
-      await Config.insertMany([
-        {
-          key: 'security:pageDeletionAuthority',
-          value: oldValue,
-        },
-        {
-          key: 'security:pageRecursiveDeletionAuthority',
-          value: `"${PageRecursiveDeleteConfigValue.Inherit}"`,
-        },
-        {
-          key: 'security:pageRecursiveCompleteDeletionAuthority',
-          value: `"${PageRecursiveDeleteCompConfigValue.Inherit}"`,
-        },
-      ]);
-    } catch (err) {
-      logger.error('Failed to migrate page delete configs', err);
-      throw err;
-    }
-
+  if (isNewConfigExists) {
+    logger.info('This migration is skipped because new configs are existed.');
     logger.info('Migration has successfully applied');
-  },
+    return;
+  }
 
-  async down(db, client) {
-    logger.info('Migration down has successfully applied');
-  },
-};
+  const oldConfig = await Config.findOne({
+    key: 'security:pageCompleteDeletionAuthority',
+  });
+
+  const oldValue = oldConfig?.value ?? '"anyOne"';
+
+  try {
+    await Config.insertMany([
+      {
+        key: 'security:pageDeletionAuthority',
+        value: oldValue,
+      },
+      {
+        key: 'security:pageRecursiveDeletionAuthority',
+        value: `"${PageRecursiveDeleteConfigValue.Inherit}"`,
+      },
+      {
+        key: 'security:pageRecursiveCompleteDeletionAuthority',
+        value: `"${PageRecursiveDeleteCompConfigValue.Inherit}"`,
+      },
+    ]);
+  } catch (err) {
+    logger.error('Failed to migrate page delete configs', err);
+    throw err;
+  }
+
+  logger.info('Migration has successfully applied');
+}
+
+export async function down(db, client) {
+  logger.info('Migration down has successfully applied');
+}

--- a/apps/app/src/migrations/20220411114257-set-sparse-option-to-slack-member-id.js
+++ b/apps/app/src/migrations/20220411114257-set-sparse-option-to-slack-member-id.js
@@ -1,28 +1,23 @@
 import mongoose from 'mongoose';
 
-import userModelFactory from '~/server/models/user';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import userModelFactory from '~/server/models/user/index.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory(
   'growi:migrate:set-sparse-option-to-slack-member-id',
 );
 
-/**
- * set sparse option to slackMemberId
- */
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const User = userModelFactory();
-    await User.syncIndexes();
+  const User = userModelFactory();
+  await User.syncIndexes();
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  down(db) {
-    // do not rollback
-  },
-};
+export function down(db) {
+  // do not rollback
+}

--- a/apps/app/src/migrations/20220613064207-add-attachment-type-to-existing-attachments.js
+++ b/apps/app/src/migrations/20220613064207-add-attachment-type-to-existing-attachments.js
@@ -1,45 +1,43 @@
 import mongoose from 'mongoose';
 
-import { AttachmentType } from '~/server/interfaces/attachment';
-import { Attachment } from '~/server/models/attachment';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { AttachmentType } from '~/server/interfaces/attachment.js';
+import { Attachment } from '~/server/models/attachment.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory(
   'growi:migrate:add-attachment-type-to-existing-attachments',
 );
 
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    // Add attachmentType for wiki page
-    // Filter pages where "attachmentType" doesn't exist and "page" is not null
-    const operationsForWikiPage = {
-      updateMany: {
-        filter: { page: { $ne: null }, attachmentType: { $exists: false } },
-        update: { $set: { attachmentType: AttachmentType.WIKI_PAGE } },
-      },
-    };
+  // Add attachmentType for wiki page
+  // Filter pages where "attachmentType" doesn't exist and "page" is not null
+  const operationsForWikiPage = {
+    updateMany: {
+      filter: { page: { $ne: null }, attachmentType: { $exists: false } },
+      update: { $set: { attachmentType: AttachmentType.WIKI_PAGE } },
+    },
+  };
 
-    // Add attachmentType for profile image
-    // Filter pages where "attachmentType" doesn't exist and "page" is null
-    const operationsForProfileImage = {
-      updateMany: {
-        filter: { page: { $eq: null }, attachmentType: { $exists: false } },
-        update: { $set: { attachmentType: AttachmentType.PROFILE_IMAGE } },
-      },
-    };
-    await Attachment.bulkWrite([
-      operationsForWikiPage,
-      operationsForProfileImage,
-    ]);
+  // Add attachmentType for profile image
+  // Filter pages where "attachmentType" doesn't exist and "page" is null
+  const operationsForProfileImage = {
+    updateMany: {
+      filter: { page: { $eq: null }, attachmentType: { $exists: false } },
+      update: { $set: { attachmentType: AttachmentType.PROFILE_IMAGE } },
+    },
+  };
+  await Attachment.bulkWrite([
+    operationsForWikiPage,
+    operationsForProfileImage,
+  ]);
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  async down(db) {
-    // No rollback
-  },
-};
+export async function down(db) {
+  // No rollback
+}

--- a/apps/app/src/migrations/20221014130200-remove-customize-is-saved-states-of-tab-changes.js
+++ b/apps/app/src/migrations/20221014130200-remove-customize-is-saved-states-of-tab-changes.js
@@ -1,34 +1,32 @@
-import { Config } from '~/server/models/config';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { Config } from '~/server/models/config.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:remove-isSavedStatesOfTabChanges');
 
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
 
-module.exports = {
-  async up() {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up() {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    await Config.findOneAndDelete({
-      key: 'customize:isSavedStatesOfTabChanges',
-    }); // remove isSavedStatesOfTabChanges
+  await Config.findOneAndDelete({
+    key: 'customize:isSavedStatesOfTabChanges',
+  }); // remove isSavedStatesOfTabChanges
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  async down() {
-    logger.info('Rollback migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function down() {
+  logger.info('Rollback migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const insertConfig = new Config({
-      key: 'customize:isSavedStatesOfTabChanges',
-      value: false,
-    });
+  const insertConfig = new Config({
+    key: 'customize:isSavedStatesOfTabChanges',
+    value: false,
+  });
 
-    await insertConfig.save();
+  await insertConfig.save();
 
-    logger.info('Migration has been successfully rollbacked');
-  },
-};
+  logger.info('Migration has been successfully rollbacked');
+}

--- a/apps/app/src/migrations/20221219011829-remove-basic-auth-related-config.js
+++ b/apps/app/src/migrations/20221219011829-remove-basic-auth-related-config.js
@@ -1,25 +1,23 @@
-import { Config } from '~/server/models/config';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { Config } from '~/server/models/config.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:remove-basic-auth-related-config');
 
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
 
-module.exports = {
-  async up() {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up() {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    await Config.findOneAndDelete({ key: 'security:passport-basic:isEnabled' });
-    await Config.findOneAndDelete({
-      key: 'security:passport-basic:isSameUsernameTreatedAsIdenticalUser',
-    });
+  await Config.findOneAndDelete({ key: 'security:passport-basic:isEnabled' });
+  await Config.findOneAndDelete({
+    key: 'security:passport-basic:isSameUsernameTreatedAsIdenticalUser',
+  });
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  async down() {
-    // No rollback
-  },
-};
+export async function down() {
+  // No rollback
+}

--- a/apps/app/src/migrations/20230213090921-remove-presentation-configurations.js
+++ b/apps/app/src/migrations/20230213090921-remove-presentation-configurations.js
@@ -1,39 +1,37 @@
-import { Config } from '~/server/models/config';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { Config } from '~/server/models/config.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory(
   'growi:migrate:remove-presentation-configurations',
 );
 
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
 
-module.exports = {
-  async up() {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up() {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    await Config.findOneAndDelete({
-      key: 'markdown:presentation:pageBreakSeparator',
-    });
-    await Config.findOneAndDelete({
-      key: 'markdown:presentation:pageBreakCustomSeparator',
-    });
+  await Config.findOneAndDelete({
+    key: 'markdown:presentation:pageBreakSeparator',
+  });
+  await Config.findOneAndDelete({
+    key: 'markdown:presentation:pageBreakCustomSeparator',
+  });
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  async down() {
-    logger.info('Rollback migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function down() {
+  logger.info('Rollback migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const insertConfig = new Config({
-      key: 'markdown:presentation:pageBreakSeparator',
-      value: 2,
-    });
+  const insertConfig = new Config({
+    key: 'markdown:presentation:pageBreakSeparator',
+    value: 2,
+  });
 
-    await insertConfig.save();
+  await insertConfig.save();
 
-    logger.info('Migration has been successfully rollbacked');
-  },
-};
+  logger.info('Migration has been successfully rollbacked');
+}

--- a/apps/app/src/migrations/20230723061824-granted-group-to-array-of-objects.js
+++ b/apps/app/src/migrations/20230723061824-granted-group-to-array-of-objects.js
@@ -1,169 +1,167 @@
-import loggerFactory from '~/utils/logger';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:granted-group-to-array-of-objects');
 
-module.exports = {
-  async up(db, client) {
-    logger.info('Apply migration');
+export async function up(db, client) {
+  logger.info('Apply migration');
 
-    const pageCollection = await db.collection('pages');
-    const pageOperationCollection = await db.collection('pageoperations');
-    // Convert grantedGroup to array
-    // Set the model type of grantedGroup to UserGroup for Pages that were created before ExternalUserGroup was introduced
-    await pageCollection.updateMany({ grantedGroup: { $ne: null } }, [
+  const pageCollection = await db.collection('pages');
+  const pageOperationCollection = await db.collection('pageoperations');
+  // Convert grantedGroup to array
+  // Set the model type of grantedGroup to UserGroup for Pages that were created before ExternalUserGroup was introduced
+  await pageCollection.updateMany({ grantedGroup: { $ne: null } }, [
+    {
+      $set: {
+        grantedGroup: [
+          {
+            type: 'UserGroup',
+            item: '$grantedGroup',
+          },
+        ],
+      },
+    },
+  ]);
+
+  await pageOperationCollection.updateMany(
+    { 'options.grantUserGroupId': { $ne: null } },
+    [
       {
         $set: {
-          grantedGroup: [
+          'options.grantUserGroupId': [
             {
               type: 'UserGroup',
-              item: '$grantedGroup',
+              item: '$options.grantUserGroupId',
             },
           ],
         },
       },
-    ]);
+    ],
+  );
 
-    await pageOperationCollection.updateMany(
-      { 'options.grantUserGroupId': { $ne: null } },
-      [
-        {
-          $set: {
-            'options.grantUserGroupId': [
-              {
-                type: 'UserGroup',
-                item: '$options.grantUserGroupId',
-              },
-            ],
-          },
-        },
-      ],
-    );
-
-    await pageOperationCollection.updateMany(
-      { 'page.grantedGroup': { $ne: null } },
-      [
-        {
-          $set: {
-            'page.grantedGroup': [
-              {
-                type: 'UserGroup',
-                item: '$page.grantedGroup',
-              },
-            ],
-          },
-        },
-      ],
-    );
-
-    await pageOperationCollection.updateMany(
-      { 'exPage.grantedGroup': { $ne: null } },
-      [
-        {
-          $set: {
-            'exPage.grantedGroup': [
-              {
-                type: 'UserGroup',
-                item: '$exPage.grantedGroup',
-              },
-            ],
-          },
-        },
-      ],
-    );
-
-    // rename fields
-    await pageCollection.updateMany(
-      {},
-      {
-        $rename: {
-          grantedGroup: 'grantedGroups',
-        },
-      },
-    );
-    await pageOperationCollection.updateMany(
-      {},
-      {
-        $rename: {
-          'options.grantUserGroupId': 'options.grantUserGroupIds',
-          'page.grantedGroup': 'page.grantedGroups',
-          'exPage.grantedGroup': 'exPage.grantedGroups',
-        },
-      },
-    );
-
-    logger.info('Migration has successfully applied');
-  },
-
-  async down(db, client) {
-    logger.info('Rollback migration');
-
-    const pageCollection = await db.collection('pages');
-    const pageOperationCollection = await db.collection('pageoperations');
-
-    await pageCollection.updateMany({ grantedGroups: { $exists: true } }, [
+  await pageOperationCollection.updateMany(
+    { 'page.grantedGroup': { $ne: null } },
+    [
       {
         $set: {
-          grantedGroups: { $arrayElemAt: ['$grantedGroups.item', 0] },
+          'page.grantedGroup': [
+            {
+              type: 'UserGroup',
+              item: '$page.grantedGroup',
+            },
+          ],
         },
       },
-    ]);
-    await pageOperationCollection.updateMany(
-      { 'options.grantUserGroupIds': { $exists: true } },
-      [
-        {
-          $set: {
-            'options.grantUserGroupIds': {
-              $arrayElemAt: ['options.grantUserGroupIds.item', 0],
-            },
-          },
-        },
-      ],
-    );
-    await pageOperationCollection.updateMany(
-      { 'page.grantedGroups': { $exists: true } },
-      [
-        {
-          $set: {
-            'page.grantedGroups': {
-              $arrayElemAt: ['page.grantedGroups.item', 0],
-            },
-          },
-        },
-      ],
-    );
-    await pageOperationCollection.updateMany(
-      { 'exPage.grantedGroups': { $exists: true } },
-      [
-        {
-          $set: {
-            'exPage.grantedGroups': {
-              $arrayElemAt: ['exPage.grantedGroups.item', 0],
-            },
-          },
-        },
-      ],
-    );
+    ],
+  );
 
-    // rename fields
-    await pageCollection.updateMany(
-      { grantedGroups: { $exists: true } },
+  await pageOperationCollection.updateMany(
+    { 'exPage.grantedGroup': { $ne: null } },
+    [
       {
-        $rename: {
-          grantedGroups: 'grantedGroup',
+        $set: {
+          'exPage.grantedGroup': [
+            {
+              type: 'UserGroup',
+              item: '$exPage.grantedGroup',
+            },
+          ],
         },
       },
-    );
-    await pageOperationCollection.updateMany(
-      {},
-      {
-        $rename: {
-          'options.grantUserGroupIds': 'options.grantUserGroupId',
-          'page.grantedGroups': 'page.grantedGroup',
-          'exPage.grantedGroups': 'exPage.grantedGroup',
-        },
-      },
-    );
+    ],
+  );
 
-    logger.info('Migration has been successfully rollbacked');
-  },
-};
+  // rename fields
+  await pageCollection.updateMany(
+    {},
+    {
+      $rename: {
+        grantedGroup: 'grantedGroups',
+      },
+    },
+  );
+  await pageOperationCollection.updateMany(
+    {},
+    {
+      $rename: {
+        'options.grantUserGroupId': 'options.grantUserGroupIds',
+        'page.grantedGroup': 'page.grantedGroups',
+        'exPage.grantedGroup': 'exPage.grantedGroups',
+      },
+    },
+  );
+
+  logger.info('Migration has successfully applied');
+}
+
+export async function down(db, client) {
+  logger.info('Rollback migration');
+
+  const pageCollection = await db.collection('pages');
+  const pageOperationCollection = await db.collection('pageoperations');
+
+  await pageCollection.updateMany({ grantedGroups: { $exists: true } }, [
+    {
+      $set: {
+        grantedGroups: { $arrayElemAt: ['$grantedGroups.item', 0] },
+      },
+    },
+  ]);
+  await pageOperationCollection.updateMany(
+    { 'options.grantUserGroupIds': { $exists: true } },
+    [
+      {
+        $set: {
+          'options.grantUserGroupIds': {
+            $arrayElemAt: ['options.grantUserGroupIds.item', 0],
+          },
+        },
+      },
+    ],
+  );
+  await pageOperationCollection.updateMany(
+    { 'page.grantedGroups': { $exists: true } },
+    [
+      {
+        $set: {
+          'page.grantedGroups': {
+            $arrayElemAt: ['page.grantedGroups.item', 0],
+          },
+        },
+      },
+    ],
+  );
+  await pageOperationCollection.updateMany(
+    { 'exPage.grantedGroups': { $exists: true } },
+    [
+      {
+        $set: {
+          'exPage.grantedGroups': {
+            $arrayElemAt: ['exPage.grantedGroups.item', 0],
+          },
+        },
+      },
+    ],
+  );
+
+  // rename fields
+  await pageCollection.updateMany(
+    { grantedGroups: { $exists: true } },
+    {
+      $rename: {
+        grantedGroups: 'grantedGroup',
+      },
+    },
+  );
+  await pageOperationCollection.updateMany(
+    {},
+    {
+      $rename: {
+        'options.grantUserGroupIds': 'options.grantUserGroupId',
+        'page.grantedGroups': 'page.grantedGroup',
+        'exPage.grantedGroups': 'exPage.grantedGroup',
+      },
+    },
+  );
+
+  logger.info('Migration has been successfully rollbacked');
+}

--- a/apps/app/src/migrations/20230731075753-add_installed_date_to_config.js
+++ b/apps/app/src/migrations/20230731075753-add_installed_date_to_config.js
@@ -1,62 +1,60 @@
-import { Config } from '~/server/models/config';
-import userModelFactory from '~/server/models/user';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { Config } from '~/server/models/config.js';
+import userModelFactory from '~/server/models/user/index.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:add-installed-date-to-config');
 
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
 
-module.exports = {
-  async up() {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
-    const User = userModelFactory();
+export async function up() {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
+  const User = userModelFactory();
 
-    const appInstalled = await Config.findOne({ key: 'app:installed' });
-    if (appInstalled != null && appInstalled.createdAt == null) {
-      // Get the oldest user who probably installed this GROWI.
-      const users = await User.find().limit(1).sort({ createdAt: 1 });
-      const initialUserCreatedAt = users[0].createdAt;
-      logger.debug('initialUserCreatedAt: ', initialUserCreatedAt);
+  const appInstalled = await Config.findOne({ key: 'app:installed' });
+  if (appInstalled != null && appInstalled.createdAt == null) {
+    // Get the oldest user who probably installed this GROWI.
+    const users = await User.find().limit(1).sort({ createdAt: 1 });
+    const initialUserCreatedAt = users[0].createdAt;
+    logger.debug('initialUserCreatedAt: ', initialUserCreatedAt);
 
-      // Set app:installed date.
-      // refs: https://mongoosejs.com/docs/6.x/docs/timestamps.html#disabling-timestamps
-      //       Read the section after "Disabling timestamps also lets you set timestamps yourself..."
-      const updatedConfig = await Config.findOneAndUpdate(
-        { _id: appInstalled._id },
-        { createdAt: initialUserCreatedAt },
-        {
-          new: true,
-          timestamps: false,
-          strict: false,
-        },
-      );
-      logger.debug('updatedConfig: ', updatedConfig);
-    }
+    // Set app:installed date.
+    // refs: https://mongoosejs.com/docs/6.x/docs/timestamps.html#disabling-timestamps
+    //       Read the section after "Disabling timestamps also lets you set timestamps yourself..."
+    const updatedConfig = await Config.findOneAndUpdate(
+      { _id: appInstalled._id },
+      { createdAt: initialUserCreatedAt },
+      {
+        new: true,
+        timestamps: false,
+        strict: false,
+      },
+    );
+    logger.debug('updatedConfig: ', updatedConfig);
+  }
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  async down() {
-    logger.info('Rollback migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function down() {
+  logger.info('Rollback migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const appInstalled = await Config.findOne({ key: 'app:installed' });
-    if (appInstalled != null) {
-      // Unset app:installed date.
-      const updatedConfig = await Config.findOneAndUpdate(
-        { _id: appInstalled._id },
-        { $unset: { createdAt: 1 } },
-        {
-          new: true,
-          timestamps: false,
-          strict: false,
-        },
-      );
-      logger.debug('updatedConfig: ', updatedConfig);
-    }
+  const appInstalled = await Config.findOne({ key: 'app:installed' });
+  if (appInstalled != null) {
+    // Unset app:installed date.
+    const updatedConfig = await Config.findOneAndUpdate(
+      { _id: appInstalled._id },
+      { $unset: { createdAt: 1 } },
+      {
+        new: true,
+        timestamps: false,
+        strict: false,
+      },
+    );
+    logger.debug('updatedConfig: ', updatedConfig);
+  }
 
-    logger.info('Migration has been successfully rollbacked');
-  },
-};
+  logger.info('Migration has been successfully rollbacked');
+}

--- a/apps/app/src/migrations/20231102012742-clean-user-ui-settings-collection.js
+++ b/apps/app/src/migrations/20231102012742-clean-user-ui-settings-collection.js
@@ -1,32 +1,30 @@
-import UserUISettings from '~/server/models/user-ui-settings';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import UserUISettings from '~/server/models/user-ui-settings.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:clean-user-ui-settings-collection');
 
-const mongoose = require('mongoose');
+import mongoose from 'mongoose';
 
-module.exports = {
-  async up() {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up() {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    await UserUISettings.updateMany(
-      {},
-      {
-        $unset: {
-          isSidebarCollapsed: '',
-          preferDrawerModeByUser: '',
-          preferDrawerModeOnEditByUser: '',
-        },
+  await UserUISettings.updateMany(
+    {},
+    {
+      $unset: {
+        isSidebarCollapsed: '',
+        preferDrawerModeByUser: '',
+        preferDrawerModeOnEditByUser: '',
       },
-      { strict: false },
-    );
+    },
+    { strict: false },
+  );
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  async down() {
-    // No rollback
-  },
-};
+export async function down() {
+  // No rollback
+}

--- a/apps/app/src/migrations/20231223155127-non-null-granted-groups.js
+++ b/apps/app/src/migrations/20231223155127-non-null-granted-groups.js
@@ -1,25 +1,23 @@
-import loggerFactory from '~/utils/logger';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:non-null-granted-groups');
 
-module.exports = {
-  async up(db, client) {
-    logger.info('Apply migration');
+export async function up(db, client) {
+  logger.info('Apply migration');
 
-    const pageCollection = await db.collection('pages');
+  const pageCollection = await db.collection('pages');
 
-    await pageCollection.updateMany({ grantedGroups: { $eq: null } }, [
-      {
-        $set: {
-          grantedGroups: [],
-        },
+  await pageCollection.updateMany({ grantedGroups: { $eq: null } }, [
+    {
+      $set: {
+        grantedGroups: [],
       },
-    ]);
+    },
+  ]);
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  async down(db, client) {
-    // No rollback
-  },
-};
+export async function down(db, client) {
+  // No rollback
+}

--- a/apps/app/src/migrations/20240924181317-changed-status-in-inappnotifications-from-unread-to-unopened.js
+++ b/apps/app/src/migrations/20240924181317-changed-status-in-inappnotifications-from-unread-to-unopened.js
@@ -1,26 +1,24 @@
-import loggerFactory from '~/utils/logger';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory(
   'growi:changed-status-in-inappnotifications-from-unread-to-unopened',
 );
 
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
+export async function up(db) {
+  logger.info('Apply migration');
 
-    const unreadInAppnotifications = await db.collection('inappnotifications');
-    await unreadInAppnotifications.updateMany({ status: { $eq: 'UNREAD' } }, [
-      {
-        $set: {
-          status: 'UNOPENED',
-        },
+  const unreadInAppnotifications = await db.collection('inappnotifications');
+  await unreadInAppnotifications.updateMany({ status: { $eq: 'UNREAD' } }, [
+    {
+      $set: {
+        status: 'UNOPENED',
       },
-    ]);
+    },
+  ]);
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  async down() {
-    // No rollback
-  },
-};
+export async function down() {
+  // No rollback
+}

--- a/apps/app/src/migrations/20241107172359-rename-pageId-to-page.js
+++ b/apps/app/src/migrations/20241107172359-rename-pageId-to-page.js
@@ -1,8 +1,8 @@
 import mongoose from 'mongoose';
 
-import VectorStoreFileRelationModel from '~/features/openai/server/models/vector-store-file-relation';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import VectorStoreFileRelationModel from '~/features/openai/server/models/vector-store-file-relation.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:rename-pageId-to-page');
 
@@ -21,35 +21,33 @@ async function dropIndexIfExists(db, collectionName, indexName) {
   }
 }
 
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up(db) {
+  logger.info('Apply migration');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    // Drop index
-    await dropIndexIfExists(
-      db,
-      'vectorstorefilerelations',
-      'vectorStoreRelationId_1_pageId_1',
-    );
+  // Drop index
+  await dropIndexIfExists(
+    db,
+    'vectorstorefilerelations',
+    'vectorStoreRelationId_1_pageId_1',
+  );
 
-    // Rename field (pageId -> page)
-    await VectorStoreFileRelationModel.updateMany({}, [
-      { $set: { page: '$pageId' } },
-      { $unset: ['pageId'] },
-    ]);
+  // Rename field (pageId -> page)
+  await VectorStoreFileRelationModel.updateMany({}, [
+    { $set: { page: '$pageId' } },
+    { $unset: ['pageId'] },
+  ]);
 
-    // Create index
-    const collection = mongoose.connection.collection(
-      'vectorstorefilerelations',
-    );
-    await collection.createIndex(
-      { vectorStoreRelationId: 1, page: 1 },
-      { unique: true },
-    );
-  },
+  // Create index
+  const collection = mongoose.connection.collection(
+    'vectorstorefilerelations',
+  );
+  await collection.createIndex(
+    { vectorStoreRelationId: 1, page: 1 },
+    { unique: true },
+  );
+}
 
-  async down() {
-    // No rollback
-  },
-};
+export async function down() {
+  // No rollback
+}

--- a/apps/app/src/migrations/20250522105040-delete-old-index-for-vector-store-file-relation.js
+++ b/apps/app/src/migrations/20250522105040-delete-old-index-for-vector-store-file-relation.js
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory(
   'growi:migrate:vector-store-file-relation-index-migration',
@@ -22,47 +22,46 @@ async function dropIndexIfExists(db, collectionName, indexName) {
   }
 }
 
-module.exports = {
-  async up(db) {
-    logger.info('Apply migration');
+export async function up(db) {
+  logger.info('Apply migration');
 
-    await mongoose.connect(getMongoUri(), mongoOptions);
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    // Drop old index
-    await dropIndexIfExists(
-      db,
-      'vectorstorefilerelations',
-      'vectorStoreRelationId_1_page_1',
-    );
+  // Drop old index
+  await dropIndexIfExists(
+    db,
+    'vectorstorefilerelations',
+    'vectorStoreRelationId_1_page_1',
+  );
 
-    // Create index
-    const collection = mongoose.connection.collection(
-      'vectorstorefilerelations',
-    );
-    await collection.createIndex(
-      { vectorStoreRelationId: 1, page: 1, attachment: 1 },
-      { unique: true },
-    );
-  },
-  async down(db) {
-    logger.info('Rollback migration');
+  // Create index
+  const collection = mongoose.connection.collection(
+    'vectorstorefilerelations',
+  );
+  await collection.createIndex(
+    { vectorStoreRelationId: 1, page: 1, attachment: 1 },
+    { unique: true },
+  );
+}
 
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function down(db) {
+  logger.info('Rollback migration');
 
-    // Drop new index
-    await dropIndexIfExists(
-      db,
-      'vectorstorefilerelations',
-      'vectorStoreRelationId_1_page_1_attachment_1',
-    );
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    // Recreate old index
-    const collection = mongoose.connection.collection(
-      'vectorstorefilerelations',
-    );
-    await collection.createIndex(
-      { vectorStoreRelationId: 1, page: 1 },
-      { unique: true },
-    );
-  },
-};
+  // Drop new index
+  await dropIndexIfExists(
+    db,
+    'vectorstorefilerelations',
+    'vectorStoreRelationId_1_page_1_attachment_1',
+  );
+
+  // Recreate old index
+  const collection = mongoose.connection.collection(
+    'vectorstorefilerelations',
+  );
+  await collection.createIndex(
+    { vectorStoreRelationId: 1, page: 1 },
+    { unique: true },
+  );
+}

--- a/apps/app/src/migrations/20251209120000-remove-esa-qiita-importer-configs.js
+++ b/apps/app/src/migrations/20251209120000-remove-esa-qiita-importer-configs.js
@@ -1,51 +1,49 @@
 import mongoose from 'mongoose';
 
-import { Config } from '~/server/models/config';
-import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
-import loggerFactory from '~/utils/logger';
+import { Config } from '~/server/models/config.js';
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils.js';
+import loggerFactory from '~/utils/logger/index.js';
 
 const logger = loggerFactory('growi:migrate:remove-esa-qiita-importer-configs');
 
-module.exports = {
-  async up() {
-    logger.info('Apply migration: Remove esa and qiita importer configs');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up() {
+  logger.info('Apply migration: Remove esa and qiita importer configs');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const keysToDelete = [
-      'importer:esa:team_name',
-      'importer:esa:access_token',
-      'importer:qiita:team_name',
-      'importer:qiita:access_token',
-    ];
+  const keysToDelete = [
+    'importer:esa:team_name',
+    'importer:esa:access_token',
+    'importer:qiita:team_name',
+    'importer:qiita:access_token',
+  ];
 
-    // Check if any configs exist before deletion
-    const existingConfigs = await Config.countDocuments({
-      key: {
-        $in: keysToDelete,
-      },
-    });
+  // Check if any configs exist before deletion
+  const existingConfigs = await Config.countDocuments({
+    key: {
+      $in: keysToDelete,
+    },
+  });
 
-    if (existingConfigs === 0) {
-      logger.info('No configs to delete - migration not needed');
-      return;
-    }
+  if (existingConfigs === 0) {
+    logger.info('No configs to delete - migration not needed');
+    return;
+  }
 
-    logger.info(`Found ${existingConfigs} config(s) to delete`);
+  logger.info(`Found ${existingConfigs} config(s) to delete`);
 
-    const result = await Config.deleteMany({
-      key: {
-        $in: keysToDelete,
-      },
-    });
+  const result = await Config.deleteMany({
+    key: {
+      $in: keysToDelete,
+    },
+  });
 
-    logger.info(
-      `Migration completed: ${result.deletedCount} config(s) deleted`,
-    );
-  },
+  logger.info(
+    `Migration completed: ${result.deletedCount} config(s) deleted`,
+  );
+}
 
-  async down() {
-    logger.info('Rollback migration: Remove esa and qiita importer configs');
-    // No rollback action - configs are intentionally removed
-    logger.info('No rollback action needed');
-  },
-};
+export async function down() {
+  logger.info('Rollback migration: Remove esa and qiita importer configs');
+  // No rollback action - configs are intentionally removed
+  logger.info('No rollback action needed');
+}

--- a/apps/app/src/migrations/package.json
+++ b/apps/app/src/migrations/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "commonjs"
-}

--- a/apps/app/src/server/service/file-uploader/index.ts
+++ b/apps/app/src/server/service/file-uploader/index.ts
@@ -16,7 +16,10 @@ const logger = loggerFactory('growi:service:FileUploaderServise');
 export const getUploader = async (crowi: Crowi): Promise<FileUploader> => {
   const method =
     EnvToModuleMappings[configManager.getConfig('app:fileUploadType')];
-  const modulePath = `./${method}`;
+  // Explicit `.js`: this is a template-literal dynamic import, so the static
+  // extension codemod cannot add it, and NodeNext's runtime ESM resolver
+  // requires the extension (extensionless -> ERR_MODULE_NOT_FOUND in prod).
+  const modulePath = `./${method}.js`;
   const mod = await import(modulePath);
   const factory = mod.default ?? mod.setup ?? mod;
   const uploader = factory(crowi);

--- a/apps/app/src/server/service/file-uploader/index.ts
+++ b/apps/app/src/server/service/file-uploader/index.ts
@@ -9,6 +9,22 @@ export type { FileUploader } from './file-uploader.js';
 
 const logger = loggerFactory('growi:service:FileUploaderServise');
 
+// Static loader map keyed by resolved module name. Each entry uses an explicit,
+// statically analyzable specifier with the correct path: `aws`/`gcs` are
+// directories (`/index.js`); the rest are sibling files (`.js`). A computed
+// `import(\`./${method}\`)` cannot express the file-vs-directory distinction —
+// it broke NodeNext's runtime resolver in production (task 3.8.b): a bare
+// `./aws` only worked under tsx's lenient dev resolution, and `./aws.js`
+// (file) does not match the `aws/` directory.
+const uploaderModuleLoaders = {
+  aws: () => import('./aws/index.js'),
+  gcs: () => import('./gcs/index.js'),
+  azure: () => import('./azure.js'),
+  gridfs: () => import('./gridfs.js'),
+  local: () => import('./local.js'),
+  none: () => import('./none.js'),
+};
+
 // Do NOT memoize the uploader instance here: Crowi.setUpFileUpload(isForceUpdate=true)
 // relies on every call re-reading app:fileUploadType and producing a fresh uploader
 // (admin settings change, S2S switch propagation, G2G transfer). The ESM loader
@@ -16,13 +32,16 @@ const logger = loggerFactory('growi:service:FileUploaderServise');
 export const getUploader = async (crowi: Crowi): Promise<FileUploader> => {
   const method =
     EnvToModuleMappings[configManager.getConfig('app:fileUploadType')];
-  // Explicit `.js`: this is a template-literal dynamic import, so the static
-  // extension codemod cannot add it, and NodeNext's runtime ESM resolver
-  // requires the extension (extensionless -> ERR_MODULE_NOT_FOUND in prod).
-  const modulePath = `./${method}.js`;
-  const mod = await import(modulePath);
-  const factory = mod.default ?? mod.setup ?? mod;
-  const uploader = factory(crowi);
+  const loadUploaderModule =
+    uploaderModuleLoaders[method as keyof typeof uploaderModuleLoaders];
+  if (loadUploaderModule == null) {
+    throw new Error(`Unknown file upload method: '${method}'`);
+  }
+  const { setup } = await loadUploaderModule();
+  // The per-uploader `setup` returns its concrete subtype; the union is not
+  // structurally assignable to the `FileUploader` supertype, so narrow it back
+  // here (the previous computed `import()` returned `any` and skipped this).
+  const uploader = setup(crowi) as FileUploader;
 
   if (uploader == null) {
     logger.warn('Failed to initialize uploader.');

--- a/apps/app/src/server/service/s2s-messaging/index.ts
+++ b/apps/app/src/server/service/s2s-messaging/index.ts
@@ -56,7 +56,9 @@ class S2sMessagingServiceFactory {
 
     const moduleFileName = envToModuleMappings[type];
 
-    const modulePath = `./${moduleFileName}`;
+    // Explicit `.js`: template-literal dynamic import — NodeNext's runtime ESM
+    // resolver needs the extension (extensionless -> ERR_MODULE_NOT_FOUND).
+    const modulePath = `./${moduleFileName}.js`;
     const mod = await import(modulePath);
     const factory = mod.default ?? mod.setup ?? mod;
     this.delegator = factory(crowi);

--- a/apps/app/src/server/service/slack-integration.ts
+++ b/apps/app/src/server/service/slack-integration.ts
@@ -281,7 +281,9 @@ export class SlackIntegrationService implements S2sMessageHandlable {
     respondUtil: RespondUtil,
   ): Promise<void> {
     const { growiCommandType } = growiCommand;
-    const modulePath = `./slack-command-handler/${growiCommandType}`;
+    // Explicit `.js`: template-literal dynamic import resolved at runtime by
+    // NodeNext, which requires the extension (extensionless -> ERR_MODULE_NOT_FOUND).
+    const modulePath = `./slack-command-handler/${growiCommandType}.js`;
 
     let handler: any;
     try {
@@ -318,7 +320,9 @@ export class SlackIntegrationService implements S2sMessageHandlable {
     const commandName = actionId.split(':')[0];
     const handlerMethodName = actionId.split(':')[1];
 
-    const modulePath = `./slack-command-handler/${commandName}`;
+    // Explicit `.js`: template-literal dynamic import resolved at runtime by
+    // NodeNext, which requires the extension (extensionless -> ERR_MODULE_NOT_FOUND).
+    const modulePath = `./slack-command-handler/${commandName}.js`;
 
     let handler: any;
     try {
@@ -352,7 +356,9 @@ export class SlackIntegrationService implements S2sMessageHandlable {
     const commandName = callbackId.split(':')[0];
     const handlerMethodName = callbackId.split(':')[1];
 
-    const modulePath = `./slack-command-handler/${commandName}`;
+    // Explicit `.js`: template-literal dynamic import resolved at runtime by
+    // NodeNext, which requires the extension (extensionless -> ERR_MODULE_NOT_FOUND).
+    const modulePath = `./slack-command-handler/${commandName}.js`;
 
     let handler: any;
     try {

--- a/apps/app/test/setup/migrate-mongo.ts
+++ b/apps/app/test/setup/migrate-mongo.ts
@@ -22,6 +22,12 @@ function runMigrations(mongoUri: string): void {
   });
 }
 
+// 120s timeout: this hook spawns `dev:migrate:up`, which runs every migration
+// through tsx (cold-transpiling the 48 migrations + their `~/server/**` import
+// graph) once per Vitest worker. Under the parallel integration run (many
+// workers transpiling at once against one Mongo) this routinely exceeds the
+// default 10s hook timeout — bumped so a slow-but-successful migration pass
+// does not flake the suite.
 beforeAll(() => {
   // Skip if already run (setupFiles run per test file, but we only need to migrate once per worker)
   if (migrationsRun) {
@@ -40,4 +46,4 @@ beforeAll(() => {
 
   runMigrations(mongoUri);
   migrationsRun = true;
-});
+}, 120_000);

--- a/apps/app/test/setup/migrate-mongo.ts
+++ b/apps/app/test/setup/migrate-mongo.ts
@@ -22,12 +22,13 @@ function runMigrations(mongoUri: string): void {
   });
 }
 
-// 120s timeout: this hook spawns `dev:migrate:up`, which runs every migration
-// through tsx (cold-transpiling the 48 migrations + their `~/server/**` import
-// graph) once per Vitest worker. Under the parallel integration run (many
-// workers transpiling at once against one Mongo) this routinely exceeds the
-// default 10s hook timeout — bumped so a slow-but-successful migration pass
-// does not flake the suite.
+// 20s timeout (2x the 10s default): this hook spawns `dev:migrate:up`, which
+// runs every migration through the dev TS runner once per Vitest worker. The
+// default 10s is borderline under the parallel integration run; 20s gives a
+// modest margin without normalizing a runaway threshold. NOTE: if this keeps
+// flaking, the real cause is the dev runner's per-file resolve/load cost over
+// the migration import fan-out (see esm-migration research.md §"dev runner
+// bake-off") — fix the runner perf (Phase 3.8.e ±20% gate), not this number.
 beforeAll(() => {
   // Skip if already run (setupFiles run per test file, but we only need to migrate once per worker)
   if (migrationsRun) {
@@ -46,4 +47,4 @@ beforeAll(() => {
 
   runMigrations(mongoUri);
   migrationsRun = true;
-}, 120_000);
+}, 20_000);

--- a/apps/app/tools/codemod/add-import-extensions.cjs
+++ b/apps/app/tools/codemod/add-import-extensions.cjs
@@ -297,8 +297,6 @@ if (require.main === module) {
           parser,
           '--ignore-pattern',
           '**/node_modules/**',
-          '--ignore-pattern',
-          '**/src/migrations/**',
           ...passPaths,
         ],
         { stdio: 'inherit', cwd: path.resolve(__dirname, '../..') },

--- a/apps/app/tools/codemod/cjs-to-esm.cjs
+++ b/apps/app/tools/codemod/cjs-to-esm.cjs
@@ -576,8 +576,6 @@ if (require.main === module) {
         'ts',
         '--ignore-pattern',
         '**/node_modules/**',
-        '--ignore-pattern',
-        '**/src/migrations/**',
         ...targetPaths,
       ],
       { stdio: 'inherit', cwd: path.resolve(__dirname, '../..') },

--- a/apps/app/tools/codemod/migrations-cjs-to-esm.cjs
+++ b/apps/app/tools/codemod/migrations-cjs-to-esm.cjs
@@ -1,0 +1,134 @@
+/**
+ * jscodeshift transform: convert migrate-mongo migration modules from the
+ * mixed-CJS authoring style to native ESM with NAMED `up`/`down` exports.
+ *
+ * Background (esm-migration task 3.8.b fix): migrate-mongo loads each migration
+ * and reads `migration.up` / `migration.down` directly off the loaded module
+ * (lib/actions/up.js, down.js). Under ESM that requires NAMED exports — a
+ * `export default { up, down }` would leave `migration.up` undefined. The
+ * legacy migrations used `module.exports = { async up(){}, async down(){} }`
+ * plus a mix of `import` and `const x = require('pkg')`, which only worked
+ * because tsc compiled them to CommonJS. Once migrations are compiled as ESM
+ * (their CJS isolation is dissolved), those CJS constructs must become ESM.
+ *
+ * Transforms (idempotent):
+ *   - `const x = require('pkg')`            -> `import x from 'pkg'`
+ *   - `const { a, b } = require('pkg')`     -> `import { a, b } from 'pkg'`
+ *   - `module.exports = { async up(){…}, async down(){…} }`
+ *        -> `export async function up(){…}` + `export async function down(){…}`
+ *      (object methods, function-expression values and arrow values are all
+ *       lifted to named function declarations; non-function values become
+ *       `export const <key> = <value>`)
+ *
+ * Bare-package require specifiers (e.g. 'mongoose') need no extension; relative
+ * and alias specifiers are handled by the separate add-import-extensions pass.
+ */
+
+'use strict';
+
+/** @type {import('jscodeshift').Transform} */
+module.exports = function transform(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let mutated = false;
+
+  // 1) `const x = require('pkg')` / `const { a } = require('pkg')` -> import
+  root
+    .find(j.VariableDeclaration)
+    .filter((path) => {
+      const decls = path.node.declarations;
+      if (decls.length !== 1) return false;
+      const init = decls[0].init;
+      return (
+        init != null &&
+        init.type === 'CallExpression' &&
+        init.callee.type === 'Identifier' &&
+        init.callee.name === 'require' &&
+        init.arguments.length === 1 &&
+        (init.arguments[0].type === 'StringLiteral' ||
+          init.arguments[0].type === 'Literal') &&
+        typeof init.arguments[0].value === 'string'
+      );
+    })
+    .forEach((path) => {
+      const decl = path.node.declarations[0];
+      const source = j.literal(decl.init.arguments[0].value);
+      let specifiers;
+      if (decl.id.type === 'Identifier') {
+        specifiers = [j.importDefaultSpecifier(j.identifier(decl.id.name))];
+      } else if (decl.id.type === 'ObjectPattern') {
+        specifiers = decl.id.properties.map((p) =>
+          j.importSpecifier(
+            j.identifier(p.key.name),
+            j.identifier(p.value.name),
+          ),
+        );
+      } else {
+        return; // unsupported shape, leave as-is
+      }
+      j(path).replaceWith(j.importDeclaration(specifiers, source));
+      mutated = true;
+    });
+
+  // 2) `module.exports = { up, down, ... }` -> named exports
+  root
+    .find(j.ExpressionStatement, {
+      expression: {
+        type: 'AssignmentExpression',
+        left: {
+          type: 'MemberExpression',
+          object: { name: 'module' },
+          property: { name: 'exports' },
+        },
+        right: { type: 'ObjectExpression' },
+      },
+    })
+    .forEach((path) => {
+      const props = path.node.expression.right.properties;
+      const exportNodes = props.map((prop) => {
+        const key = prop.key;
+        const name = key.name ?? key.value;
+
+        // `async up() {}` (ObjectMethod) or `up: function(){}` / `up: () => {}`
+        const fn =
+          prop.type === 'ObjectMethod' || prop.type === 'Property'
+            ? prop.type === 'ObjectMethod'
+              ? prop
+              : prop.value
+            : null;
+
+        if (
+          fn != null &&
+          (fn.type === 'ObjectMethod' ||
+            fn.type === 'FunctionExpression' ||
+            fn.type === 'ArrowFunctionExpression')
+        ) {
+          const body =
+            fn.body.type === 'BlockStatement'
+              ? fn.body
+              : j.blockStatement([j.returnStatement(fn.body)]);
+          const fnDecl = j.functionDeclaration(
+            j.identifier(name),
+            fn.params,
+            body,
+          );
+          fnDecl.async = fn.async ?? false;
+          fnDecl.generator = fn.generator ?? false;
+          return j.exportNamedDeclaration(fnDecl, []);
+        }
+
+        // Non-function value -> `export const <name> = <value>`
+        const value = prop.value ?? prop;
+        return j.exportNamedDeclaration(
+          j.variableDeclaration('const', [
+            j.variableDeclarator(j.identifier(name), value),
+          ]),
+          [],
+        );
+      });
+      j(path).replaceWith(exportNodes);
+      mutated = true;
+    });
+
+  return mutated ? root.toSource({ quote: 'single' }) : null;
+};

--- a/apps/app/tsconfig.build.server.json
+++ b/apps/app/tsconfig.build.server.json
@@ -53,7 +53,6 @@
     "config/*.js",
     "config/*.spec.ts",
     "resource",
-    "src/migrations/**",
     "src/client",
     "src/components",
     "src/components-universal",


### PR DESCRIPTION
## 概要

esm-migration spec **task 3.8(Phase 3 統合ゲート)**で発見した**本番固有の回帰の修正**と、サンドボックスでの検証状況の記録です。

PR #11303(tasks 3.7)merge 後、本番 CI(`reusable-app-prod.yml`)を support/esm で初めて dispatch した結果、`launch-prod` の `server:ci` が失敗 ―― **3.8.b が想定どおり本番固有の問題を捕捉**しました。

## 3.8.b で捕まえた本番回帰

```
ERROR: migrations directory does not exist: .../apps/app/dist/migrations/
```

- **根本原因**: task 2.1 で `src/migrations/**` を `tsconfig.build.server.json` の `exclude` に追加したため、以前は build が `dist/migrations` にコンパイル出力していた migration が生成されなくなった
- **なぜ潜伏したか**: dev は `MIGRATIONS_DIR=src/migrations`(tsx 実行)のため無傷。`test-prod-node24` は support/esm の PR では `if` 条件外で skip され、初回 dispatch まで本番経路が走らなかった
- `build-prod` 自体は ✅(本番 ESM ビルド + assemble + check-next-symlinks 通過)。失敗は migration ステップのみで、Playwright 群の失敗は `launch-prod` 不起動の連鎖

## 修正(Option B — ESM 出力、ユーザー承認済み)

migrate-mongo は `migration.up` / `migration.down` を**ロード済みモジュールから直接参照**するため、ESM migration は **named export** が必須(`export default { up, down }` では `migration.up` が undefined)。旧 migration は `module.exports = { up, down }` + `import`/`require` 混在で、tsc が CJS にコンパイルすることでのみ動いていた。これを native ESM に変換し、通常ビルドへ戻した:

- **`tools/codemod/migrations-cjs-to-esm.cjs`(新規)**: `require()` → `import`、`module.exports = { async up(){…}, async down(){…} }` → `export async function up/down`。48 migration 全件に適用
- `add-import-extensions` を migration にも適用(相対/alias specifier に `.js`)
- **`src/migrations/package.json`(`{type:commonjs}`)を削除** → apps/app の `type:module` を継承し、`src`(dev/tsx)・`dist`(prod)とも ESM
- `tsconfig.build.server.json` の `exclude` から `src/migrations/**` を除去 → build が `dist/migrations` へ ESM 出力(`~/` は typescript-transform-paths で相対 `../server/...js` に解決)
- codemod CLI 2 本(add-import-extensions / cjs-to-esm)の `**/src/migrations/**` ignore を撤去(隔離解消の整合 + 将来の再発防止)
- migration の `.integ.ts` を named import に追従(`migrateModule.default` → namespace)

## 検証

### ローカル(サンドボックス、mongo 無し)
| 項目 | 結果 |
|---|---|
| `turbo run build --filter @growi/app` | ✅ 21/21、`dist/migrations/` に 48 `.js` 生成 |
| 出力 migration | ✅ ESM(`import { Config } from "../server/models/config.js"` / `export async function up,down`)、CJS 残存 0 |
| `import()` ロード | ✅ `keys: [down, up]` 両方 function(migrate-mongo の named 要件 OK) |
| dev 経路(tsx で src migration ロード) | ✅ 同じく named up/down |
| **回帰解消** | ✅ 本番 `migrate-mongo`(`MIGRATIONS_DIR=dist/migrations`)が "dir does not exist" を越え **mongo 接続まで到達** |
| typecheck / biome / unit | ✅(unit 1951 passed、既知 env-fail 1 のみ) |

詳細 evidence: `.kiro/specs/esm-migration/phase3-gate-evidence/3.8b-prod-migrations-fix.md`、サンドボックス全体状況: `SANDBOX-STATUS.md`

### 実 DB(本 PR で確認したいこと)
- `reusable-app-prod.yml` を **このブランチに対して再 dispatch** し、`launch-prod`(`server:ci`)が実 mongo 上で migration を越えて起動 + Playwright が走ることを確認
- `ci-app-test-integration`(実 mongo)で migration の `.integ.ts` が通過

## 残り(3.8 のうち本番 CI で賄えない分)
3.8.c(認可マトリクス diff)/ 3.8.e(起動時間 vs Phase 0.4/0.5 ベースライン、同一ホスト要)は devcontainer 実行が必要(capture スクリプトは tsx で ESM ロード成立を pre-flight 済み)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrFirpXuRb3iq1bBHRb2CQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrFirpXuRb3iq1bBHRb2CQ)_