### PR TITLE
imprv: Expose news body

### DIFF
--- a/.changeset/news-feed-reserved-path.md
+++ b/.changeset/news-feed-reserved-path.md
@@ -1,0 +1,5 @@
+---
+"@growi/core": patch
+---
+
+Reserve the `/_news` path (in-app news feed page) in `isCreatablePage` so it cannot be created as a wiki page.

--- a/apps/app/public/static/locales/en_US/commons.json
+++ b/apps/app/public/static/locales/en_US/commons.json
@@ -62,7 +62,8 @@
     "news": "News",
     "notifications": "Notifications",
     "filter_all": "All",
-    "no_news": "No news available"
+    "no_news": "No news available",
+    "view_detail": "View details"
   },
   "personal_dropdown": {
     "home": "Home",

--- a/apps/app/public/static/locales/fr_FR/commons.json
+++ b/apps/app/public/static/locales/fr_FR/commons.json
@@ -63,7 +63,8 @@
     "news": "Actualités",
     "notifications": "Notifications",
     "filter_all": "Tout",
-    "no_news": "Aucune actualité disponible"
+    "no_news": "Aucune actualité disponible",
+    "view_detail": "Voir les détails"
   },
   "personal_dropdown": {
     "home": "Accueil",

--- a/apps/app/public/static/locales/ja_JP/commons.json
+++ b/apps/app/public/static/locales/ja_JP/commons.json
@@ -65,7 +65,8 @@
     "news": "お知らせ",
     "notifications": "通知",
     "filter_all": "すべて",
-    "no_news": "ニュースはありません"
+    "no_news": "ニュースはありません",
+    "view_detail": "詳細を見る"
   },
   "personal_dropdown": {
     "home": "ホーム",

--- a/apps/app/public/static/locales/ko_KR/commons.json
+++ b/apps/app/public/static/locales/ko_KR/commons.json
@@ -62,7 +62,8 @@
     "news": "공지사항",
     "notifications": "알림",
     "filter_all": "전체",
-    "no_news": "공지사항이 없습니다"
+    "no_news": "공지사항이 없습니다",
+    "view_detail": "자세히 보기"
   },
   "personal_dropdown": {
     "home": "홈",

--- a/apps/app/public/static/locales/zh_CN/commons.json
+++ b/apps/app/public/static/locales/zh_CN/commons.json
@@ -65,7 +65,8 @@
     "news": "公告",
     "notifications": "通知",
     "filter_all": "全部",
-    "no_news": "暂无公告"
+    "no_news": "暂无公告",
+    "view_detail": "查看详情"
   },
   "personal_dropdown": {
     "home": "家",

--- a/apps/app/src/features/news/client/components/NewsFeed.tsx
+++ b/apps/app/src/features/news/client/components/NewsFeed.tsx
@@ -1,0 +1,136 @@
+import type { JSX } from 'react';
+import { useEffect, useRef } from 'react';
+import { format } from 'date-fns';
+import { useTranslation } from 'next-i18next';
+
+import unreadDotStyles from '~/client/components/InAppNotification/UnreadDot.module.scss';
+import InfiniteScroll from '~/client/components/InfiniteScroll';
+import { getLocale } from '~/utils/locale-utils';
+
+import { newsItemAnchorId } from '../consts';
+import { useSWRINFxNews } from '../hooks/use-news';
+import { resolveLocaleText } from '../utils/resolve-locale-text';
+
+const NEWS_PER_PAGE = 10;
+const DEFAULT_EMOJI = '📢';
+
+/**
+ * Full-page news feed. Reuses the same SWRInfinite stream as the notification
+ * panel and renders each item with its body as plain text (React escapes the
+ * string, so external feed content cannot inject markup).
+ *
+ * Anchor handling: the browser cannot jump to `#news-<id>` when the target is
+ * on a not-yet-loaded page. So on mount we read the hash and keep advancing the
+ * infinite stream until the element exists, then scroll to it.
+ */
+export const NewsFeed = (): JSX.Element => {
+  const { t, i18n } = useTranslation('commons');
+  const locale = i18n.language;
+
+  const swrResponse = useSWRINFxNews(NEWS_PER_PAGE);
+  const { data, setSize, isValidating } = swrResponse;
+
+  const items = (data ?? []).flatMap((page) => page.docs);
+  const lastPage = data != null ? data[data.length - 1] : undefined;
+  const isReachingEnd = lastPage != null && lastPage.hasNextPage === false;
+
+  const scrolledRef = useRef(false);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: items.length is an intentional trigger — re-run to re-check the anchor element each time a new page loads
+  useEffect(() => {
+    if (scrolledRef.current) return;
+
+    const hash = decodeURIComponent(window.location.hash.replace(/^#/, ''));
+    if (hash === '') {
+      scrolledRef.current = true;
+      return;
+    }
+
+    const el = document.getElementById(hash);
+    if (el != null) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      scrolledRef.current = true;
+      return;
+    }
+
+    // Target not loaded yet — pull the next page and re-evaluate on the next render.
+    if (!isReachingEnd && !isValidating) {
+      setSize((size) => size + 1);
+    }
+  }, [items.length, isReachingEnd, isValidating, setSize]);
+
+  if (items.length === 0 && !isValidating) {
+    return (
+      <div className="text-muted text-center py-5">
+        {t('in_app_notification.no_news')}
+      </div>
+    );
+  }
+
+  return (
+    <InfiniteScroll
+      swrInifiniteResponse={swrResponse}
+      isReachingEnd={isReachingEnd}
+    >
+      <div className="list-group list-group-flush">
+        {items.map((item) => {
+          const id = item._id.toString();
+          const title = resolveLocaleText(item.title, locale);
+          const body =
+            item.body != null ? resolveLocaleText(item.body, locale) : '';
+          const emoji = item.emoji ?? DEFAULT_EMOJI;
+          const publishedDate =
+            item.publishedAt instanceof Date
+              ? item.publishedAt
+              : new Date(item.publishedAt);
+          const formattedDate = format(publishedDate, 'PP', {
+            locale: getLocale(locale),
+          });
+
+          return (
+            <section
+              key={id}
+              id={newsItemAnchorId(id)}
+              className="list-group-item py-4"
+            >
+              <div className="d-flex align-items-center mb-1">
+                <span
+                  className={`${item.isRead ? '' : 'bg-primary'} rounded-circle me-3 ${unreadDotStyles['unread-dot']}`}
+                />
+                <span className="me-2 fs-4 lh-1">{emoji}</span>
+                <h2
+                  className={`h5 mb-0 ${item.isRead ? 'fw-normal' : 'fw-bold'}`}
+                >
+                  {title}
+                </h2>
+              </div>
+
+              <div className="text-muted small mb-2 ms-5">{formattedDate}</div>
+
+              {body !== '' && (
+                <div className="ms-5" style={{ whiteSpace: 'pre-wrap' }}>
+                  {body}
+                </div>
+              )}
+
+              {item.url != null && (
+                <div className="ms-5 mt-3">
+                  <a
+                    href={item.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="btn btn-outline-secondary btn-sm"
+                  >
+                    {t('in_app_notification.view_detail')}
+                    <span className="growi-custom-icons ms-1 small">
+                      external_link
+                    </span>
+                  </a>
+                </div>
+              )}
+            </section>
+          );
+        })}
+      </div>
+    </InfiniteScroll>
+  );
+};

--- a/apps/app/src/features/news/client/components/NewsFeed.tsx
+++ b/apps/app/src/features/news/client/components/NewsFeed.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from 'react';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/router';
 import { format } from 'date-fns';
 import { useTranslation } from 'next-i18next';
 
@@ -15,6 +16,22 @@ const NEWS_PER_PAGE = 10;
 const DEFAULT_EMOJI = '📢';
 
 /**
+ * Maximum number of additional pages to pull while searching for an anchor
+ * target. Caps the worst-case workload when the URL hash points at a deleted
+ * or otherwise unreachable news item — without this guard the lookup walks
+ * the entire history before giving up.
+ */
+const MAX_ANCHOR_SCAN_PAGES = 5;
+
+/**
+ * Defense-in-depth: even though `feed-parser` rejects non-http(s) URLs at
+ * ingest time, the rendered href is exposed to whatever happens to be in the
+ * DB (e.g. a row inserted before the validator existed). Re-check at render
+ * to block `javascript:`, `data:`, and similar XSS vectors.
+ */
+const isSafeHttpUrl = (url: string): boolean => /^https?:\/\//i.test(url);
+
+/**
  * Full-page news feed. Reuses the same SWRInfinite stream as the notification
  * panel and renders each item with its body as plain text (React escapes the
  * string, so external feed content cannot inject markup).
@@ -26,6 +43,7 @@ const DEFAULT_EMOJI = '📢';
 export const NewsFeed = (): JSX.Element => {
   const { t, i18n } = useTranslation('commons');
   const locale = i18n.language;
+  const router = useRouter();
 
   const swrResponse = useSWRINFxNews(NEWS_PER_PAGE);
   const { data, setSize, isValidating } = swrResponse;
@@ -34,29 +52,53 @@ export const NewsFeed = (): JSX.Element => {
   const lastPage = data != null ? data[data.length - 1] : undefined;
   const isReachingEnd = lastPage != null && lastPage.hasNextPage === false;
 
-  const scrolledRef = useRef(false);
+  // Pending anchor to scroll to. Empty string means "nothing to do".
+  // Captures the initial hash at mount; subsequent hash changes (e.g. when the
+  // user clicks another news item while /_news is already open) refresh it.
+  const [scrollTargetHash, setScrollTargetHash] = useState<string>(() =>
+    typeof window === 'undefined'
+      ? ''
+      : decodeURIComponent(window.location.hash.replace(/^#/, '')),
+  );
+  const scanAttemptsRef = useRef(0);
+
+  // Reset the scroll target whenever the URL hash changes while the page is
+  // already mounted. Without this the second click from the sidebar would not
+  // scroll because the component is not remounted.
+  useEffect(() => {
+    const handleHashChange = (url: string) => {
+      const hashIndex = url.indexOf('#');
+      const hash =
+        hashIndex >= 0 ? decodeURIComponent(url.slice(hashIndex + 1)) : '';
+      scanAttemptsRef.current = 0;
+      setScrollTargetHash(hash);
+    };
+    router.events.on('hashChangeComplete', handleHashChange);
+    return () => router.events.off('hashChangeComplete', handleHashChange);
+  }, [router.events]);
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: items.length is an intentional trigger — re-run to re-check the anchor element each time a new page loads
   useEffect(() => {
-    if (scrolledRef.current) return;
+    if (scrollTargetHash === '') return;
 
-    const hash = decodeURIComponent(window.location.hash.replace(/^#/, ''));
-    if (hash === '') {
-      scrolledRef.current = true;
-      return;
-    }
-
-    const el = document.getElementById(hash);
+    const el = document.getElementById(scrollTargetHash);
     if (el != null) {
       el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      scrolledRef.current = true;
+      setScrollTargetHash('');
       return;
     }
 
-    // Target not loaded yet — pull the next page and re-evaluate on the next render.
-    if (!isReachingEnd && !isValidating) {
+    // Give up if there are no more pages, we've already scanned the maximum,
+    // or a fetch is in flight (next render will retry).
+    if (isReachingEnd || scanAttemptsRef.current >= MAX_ANCHOR_SCAN_PAGES) {
+      setScrollTargetHash('');
+      return;
+    }
+    if (!isValidating) {
+      scanAttemptsRef.current += 1;
       setSize((size) => size + 1);
     }
-  }, [items.length, isReachingEnd, isValidating, setSize]);
+  }, [scrollTargetHash, items.length, isReachingEnd, isValidating, setSize]);
 
   if (items.length === 0 && !isValidating) {
     return (
@@ -112,7 +154,7 @@ export const NewsFeed = (): JSX.Element => {
                 </div>
               )}
 
-              {item.url != null && (
+              {item.url != null && isSafeHttpUrl(item.url) && (
                 <div className="ms-5 mt-3">
                   <a
                     href={item.url}

--- a/apps/app/src/features/news/client/components/NewsItem.spec.tsx
+++ b/apps/app/src/features/news/client/components/NewsItem.spec.tsx
@@ -4,12 +4,17 @@ import mongoose from 'mongoose';
 const mocks = vi.hoisted(() => {
   const apiv3Post = vi.fn().mockResolvedValue({});
   const mutate = vi.fn();
+  const routerPush = vi.fn();
   const i18nLanguage = { current: 'ja_JP' };
-  return { apiv3Post, mutate, i18nLanguage };
+  return { apiv3Post, mutate, routerPush, i18nLanguage };
 });
 
 vi.mock('~/client/util/apiv3-client', () => ({
   apiv3Post: mocks.apiv3Post,
+}));
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({ push: mocks.routerPush }),
 }));
 
 vi.mock('next-i18next', () => ({
@@ -22,10 +27,6 @@ vi.mock('next-i18next', () => ({
     },
   }),
 }));
-
-// Mock window.open
-const mockOpen = vi.fn();
-vi.stubGlobal('open', mockOpen);
 
 import type { INewsItemWithReadStatus } from '../../interfaces/news-item';
 import { NewsItem } from './NewsItem';
@@ -145,36 +146,30 @@ describe('NewsItem', () => {
       });
     });
 
-    test('should open URL in new tab when url is set', async () => {
-      const item = makeNewsItem({
-        url: 'https://github.com/growi',
-        isRead: false,
-      });
+    test('should navigate to the news feed page anchored to the clicked item', async () => {
+      const item = makeNewsItem({ isRead: false });
       render(<NewsItem item={item} onReadMutate={onReadMutate} />);
 
-      const element = screen.getByRole('button');
-      fireEvent.click(element);
+      fireEvent.click(screen.getByRole('button'));
 
       await vi.waitFor(() => {
-        expect(mockOpen).toHaveBeenCalledWith(
-          'https://github.com/growi',
-          '_blank',
-          'noopener,noreferrer',
+        expect(mocks.routerPush).toHaveBeenCalledWith(
+          `/_news#news-${item._id.toString()}`,
         );
       });
     });
 
-    test('should NOT open URL when url is not set', async () => {
+    test('should navigate even when url is not set', async () => {
       const item = makeNewsItem({ url: undefined, isRead: false });
       render(<NewsItem item={item} onReadMutate={onReadMutate} />);
 
-      const element = screen.getByRole('button');
-      fireEvent.click(element);
+      fireEvent.click(screen.getByRole('button'));
 
       await vi.waitFor(() => {
-        expect(mocks.apiv3Post).toHaveBeenCalled();
+        expect(mocks.routerPush).toHaveBeenCalledWith(
+          `/_news#news-${item._id.toString()}`,
+        );
       });
-      expect(mockOpen).not.toHaveBeenCalled();
     });
 
     test('should call onReadMutate after marking as read', async () => {

--- a/apps/app/src/features/news/client/components/NewsItem.tsx
+++ b/apps/app/src/features/news/client/components/NewsItem.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
+import { useRouter } from 'next/router';
 import { format } from 'date-fns';
 import { useTranslation } from 'next-i18next';
 
@@ -8,23 +9,10 @@ import { apiv3Post } from '~/client/util/apiv3-client';
 import { getLocale } from '~/utils/locale-utils';
 
 import type { INewsItemWithReadStatus } from '../../interfaces/news-item';
+import { NEWS_FEED_PATH, newsItemAnchorId } from '../consts';
+import { resolveLocaleText } from '../utils/resolve-locale-text';
 
 const DEFAULT_EMOJI = '📢';
-
-/**
- * Resolve the title for the given locale with fallback chain:
- * browserLocale → ja_JP → en_US → first available key
- */
-const resolveTitle = (
-  title: Record<string, string>,
-  locale: string,
-): string => {
-  if (title[locale]) return title[locale];
-  if (title.ja_JP) return title.ja_JP;
-  if (title.en_US) return title.en_US;
-  const keys = Object.keys(title);
-  return keys.length > 0 ? title[keys[0]] : '';
-};
 
 type Props = {
   item: INewsItemWithReadStatus;
@@ -33,8 +21,9 @@ type Props = {
 
 const NewsItemInner: FC<Props> = ({ item, onReadMutate }) => {
   const { i18n } = useTranslation();
+  const router = useRouter();
   const locale = i18n.language;
-  const title = resolveTitle(item.title, locale);
+  const title = resolveLocaleText(item.title, locale);
   const emoji = item.emoji ?? DEFAULT_EMOJI;
 
   const publishedDate =
@@ -45,18 +34,18 @@ const NewsItemInner: FC<Props> = ({ item, onReadMutate }) => {
     locale: getLocale(locale),
   });
 
-  const handleClick = async () => {
+  // Clicking a news item always navigates to the news feed page, anchored to
+  // the clicked item. Marking it read first keeps the unread badge in sync.
+  const handleClick = useCallback(async () => {
+    const id = item._id.toString();
     try {
-      await apiv3Post('/news/mark-read', { newsItemId: item._id.toString() });
+      await apiv3Post('/news/mark-read', { newsItemId: id });
       onReadMutate();
     } catch {
       // silently ignore mark-read failures
     }
-
-    if (item.url) {
-      window.open(item.url, '_blank', 'noopener,noreferrer');
-    }
-  };
+    router.push(`${NEWS_FEED_PATH}#${newsItemAnchorId(id)}`);
+  }, [item._id, onReadMutate, router]);
 
   return (
     <button

--- a/apps/app/src/features/news/client/consts.ts
+++ b/apps/app/src/features/news/client/consts.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared constants for the news feed page and the items that link into it.
+ * Keeping the path and the anchor-id scheme in one place ensures the link
+ * produced by NewsItem always matches the element id rendered by NewsFeed.
+ */
+
+/** Route of the in-app news feed page (reserved system path, see @growi/core page-path-utils). */
+export const NEWS_FEED_PATH = '/_news';
+
+/** DOM id for a news item section on the feed page, used as the scroll anchor. */
+export const newsItemAnchorId = (id: string): string => `news-${id}`;

--- a/apps/app/src/features/news/client/utils/resolve-locale-text.ts
+++ b/apps/app/src/features/news/client/utils/resolve-locale-text.ts
@@ -1,0 +1,17 @@
+/**
+ * Resolve a localized text from a locale-keyed map with fallback chain:
+ * requested locale → ja_JP → en_US → first available key → ''.
+ *
+ * Shared by NewsItem (title) and NewsItemModal (title / body) so the
+ * fallback behaviour stays identical across the list row and the detail modal.
+ */
+export const resolveLocaleText = (
+  map: Record<string, string>,
+  locale: string,
+): string => {
+  if (map[locale]) return map[locale];
+  if (map.ja_JP) return map.ja_JP;
+  if (map.en_US) return map.en_US;
+  const keys = Object.keys(map);
+  return keys.length > 0 ? map[keys[0]] : '';
+};

--- a/apps/app/src/features/news/client/utils/resolve-locale-text.ts
+++ b/apps/app/src/features/news/client/utils/resolve-locale-text.ts
@@ -2,8 +2,9 @@
  * Resolve a localized text from a locale-keyed map with fallback chain:
  * requested locale → ja_JP → en_US → first available key → ''.
  *
- * Shared by NewsItem (title) and NewsItemModal (title / body) so the
- * fallback behaviour stays identical across the list row and the detail modal.
+ * Shared by NewsItem (title in the sidebar panel) and NewsFeed
+ * (title / body on the full-page feed) so the fallback behaviour stays
+ * identical across both surfaces.
  */
 export const resolveLocaleText = (
   map: Record<string, string>,

--- a/apps/app/src/features/news/server/services/feed-parser.ts
+++ b/apps/app/src/features/news/server/services/feed-parser.ts
@@ -4,13 +4,17 @@ import loggerFactory from '~/utils/logger';
 
 const logger = loggerFactory('growi:feature:news:feed-parser');
 
+// Allow only http(s) URLs to block javascript:/data:/vbscript: vectors (XSS).
+// Items with disallowed schemes fail per-item validation and are dropped at parse time.
+const HTTP_URL_PATTERN = /^https?:\/\//i;
+
 const FeedItemSchema = z.object({
   id: z.string().min(1),
   type: z.string().optional(),
   emoji: z.string().optional(),
   title: z.record(z.string()),
   body: z.record(z.string()).optional(),
-  url: z.string().optional(),
+  url: z.string().regex(HTTP_URL_PATTERN).optional(),
   publishedAt: z.string().min(1),
   conditions: z
     .object({

--- a/apps/app/src/pages/_news/index.page.tsx
+++ b/apps/app/src/pages/_news/index.page.tsx
@@ -1,0 +1,110 @@
+import type { JSX, ReactNode } from 'react';
+import type { GetServerSideProps, GetServerSidePropsContext } from 'next';
+import dynamic from 'next/dynamic';
+import Head from 'next/head';
+import { LoadingSpinner } from '@growi/ui/dist/components';
+import { useTranslation } from 'next-i18next';
+
+import { BasicLayout } from '~/components/Layout/BasicLayout';
+import { GroundGlassBar } from '~/components/Navbar/GroundGlassBar';
+
+import type { NextPageWithLayout } from '../_app.page';
+import type { BasicLayoutConfigurationProps } from '../basic-layout-page';
+import { getServerSideBasicLayoutProps } from '../basic-layout-page';
+import { useHydrateBasicLayoutConfigurationAtoms } from '../basic-layout-page/hydrate';
+import type { CommonEachProps, CommonInitialProps } from '../common-props';
+import {
+  getServerSideCommonEachProps,
+  getServerSideCommonInitialProps,
+  getServerSideI18nProps,
+} from '../common-props';
+import { useCustomTitle } from '../utils/page-title-customization';
+import { mergeGetServerSidePropsResults } from '../utils/server-side-props';
+
+const NewsFeed = dynamic(
+  () =>
+    // biome-ignore lint/style/noRestrictedImports: no-problem dynamic import
+    import('~/features/news/client/components/NewsFeed').then(
+      (m) => m.NewsFeed,
+    ),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="text-muted text-center">
+        <LoadingSpinner className="mt-3 fs-3" />
+      </div>
+    ),
+  },
+);
+
+type Props = CommonInitialProps &
+  CommonEachProps &
+  BasicLayoutConfigurationProps;
+
+const NewsFeedPage: NextPageWithLayout<Props> = () => {
+  const { t } = useTranslation('commons');
+  const title = useCustomTitle(t('in_app_notification.news'));
+
+  return (
+    <>
+      <Head>
+        <title>{title}</title>
+      </Head>
+      <div className="dynamic-layout-root">
+        <GroundGlassBar className="sticky-top py-4"></GroundGlassBar>
+
+        <div className="main ps-sidebar" data-testid="news-feed-page">
+          <div className="container-lg wide-gutter-x-lg">
+            <h2 className="sticky-top py-1">{t('in_app_notification.news')}</h2>
+
+            <NewsFeed />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+type LayoutProps = Props & {
+  children?: ReactNode;
+};
+
+const Layout = ({ children, ...props }: LayoutProps): JSX.Element => {
+  useHydrateBasicLayoutConfigurationAtoms(
+    props.searchConfig,
+    props.sidebarConfig,
+    props.userUISettings,
+  );
+
+  return <BasicLayout>{children}</BasicLayout>;
+};
+
+NewsFeedPage.getLayout = function getLayout(page) {
+  return <Layout {...page.props}>{page}</Layout>;
+};
+
+export const getServerSideProps: GetServerSideProps = async (
+  context: GetServerSidePropsContext,
+) => {
+  const [
+    commonInitialResult,
+    commonEachResult,
+    basicLayoutResult,
+    i18nPropsResult,
+  ] = await Promise.all([
+    getServerSideCommonInitialProps(context),
+    getServerSideCommonEachProps(context),
+    getServerSideBasicLayoutProps(context),
+    getServerSideI18nProps(context, ['translation', 'commons']),
+  ]);
+
+  return mergeGetServerSidePropsResults(
+    commonInitialResult,
+    mergeGetServerSidePropsResults(
+      commonEachResult,
+      mergeGetServerSidePropsResults(basicLayoutResult, i18nPropsResult),
+    ),
+  );
+};
+
+export default NewsFeedPage;

--- a/packages/core/src/utils/page-path-utils/index.ts
+++ b/packages/core/src/utils/page-path-utils/index.ts
@@ -111,7 +111,7 @@ const restrictedPatternsToCreate: Array<RegExp> = [
   /^(\.\.)$/, // see: https://github.com/growilabs/growi/issues/3582
   /(\/\.\.)\/?/, // see: https://github.com/growilabs/growi/issues/3582
   /\\/, // see: https://github.com/growilabs/growi/issues/7241
-  /^\/(_search|_private-legacy-pages)(\/.*|$)/,
+  /^\/(_search|_private-legacy-pages|_news)(\/.*|$)/,
   /^\/(installer|register|login|logout|admin|me|files|trash|paste|comments|tags|share|attachment)(\/.*|$)/,
   /^\/user(?:\/[^/]+)?$/, // https://regex101.com/r/9Eh2S1/1
   /^(\/.+){130,}$/, // avoid deep layer path. see: https://regex101.com/r/L0kzOD/1

--- a/packages/core/src/utils/page-path-utils/is-creatable-page.spec.ts
+++ b/packages/core/src/utils/page-path-utils/is-creatable-page.spec.ts
@@ -53,6 +53,8 @@ describe('isCreatablePage', () => {
       '/user/john', // User homepage
       '/_api',
       '/_search',
+      '/_news', // In-app news feed page
+      '/_news/sub', // Sub-paths under the news feed
       '/admin',
       '/login',
       '/hoge/file.md', // .md files


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/185387

### What

フィードのbody（ニュース本文）がUI上に表示されていなかったため、ニュース一覧を`/_news/`として新規作成。
ユーザはInAppNotificationからニュースアイテムをクリックすることでニュース一覧の該当アイテムの箇所に飛ぶ仕様。
フィードのurl（設定されたリンク）を external link icon と共に表示。

ファイル | 役割
-- | --
pages/_news/index.page.tsx（新規） | /_news ページ本体（タグ一覧ページに倣った作り）
NewsFeed.tsx（新規） | ページ内のニュース一覧（無限スクロール＋本文＋「詳細を見る」ボタン）
consts.ts（新規） | パス /_news とアンカーIDを共有
NewsItem.tsx（変更） | クリックで /_news へ遷移するように
@growi/core（変更） | /_news を予約パス化（wikiページと被らないように）

<br class="Apple-interchange-newline">

### スクリーンショット

<img width="1512" height="765" alt="スクリーンショット 2026-06-16 18 51 22" src="https://github.com/user-attachments/assets/b494951d-088a-4b17-8b62-3538c1e43a8d" />
