### PR TITLE
ci: reference in-repo reusable workflows via local ./ path

### DIFF
--- a/.github/workflows/release-rc-scheduled.yml
+++ b/.github/workflows/release-rc-scheduled.yml
@@ -46,7 +46,7 @@ jobs:
 
 
   build-image-rc:
-    uses: growilabs/growi/.github/workflows/reusable-app-build-image.yml@master
+    uses: ./.github/workflows/reusable-app-build-image.yml
     with:
       image-name: growilabs/growi
       tag-temporary: latest-rc
@@ -57,7 +57,7 @@ jobs:
   publish-image-rc:
     needs: [determine-tags, build-image-rc]
 
-    uses: growilabs/growi/.github/workflows/reusable-app-create-manifests.yml@master
+    uses: ./.github/workflows/reusable-app-create-manifests.yml
     with:
       tags: ${{ needs.determine-tags.outputs.TAGS }}
       registry: docker.io

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -37,7 +37,7 @@ jobs:
           type=raw,value=${{ steps.package-json.outputs.packageVersion }}.{{sha}}
 
   build-image-rc:
-    uses: growilabs/growi/.github/workflows/reusable-app-build-image.yml@rc/v7.5.x-node24
+    uses: ./.github/workflows/reusable-app-build-image.yml
     with:
       image-name: growilabs/growi
       tag-temporary: latest-rc
@@ -47,7 +47,7 @@ jobs:
   publish-image-rc:
     needs: [determine-tags, build-image-rc]
 
-    uses: growilabs/growi/.github/workflows/reusable-app-create-manifests.yml@rc/v7.5.x-node24
+    uses: ./.github/workflows/reusable-app-create-manifests.yml
     with:
       tags: ${{ needs.determine-tags.outputs.TAGS }}
       registry: docker.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
   build-app-image:
     needs: create-github-release
 
-    uses: growilabs/growi/.github/workflows/reusable-app-build-image.yml@master
+    uses: ./.github/workflows/reusable-app-build-image.yml
     with:
       source-version: refs/tags/v${{ needs.create-github-release.outputs.RELEASED_VERSION }}
       image-name: growilabs/growi
@@ -115,7 +115,7 @@ jobs:
   publish-app-image:
     needs: [determine-tags, build-app-image]
 
-    uses: growilabs/growi/.github/workflows/reusable-app-create-manifests.yml@master
+    uses: ./.github/workflows/reusable-app-create-manifests.yml
     with:
       tags: ${{ needs.determine-tags.outputs.TAGS }}
       registry: docker.io


### PR DESCRIPTION
## Summary

The in-repo reusable workflows were called through the **external** form
`growilabs/growi/.github/workflows/<reusable>.yml@<ref>`. Switch all six call sites
to the **local** form `./.github/workflows/<reusable>.yml`.

| File | Before | After |
|------|--------|-------|
| `release-rc.yml` (×2) | `…@rc/v7.5.x-node24` | `./…` |
| `release.yml` (×2) | `…@master` | `./…` |
| `release-rc-scheduled.yml` (×2) | `…@master` | `./…` |

## Why

- A local `./` reusable reference resolves to the **same commit as the triggering
  run**, so the reusable definition always matches the branch being built. The
  external `@<ref>` form pulls a different ref and can drift. This matches the
  pattern already used by `ci-app-prod.yml`.
- It also **fixes `release-rc.yml`**, which was pinned to `@rc/v7.5.x-node24` — a
  stale Node 24 migration branch. RC builds (triggered on every `rc/**` push) were
  using reusable definitions frozen on that branch, and the workflow would break
  outright if that temporary branch were ever deleted.

`secrets:` / `with:` blocks are unchanged; only the `uses:` refs change. The two
reusable workflows exist on this branch, so local resolution is satisfied.

Scope is intentionally limited to `dev/8.0.x` (the same fix on `master` can follow
separately if desired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
