### PR TITLE
read only user

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -22,8 +22,11 @@
   "unlink_redirection": "Unlink redirection",
   "Done": "Done",
   "Cancel": "Cancel",
+  "Save": "Save",
   "Create": "Create",
   "Description": "Description",
+  "Successfully updated": "Successfully updated",
+  "Failed to update": "Failed to update",
   "Admin": "Admin",
   "administrator": "Admin",
   "Tag": "Tag",
@@ -1176,6 +1179,24 @@
       "docs_badge": "Learn more about Badges",
       "docs_color": "Learn more about Colors",
       "docs_alert": "Learn more about Alert Blocks"
+    }
+  },
+  "page_permission": {
+    "title": "Page Permissions",
+    "menu_label": "Permissions",
+    "read_permission_section": "Read Permission (Who can view this page)",
+    "write_permission_section": "Write Permission (Who can edit this page)",
+    "current_summary": "Current: Read: {{readGrant}} | Write: {{writeGrant}}",
+    "read_grant": {
+      "public": "Public",
+      "restricted": "Anyone with the link",
+      "owner": "Only me",
+      "user_group": "Only inside the group"
+    },
+    "write_grant": {
+      "public": "Anyone can edit",
+      "owner": "Only me can edit",
+      "user_group": "Only inside the group can edit"
     }
   }
 }

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -22,7 +22,10 @@
   "unlink_redirection": "リダイレクト削除",
   "Done": "完了",
   "Cancel": "キャンセル",
+  "Save": "保存",
   "Create": "作成",
+  "Successfully updated": "更新しました",
+  "Failed to update": "更新に失敗しました",
   "Description": "説明",
   "Admin": "管理",
   "administrator": "管理者",
@@ -1210,6 +1213,24 @@
       "docs_badge": "バッジの詳細はこちら",
       "docs_color": "カラーの詳細はこちら",
       "docs_alert": "アラートブロックの詳細はこちら"
+    }
+  },
+  "page_permission": {
+    "title": "ページ権限設定",
+    "menu_label": "権限設定",
+    "read_permission_section": "閲覧権限 (このページを閲覧できるユーザー)",
+    "write_permission_section": "編集権限 (このページを編集できるユーザー)",
+    "current_summary": "現在の設定: 閲覧: {{readGrant}} | 編集: {{writeGrant}}",
+    "read_grant": {
+      "public": "公開",
+      "restricted": "リンクを知っている人のみ",
+      "owner": "自分のみ",
+      "user_group": "特定グループのみ"
+    },
+    "write_grant": {
+      "public": "誰でも編集可",
+      "owner": "自分のみ編集可",
+      "user_group": "特定グループのみ編集可"
     }
   }
 }

--- a/apps/app/src/client/components/Common/Dropdown/PageItemControl.spec.tsx
+++ b/apps/app/src/client/components/Common/Dropdown/PageItemControl.spec.tsx
@@ -68,6 +68,7 @@ describe('PageItemControl.tsx', () => {
         isDeletable: true,
         isAbleToDeleteCompletely: false,
         isRevertible: false,
+        isEditable: true,
         bookmarkCount: 0,
         isBookmarked: false,
       };
@@ -107,6 +108,43 @@ describe('PageItemControl.tsx', () => {
       expect(onClickRenameMenuItemMock).toHaveBeenCalledWith(
         'dummy-page-id',
         pageInfo,
+      );
+    });
+  });
+
+  describe('Should trigger onClickPermissionMenuItem() when clicking the permission button', () => {
+    it('should open permission modal on click', async () => {
+      const pageInfo = mock<IPageInfoForOperation>();
+      const onClickPermissionMenuItemMock = vi.fn();
+
+      mocks.isIPageInfoForOperationMock.mockImplementation((arg) => {
+        if (arg === pageInfo) {
+          return true;
+        }
+      });
+      mocks.isIPageInfoForEmptyMock.mockReturnValue(false);
+
+      const props = {
+        pageId: 'dummy-page-id',
+        isEnableActions: true,
+        pageInfo,
+        onClickPermissionMenuItem: onClickPermissionMenuItemMock,
+      };
+
+      render(<PageItemControl {...props} />);
+
+      const button = within(
+        screen.getByTestId('open-page-item-control-btn'),
+      ).getByText(/more_vert/);
+      fireEvent.click(button);
+      const permissionMenuItem = await screen.findByTestId(
+        'open-page-permission-modal-btn',
+      );
+      fireEvent.click(permissionMenuItem);
+
+      expect(onClickPermissionMenuItemMock).toHaveBeenCalled();
+      expect(onClickPermissionMenuItemMock).toHaveBeenCalledWith(
+        'dummy-page-id',
       );
     });
   });

--- a/apps/app/src/client/components/Common/Dropdown/PageItemControl.tsx
+++ b/apps/app/src/client/components/Common/Dropdown/PageItemControl.tsx
@@ -29,6 +29,7 @@ export const MenuItemType = {
   REVERT: 'revert',
   PATH_RECOVERY: 'pathRecovery',
   SWITCH_CONTENT_WIDTH: 'switch_content_width',
+  PERMISSION: 'permission',
 } as const;
 export type MenuItemType = (typeof MenuItemType)[keyof typeof MenuItemType];
 
@@ -57,6 +58,7 @@ type CommonProps = {
   ) => Promise<void> | void;
   onClickRevertMenuItem?: (pageId: string) => Promise<void> | void;
   onClickPathRecoveryMenuItem?: (pageId: string) => Promise<void> | void;
+  onClickPermissionMenuItem?: (pageId: string) => void;
 
   additionalMenuItemOnTopRenderer?: React.FunctionComponent<AdditionalMenuItemsRendererProps>;
   additionalMenuItemRenderer?: React.FunctionComponent<AdditionalMenuItemsRendererProps>;
@@ -90,6 +92,7 @@ const PageItemControlDropdownMenu = React.memo(
       onClickDeleteMenuItem,
       onClickRevertMenuItem,
       onClickPathRecoveryMenuItem,
+      onClickPermissionMenuItem,
       additionalMenuItemOnTopRenderer: AdditionalMenuItemsOnTop,
       additionalMenuItemRenderer: AdditionalMenuItems,
       isInstantRename,
@@ -156,6 +159,11 @@ const PageItemControlDropdownMenu = React.memo(
       }
       await onClickPathRecoveryMenuItem(pageId);
     }, [onClickPathRecoveryMenuItem, pageId]);
+
+    const permissionItemClickedHandler = useCallback(() => {
+      if (onClickPermissionMenuItem == null) return;
+      onClickPermissionMenuItem(pageId);
+    }, [onClickPermissionMenuItem, pageId]);
 
     let contents = <></>;
 
@@ -256,6 +264,22 @@ const PageItemControlDropdownMenu = React.memo(
                   file_copy
                 </span>
                 {t('Duplicate')}
+              </DropdownItem>
+            )}
+
+          {/* Permission Settings */}
+          {!forceHideMenuItems?.includes(MenuItemType.PERMISSION) &&
+            isEnableActions &&
+            !isReadOnlyUser && (
+              <DropdownItem
+                onClick={permissionItemClickedHandler}
+                data-testid="open-page-permission-modal-btn"
+                className="grw-page-control-dropdown-item"
+              >
+                <span className="material-symbols-outlined me-1 grw-page-control-dropdown-icon">
+                  manage_accounts
+                </span>
+                {t('page_permission.menu_label')}
               </DropdownItem>
             )}
 
@@ -363,6 +387,7 @@ export const PageItemControlSubstance = (
     onClickRenameMenuItem,
     onClickDuplicateMenuItem,
     onClickDeleteMenuItem,
+    onClickPermissionMenuItem,
     onClickPathRecoveryMenuItem,
   } = props;
 
@@ -461,6 +486,7 @@ export const PageItemControlSubstance = (
             onClickDuplicateMenuItem={duplicateMenuItemClickHandler}
             onClickDeleteMenuItem={deleteMenuItemClickHandler}
             onClickPathRecoveryMenuItem={pathRecoveryMenuItemClickHandler}
+            onClickPermissionMenuItem={onClickPermissionMenuItem}
           />
         )}
       </Dropdown>

--- a/apps/app/src/client/components/Navbar/GrowiContextualSubNavigation.tsx
+++ b/apps/app/src/client/components/Navbar/GrowiContextualSubNavigation.tsx
@@ -40,6 +40,7 @@ import {
 import { useCurrentPathname, useCurrentUser } from '~/states/global';
 import { useCurrentPageId, useFetchCurrentPage } from '~/states/page';
 import { useShareLinkId } from '~/states/page/hooks';
+import { PagePermissionModal } from '../PageControls/PagePermissionModal';
 import {
   disableLinkSharingAtom,
   isBulkExportPagesEnabledAtom,
@@ -351,6 +352,7 @@ const GrowiContextualSubNavigation = (
 
   const [isPageTemplateModalShown, setIsPageTempleteModalShown] =
     useState(false);
+  const [isPermissionModalShown, setIsPermissionModalShown] = useState(false);
 
   const duplicateItemClickedHandler = useCallback(
     async (page: IPageForPageDuplicateModal) => {
@@ -421,6 +423,13 @@ const GrowiContextualSubNavigation = (
       }
     },
     [isSharedPage, fetchCurrentPage],
+  );
+
+  const permissionMenuItemClickHandler = useCallback(
+    (_pageId: string) => {
+      setIsPermissionModalShown(true);
+    },
+    [],
   );
 
   const additionalMenuItemsRenderer = useCallback(() => {
@@ -498,6 +507,7 @@ const GrowiContextualSubNavigation = (
             onClickRenameMenuItem={renameItemClickedHandler}
             onClickDeleteMenuItem={deleteItemClickedHandler}
             onClickSwitchContentWidth={switchContentWidthHandler}
+            onClickPermissionMenuItem={permissionMenuItemClickHandler}
           />
 
           {isAbleToChangeEditorMode && (
@@ -556,6 +566,14 @@ const GrowiContextualSubNavigation = (
           path={path}
           isOpen={isPageTemplateModalShown}
           onClose={() => setIsPageTempleteModalShown(false)}
+        />
+      )}
+
+      {pageId != null && (
+        <PagePermissionModal
+          isOpen={isPermissionModalShown}
+          pageId={pageId}
+          onClose={() => setIsPermissionModalShown(false)}
         />
       )}
     </>

--- a/apps/app/src/client/components/PageControls/PageControls.tsx
+++ b/apps/app/src/client/components/PageControls/PageControls.tsx
@@ -129,6 +129,7 @@ type CommonProps = {
   onClickRenameMenuItem?: (pageToRename: IPageToRenameWithMeta) => void;
   onClickDeleteMenuItem?: (pageToDelete: IPageToDeleteWithMeta) => void;
   onClickSwitchContentWidth?: (pageId: string, value: boolean) => void;
+  onClickPermissionMenuItem?: (pageId: string) => void;
 };
 
 type PageControlsSubstanceProps = CommonProps & {
@@ -419,6 +420,7 @@ const PageControlsSubstance = (
           onClickRenameMenuItem={renameMenuItemClickHandler}
           onClickDuplicateMenuItem={duplicateMenuItemClickHandler}
           onClickDeleteMenuItem={deleteMenuItemClickHandler}
+          onClickPermissionMenuItem={props.onClickPermissionMenuItem}
         />
       )}
     </div>

--- a/apps/app/src/client/components/PageControls/PagePermissionModal.spec.tsx
+++ b/apps/app/src/client/components/PageControls/PagePermissionModal.spec.tsx
@@ -1,0 +1,105 @@
+import { PageWriteGrant } from '@growi/core';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { mock } from 'vitest-mock-extended';
+
+import { PagePermissionModal } from './PagePermissionModal';
+
+const mocks = vi.hoisted(() => ({
+  apiv3PutMock: vi.fn(),
+}));
+
+vi.mock('~/client/util/apiv3-client', () => ({
+  apiv3Put: mocks.apiv3PutMock,
+}));
+
+vi.mock('~/client/util/toastr', () => ({
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock('~/stores/page', () => ({
+  useSWRxCurrentGrantData: vi.fn(),
+}));
+
+import { useSWRxCurrentGrantData } from '~/stores/page';
+
+describe('PagePermissionModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should initialize writeGrant from currentGrantData', () => {
+    const currentGrantData = {
+      isGrantNormalized: true,
+      grantData: {
+        isForbidden: false,
+        currentPageGrant: {
+          grant: 1,
+          groupGrantData: {
+            userRelatedGroups: [],
+            nonUserRelatedGrantedGroups: [],
+          },
+        },
+        currentPageWriteGrant: {
+          writeGrant: PageWriteGrant.WRITE_GRANT_OWNER,
+          groupGrantData: {
+            userRelatedGroups: [],
+            nonUserRelatedGrantedGroups: [],
+          },
+        },
+        parentPageGrant: null,
+      },
+    };
+    (useSWRxCurrentGrantData as any).mockReturnValue({
+      data: currentGrantData,
+    });
+
+    render(<PagePermissionModal isOpen pageId="page-id" onClose={() => {}} />);
+
+    expect(screen.getByLabelText(/write_grant.owner/i)).toBeChecked();
+    expect(screen.getByLabelText(/write_grant.public/i)).not.toBeChecked();
+  });
+
+  it('should call apiv3Put with selected grants when saving', async () => {
+    const currentGrantData = {
+      isGrantNormalized: true,
+      grantData: {
+        isForbidden: false,
+        currentPageGrant: {
+          grant: 1,
+          groupGrantData: {
+            userRelatedGroups: [],
+            nonUserRelatedGrantedGroups: [],
+          },
+        },
+        currentPageWriteGrant: {
+          writeGrant: PageWriteGrant.WRITE_GRANT_PUBLIC,
+          groupGrantData: {
+            userRelatedGroups: [],
+            nonUserRelatedGrantedGroups: [],
+          },
+        },
+        parentPageGrant: null,
+      },
+    };
+    (useSWRxCurrentGrantData as any).mockReturnValue({
+      data: currentGrantData,
+    });
+
+    mocks.apiv3PutMock.mockResolvedValue({});
+
+    render(<PagePermissionModal isOpen pageId="page-id" onClose={() => {}} />);
+
+    fireEvent.click(screen.getByLabelText(/write_grant.owner/i));
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(mocks.apiv3PutMock).toHaveBeenCalledWith(
+        '/page/page-id/write-grant',
+        expect.objectContaining({
+          writeGrant: PageWriteGrant.WRITE_GRANT_OWNER,
+        }),
+      );
+    });
+  });
+});

--- a/apps/app/src/client/components/PageControls/PagePermissionModal.tsx
+++ b/apps/app/src/client/components/PageControls/PagePermissionModal.tsx
@@ -1,0 +1,227 @@
+import { useCallback, useEffect, useState } from 'react';
+import { type IGrantedGroup, PageGrant, PageWriteGrant } from '@growi/core';
+import { useTranslation } from 'next-i18next';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from 'reactstrap';
+
+import { apiv3Put } from '~/client/util/apiv3-client';
+import { toastError, toastSuccess } from '~/client/util/toastr';
+import { useSWRxCurrentGrantData } from '~/stores/page';
+
+type Props = {
+  isOpen: boolean;
+  pageId: string;
+  onClose: () => void;
+};
+
+type ReadGrantOption = {
+  value: PageGrant;
+  labelKey: string;
+  icon: string;
+};
+
+type WriteGrantOption = {
+  value: PageWriteGrant;
+  labelKey: string;
+  icon: string;
+};
+
+const READ_GRANT_OPTIONS: ReadGrantOption[] = [
+  {
+    value: PageGrant.GRANT_PUBLIC,
+    labelKey: 'page_permission.read_grant.public',
+    icon: 'group',
+  },
+  {
+    value: PageGrant.GRANT_RESTRICTED,
+    labelKey: 'page_permission.read_grant.restricted',
+    icon: 'link',
+  },
+  {
+    value: PageGrant.GRANT_OWNER,
+    labelKey: 'page_permission.read_grant.owner',
+    icon: 'lock',
+  },
+  {
+    value: PageGrant.GRANT_USER_GROUP,
+    labelKey: 'page_permission.read_grant.user_group',
+    icon: 'more_horiz',
+  },
+];
+
+const WRITE_GRANT_OPTIONS: WriteGrantOption[] = [
+  {
+    value: PageWriteGrant.WRITE_GRANT_PUBLIC,
+    labelKey: 'page_permission.write_grant.public',
+    icon: 'edit_note',
+  },
+  {
+    value: PageWriteGrant.WRITE_GRANT_OWNER,
+    labelKey: 'page_permission.write_grant.owner',
+    icon: 'lock',
+  },
+  {
+    value: PageWriteGrant.WRITE_GRANT_USER_GROUP,
+    labelKey: 'page_permission.write_grant.user_group',
+    icon: 'more_horiz',
+  },
+];
+
+export const PagePermissionModal = ({
+  isOpen,
+  pageId,
+  onClose,
+}: Props): JSX.Element => {
+  const { t } = useTranslation();
+
+  const [readGrant, setReadGrant] = useState<PageGrant>(PageGrant.GRANT_PUBLIC);
+  const [writeGrant, setWriteGrant] = useState<PageWriteGrant>(
+    PageWriteGrant.WRITE_GRANT_PUBLIC,
+  );
+  const [readGrantedGroups, setReadGrantedGroups] = useState<IGrantedGroup[]>(
+    [],
+  );
+  const [writeGrantedGroups, setWriteGrantedGroups] = useState<IGrantedGroup[]>(
+    [],
+  );
+
+  const { data: currentGrantData } = useSWRxCurrentGrantData(
+    isOpen ? pageId : null,
+  );
+
+  useEffect(() => {
+    if (currentGrantData == null) return;
+    const { currentPageGrant, currentPageWriteGrant } =
+      currentGrantData.grantData;
+    setReadGrant(currentPageGrant.grant);
+    setReadGrantedGroups(
+      currentPageGrant.groupGrantData?.userRelatedGroups
+        .filter((g) => g.status === 'isGranted')
+        .map((g) => ({ item: g.id, type: g.type }) as IGrantedGroup) ?? [],
+    );
+    setWriteGrant(currentPageWriteGrant.writeGrant);
+    setWriteGrantedGroups(
+      currentPageWriteGrant.groupGrantData?.userRelatedGroups
+        .filter((g) => g.status === 'isGranted')
+        .map((g) => ({ item: g.id, type: g.type }) as IGrantedGroup) ?? [],
+    );
+  }, [currentGrantData]);
+
+  const handleSave = useCallback(async () => {
+    try {
+      await apiv3Put(`/page/${pageId}/grant`, {
+        grant: readGrant,
+        userRelatedGrantedGroups:
+          readGrantedGroups.length > 0 ? readGrantedGroups : null,
+      });
+      await apiv3Put(`/page/${pageId}/write-grant`, {
+        writeGrant,
+        writeGrantUserGroupIds:
+          writeGrantedGroups.length > 0 ? writeGrantedGroups : null,
+      });
+      toastSuccess(t('Successfully updated'));
+      onClose();
+    } catch (err) {
+      toastError(t('Failed to update'));
+    }
+  }, [
+    pageId,
+    readGrant,
+    readGrantedGroups,
+    writeGrant,
+    writeGrantedGroups,
+    onClose,
+    t,
+  ]);
+
+  return (
+    <Modal size="lg" isOpen={isOpen} toggle={onClose}>
+      <ModalHeader tag="h4" toggle={onClose}>
+        {t('page_permission.title')}
+      </ModalHeader>
+      <ModalBody>
+        <h6 className="text-muted mb-3">
+          {t('page_permission.read_permission_section')}
+        </h6>
+        <div className="mb-4">
+          {READ_GRANT_OPTIONS.map((option) => (
+            <div className="form-check mb-2" key={option.value}>
+              <input
+                className="form-check-input"
+                type="radio"
+                name="readGrant"
+                id={`readGrant-${option.value}`}
+                checked={readGrant === option.value}
+                onChange={() => setReadGrant(option.value)}
+              />
+              <label
+                className="form-check-label"
+                htmlFor={`readGrant-${option.value}`}
+              >
+                <span className="material-symbols-outlined me-1 align-middle">
+                  {option.icon}
+                </span>
+                {t(option.labelKey)}
+              </label>
+            </div>
+          ))}
+        </div>
+
+        <hr />
+
+        <h6 className="text-muted mb-3">
+          {t('page_permission.write_permission_section')}
+        </h6>
+        <div className="mb-3">
+          {WRITE_GRANT_OPTIONS.map((option) => (
+            <div className="form-check mb-2" key={option.value}>
+              <input
+                className="form-check-input"
+                type="radio"
+                name="writeGrant"
+                id={`writeGrant-${option.value}`}
+                checked={writeGrant === option.value}
+                onChange={() => setWriteGrant(option.value)}
+              />
+              <label
+                className="form-check-label"
+                htmlFor={`writeGrant-${option.value}`}
+              >
+                <span className="material-symbols-outlined me-1 align-middle">
+                  {option.icon}
+                </span>
+                {t(option.labelKey)}
+              </label>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-3 p-3 border rounded">
+          <small>
+            {t('page_permission.current_summary', {
+              readGrant: t(
+                READ_GRANT_OPTIONS.find((o) => o.value === readGrant)
+                  ?.labelKey ?? '',
+              ),
+              writeGrant: t(
+                WRITE_GRANT_OPTIONS.find((o) => o.value === writeGrant)
+                  ?.labelKey ?? '',
+              ),
+            })}
+          </small>
+        </div>
+      </ModalBody>
+      <ModalFooter>
+        <button
+          type="button"
+          className="btn btn-outline-secondary"
+          onClick={onClose}
+        >
+          {t('Cancel')}
+        </button>
+        <button type="button" className="btn btn-primary" onClick={handleSave}>
+          {t('Save')}
+        </button>
+      </ModalFooter>
+    </Modal>
+  );
+};

--- a/apps/app/src/interfaces/page-grant.ts
+++ b/apps/app/src/interfaces/page-grant.ts
@@ -1,9 +1,9 @@
-import type { GroupType, PageGrant } from '@growi/core';
+import type { GroupType, PageGrant, PageWriteGrant } from '@growi/core';
 
 import type { ExternalUserGroupDocument } from '~/features/external-user-group/server/models/external-user-group';
 import type { UserGroupDocument } from '~/server/models/user-group';
 
-import type { IPageGrantData } from './page';
+import type { IPageGrantData, IPageWriteGrantData } from './page';
 
 type UserGroupType = typeof GroupType.userGroup;
 type ExternalUserGroupType = typeof GroupType.externalUserGroup;
@@ -24,6 +24,7 @@ export type IResApplicableGrant = {
 export type IResGrantData = {
   isForbidden: boolean;
   currentPageGrant: IPageGrantData;
+  currentPageWriteGrant: IPageWriteGrantData;
   parentPageGrant?: IPageGrantData;
 };
 export type IResCurrentGrantData = {

--- a/apps/app/src/interfaces/page.ts
+++ b/apps/app/src/interfaces/page.ts
@@ -5,6 +5,7 @@ import type {
   Nullable,
   Origin,
   PageGrant,
+  PageWriteGrant,
 } from '@growi/core';
 
 import type { ExternalGroupProviderType } from '~/features/external-user-group/interfaces/external-user-group';
@@ -63,6 +64,11 @@ export type IPageGrantData = {
   grant: PageGrant;
   groupGrantData?: GroupGrantData;
 };
+// current write grant data of page
+export type IPageWriteGrantData = {
+  writeGrant: PageWriteGrant;
+  groupGrantData?: GroupGrantData;
+};
 // grant selected by user which is not yet applied
 export type IPageSelectedGrant = {
   grant: PageGrant;
@@ -89,6 +95,8 @@ export type IOptionsForUpdate = {
   userRelatedGrantUserGroupIds?: IGrantedGroup[];
   // isSyncRevisionToHackmd?: boolean,
   overwriteScopesOfDescendants?: boolean;
+
+  readOnlyUserIds?: string[];
 };
 
 export type IOptionsForCreate = {
@@ -99,6 +107,8 @@ export type IOptionsForCreate = {
 
   origin?: Origin;
   wip?: boolean;
+
+  readOnlyUserIds?: string[];
 };
 
 export type IPagePathWithDescendantCount = {

--- a/apps/app/src/server/models/page.ts
+++ b/apps/app/src/server/models/page.ts
@@ -251,6 +251,37 @@ const schema = new Schema<PageDocument, PageModel>(
       default: [],
       required: true,
     },
+    writeGrant: { type: Number, default: 1, index: true },
+    writeGrantedUsers: [{ type: Schema.Types.ObjectId, ref: 'User' }],
+    writeGrantedGroups: {
+      type: [
+        {
+          type: {
+            type: String,
+            enum: Object.values(GroupType),
+            required: true,
+            default: 'UserGroup',
+          },
+          item: {
+            type: Schema.Types.ObjectId,
+            refPath: 'writeGrantedGroups.type',
+            required: true,
+            index: true,
+          },
+        },
+      ],
+      validate: [
+        (arr) => {
+          if (arr == null) return true;
+          const uniqueItemValues = new Set(arr.map((e) => e.item));
+          return arr.length === uniqueItemValues.size;
+        },
+        'writeGrantedGroups contains non unique item',
+      ],
+      default: [],
+      required: true,
+    },
+    readOnlyUserIds: [{ type: Schema.Types.ObjectId, ref: 'User' }],
     creator: { type: Schema.Types.ObjectId, ref: 'User', index: true },
     lastUpdateUser: { type: Schema.Types.ObjectId, ref: 'User' },
     liker: [{ type: Schema.Types.ObjectId, ref: 'User' }],

--- a/apps/app/src/server/routes/apiv3/page/get-page-info.integ.ts
+++ b/apps/app/src/server/routes/apiv3/page/get-page-info.integ.ts
@@ -109,6 +109,7 @@ describe('GET /info', () => {
         isDeletable: false,
         isAbleToDeleteCompletely: false,
         isRevertible: false,
+        isEditable: false,
         bookmarkCount: 0,
       } satisfies PageInfoExt,
     });

--- a/apps/app/src/server/routes/apiv3/page/index.ts
+++ b/apps/app/src/server/routes/apiv3/page/index.ts
@@ -28,7 +28,7 @@ import path from 'pathe';
 import sanitize from 'sanitize-filename';
 
 import { SupportedAction, SupportedTargetModel } from '~/interfaces/activity';
-import type { IPageGrantData } from '~/interfaces/page';
+import type { IPageGrantData, IPageWriteGrantData } from '~/interfaces/page';
 import type { IRecordApplicableGrant } from '~/interfaces/page-grant';
 import type Crowi from '~/server/crowi';
 import { accessTokenParser } from '~/server/middlewares/access-token-parser';
@@ -125,6 +125,20 @@ module.exports = (crowi: Crowi) => {
       body('grantedGroups.*.item')
         .isMongoId()
         .withMessage('grantedGroups item is required'),
+    ],
+    updateWriteGrant: [
+      param('pageId').isMongoId().withMessage('pageId is required'),
+      body('writeGrant').isInt().withMessage('writeGrant is required'),
+      body('writeGrantUserGroupIds')
+        .optional()
+        .isArray()
+        .withMessage('writeGrantUserGroupIds must be an array'),
+      body('writeGrantUserGroupIds.*.type')
+        .isString()
+        .withMessage('writeGrantUserGroupIds type is required'),
+      body('writeGrantUserGroupIds.*.item')
+        .isMongoId()
+        .withMessage('writeGrantUserGroupIds item is required'),
     ],
     export: [
       query('format').isString().isIn(['md', 'pdf']),
@@ -575,12 +589,16 @@ module.exports = (crowi: Crowi) => {
         grant: page.grant,
         groupGrantData: currentPageGroupGrantData,
       };
+      const currentPageWriteGrant: IPageWriteGrantData = {
+        writeGrant: page.writeGrant,
+      };
 
       // page doesn't have parent page
       if (page.parent == null) {
         const grantData = {
           isForbidden: false,
           currentPageGrant,
+          currentPageWriteGrant,
           parentPageGrant: null,
         };
         return res.apiv3({ isGrantNormalized, grantData });
@@ -598,6 +616,7 @@ module.exports = (crowi: Crowi) => {
         const grantData = {
           isForbidden: true,
           currentPageGrant,
+          currentPageWriteGrant,
           parentPageGrant: null,
         };
         return res.apiv3({ isGrantNormalized, grantData });
@@ -613,6 +632,7 @@ module.exports = (crowi: Crowi) => {
       const grantData = {
         isForbidden: false,
         currentPageGrant,
+        currentPageWriteGrant,
         parentPageGrant,
       };
 
@@ -853,6 +873,18 @@ module.exports = (crowi: Crowi) => {
         );
       }
 
+      const userRelatedGroups =
+        await crowi.pageGrantService.getUserRelatedGroups(req.user);
+      if (!crowi.pageService.canEdit(page, req.user, userRelatedGroups)) {
+        return res.apiv3Err(
+          new ErrorV3(
+            'You do not have permission to edit this page.',
+            'forbidden',
+          ),
+          403,
+        );
+      }
+
       let data: PageDocument;
       try {
         const grantData = { grant, userRelatedGrantedGroups };
@@ -862,6 +894,60 @@ module.exports = (crowi: Crowi) => {
           'Error occurred while processing calcApplicableGrantData.',
           err,
         );
+        return res.apiv3Err(err, 500);
+      }
+
+      return res.apiv3(data);
+    },
+  );
+
+  router.put(
+    '/:pageId/write-grant',
+    accessTokenParser([SCOPE.WRITE.FEATURES.PAGE]),
+    loginRequiredStrictly,
+    excludeReadOnlyUser,
+    validator.updateWriteGrant,
+    apiV3FormValidator,
+    async (req, res) => {
+      const { pageId } = req.params;
+      const { writeGrant, writeGrantUserGroupIds } = req.body;
+
+      const Page = mongoose.model<IPage, PageModel>('Page');
+
+      const page = await Page.findByIdAndViewer(pageId, req.user, null, false);
+
+      if (page == null) {
+        return res.apiv3Err(
+          new ErrorV3(
+            'Page is unreachable or empty.',
+            'page_unreachable_or_empty',
+          ),
+          400,
+        );
+      }
+
+      const userRelatedGroups =
+        await crowi.pageGrantService.getUserRelatedGroups(req.user);
+      if (!crowi.pageService.canEdit(page, req.user, userRelatedGroups)) {
+        return res.apiv3Err(
+          new ErrorV3(
+            'You do not have permission to edit this page.',
+            'forbidden',
+          ),
+          403,
+        );
+      }
+
+      let data: PageDocument;
+      try {
+        const writeGrantData = { writeGrant, writeGrantUserGroupIds };
+        data = await crowi.pageService.updateWriteGrant(
+          page,
+          req.user,
+          writeGrantData,
+        );
+      } catch (err) {
+        logger.error('Error occurred while updating write grant.', err);
         return res.apiv3Err(err, 500);
       }
 
@@ -1001,6 +1087,58 @@ module.exports = (crowi: Crowi) => {
       await crowi.activityService.createActivity(parameters);
 
       await pipeline(stream, res);
+    },
+  );
+
+  router.put(
+    '/:pageId/read-only-users',
+    accessTokenParser([SCOPE.WRITE.FEATURES.PAGE]),
+    loginRequiredStrictly,
+    excludeReadOnlyUser,
+    apiV3FormValidator,
+    async (req, res) => {
+      const { pageId } = req.params;
+      const { readOnlyUserIds } = req.body;
+
+      const Page = mongoose.model<IPage, PageModel>('Page');
+
+      const page = await Page.findByIdAndViewer(pageId, req.user, null, false);
+
+      if (page == null) {
+        return res.apiv3Err(
+          new ErrorV3(
+            'Page is unreachable or empty.',
+            'page_unreachable_or_empty',
+          ),
+          400,
+        );
+      }
+
+      const userRelatedGroups =
+        await crowi.pageGrantService.getUserRelatedGroups(req.user);
+      if (!crowi.pageService.canEdit(page, req.user, userRelatedGroups)) {
+        return res.apiv3Err(
+          new ErrorV3(
+            'You do not have permission to edit this page.',
+            'forbidden',
+          ),
+          403,
+        );
+      }
+
+      let data: PageDocument;
+      try {
+        data = await crowi.pageService.updateReadOnlyUsers(
+          page,
+          req.user,
+          readOnlyUserIds ?? [],
+        );
+      } catch (err) {
+        logger.error('Error occurred while updating read-only users.', err);
+        return res.apiv3Err(err, 500);
+      }
+
+      return res.apiv3(data);
     },
   );
 

--- a/apps/app/src/server/routes/apiv3/page/read-only-users.integ.ts
+++ b/apps/app/src/server/routes/apiv3/page/read-only-users.integ.ts
@@ -1,0 +1,188 @@
+import { PageWriteGrant } from '@growi/core';
+import type { NextFunction, Request, Response } from 'express';
+import express from 'express';
+import mockRequire from 'mock-require';
+import mongoose from 'mongoose';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { getInstance } from '^/test/setup/crowi';
+
+import type { ApiV3Response } from '../interfaces/apiv3-response';
+
+const passthroughMiddleware = (
+  _req: Request,
+  _res: Response,
+  next: NextFunction,
+) => next();
+
+vi.mock('~/server/middlewares/access-token-parser', () => ({
+  accessTokenParser: () => passthroughMiddleware,
+}));
+vi.mock('~/server/middlewares/login-required', () => ({
+  default: () => (req: Request, _res: Response, next: NextFunction) => next(),
+}));
+vi.mock('~/server/middlewares/exclude-read-only-user', () => ({
+  excludeReadOnlyUser: (_req: Request, _res: Response, next: NextFunction) =>
+    next(),
+}));
+
+describe('PUT /:pageId/read-only-users', () => {
+  let crowi: Awaited<ReturnType<typeof getInstance>>;
+  let User: mongoose.Model<any>;
+  let Page: mongoose.Model<any>;
+  let user1: any;
+  let user2: any;
+  let testPage: any;
+  let pageRouterFactory: any;
+
+  const createApp = async (user: any) => {
+    if (pageRouterFactory == null) {
+      const pageModule = await import('./index');
+      pageRouterFactory = (pageModule as any).default;
+    }
+
+    const app = express();
+    app.use(express.json());
+
+    app.use((_req: Request, res: ApiV3Response, next: NextFunction) => {
+      res.apiv3 = (data: any) => res.json(data);
+      res.apiv3Err = (error: any, statusCode?: number) => {
+        const status = statusCode ?? (Array.isArray(error) ? 400 : 500);
+        return res.status(status).json({ error: String(error) });
+      };
+      next();
+    });
+
+    app.use((req: any, _res: Response, next: NextFunction) => {
+      req.user = user;
+      req.crowi = crowi;
+      next();
+    });
+
+    const pageRouter = pageRouterFactory(crowi);
+    app.use('/', pageRouter);
+
+    return app;
+  };
+
+  beforeAll(async () => {
+    crowi = await getInstance();
+    User = mongoose.model('User');
+    Page = mongoose.model('Page');
+
+    user1 = await User.create({
+      name: 'User1',
+      username: 'user1',
+      email: 'user1@example.com',
+    });
+    user2 = await User.create({
+      name: 'User2',
+      username: 'user2',
+      email: 'user2@example.com',
+    });
+
+    const GRANT_PUBLIC = 1;
+
+    const existingRootPage = await Page.findOne({ path: '/' });
+    if (existingRootPage == null) {
+      await Page.create({ path: '/', grant: GRANT_PUBLIC });
+    }
+
+    testPage = await Page.create({
+      path: '/test-read-only-page',
+      grant: GRANT_PUBLIC,
+      creator: user1._id,
+      lastUpdateUser: user1._id,
+    });
+
+    mockRequire(
+      '../../../middlewares/certify-shared-page',
+      () => passthroughMiddleware,
+    );
+  });
+
+  afterAll(() => {
+    mockRequire.stopAll();
+  });
+
+  it('should set readOnlyUserIds for a page', async () => {
+    const app = await createApp(user1);
+    await Page.updateOne(
+      { _id: testPage._id },
+      { $set: { readOnlyUserIds: [] } },
+    );
+
+    const response = await request(app)
+      .put(`/${testPage._id}/read-only-users`)
+      .send({ readOnlyUserIds: [String(user2._id)] });
+
+    expect(response.status).toBe(200);
+
+    const updatedPage = await Page.findById(testPage._id);
+    const userIds = (updatedPage.readOnlyUserIds ?? []).map((id: any) =>
+      String(id),
+    );
+    expect(userIds).toContain(String(user2._id));
+  });
+
+  it('should clear readOnlyUserIds when empty array is sent', async () => {
+    const app = await createApp(user1);
+    await Page.updateOne(
+      { _id: testPage._id },
+      { $set: { readOnlyUserIds: [user2._id] } },
+    );
+
+    const response = await request(app)
+      .put(`/${testPage._id}/read-only-users`)
+      .send({ readOnlyUserIds: [] });
+
+    expect(response.status).toBe(200);
+
+    const updatedPage = await Page.findById(testPage._id);
+    expect(updatedPage.readOnlyUserIds).toEqual([]);
+  });
+
+  it('should set multiple readOnly users', async () => {
+    const app = await createApp(user1);
+    const response = await request(app)
+      .put(`/${testPage._id}/read-only-users`)
+      .send({ readOnlyUserIds: [String(user1._id), String(user2._id)] });
+
+    expect(response.status).toBe(200);
+
+    const updatedPage = await Page.findById(testPage._id);
+    expect(updatedPage.readOnlyUserIds).toHaveLength(2);
+  });
+
+  it('should return 400 for non-existent pageId', async () => {
+    const app = await createApp(user1);
+    const fakeId = new mongoose.Types.ObjectId();
+    const response = await request(app)
+      .put(`/${fakeId}/read-only-users`)
+      .send({ readOnlyUserIds: [] });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toContain('unreachable');
+  });
+
+  it('should return 403 when the user cannot edit the page', async () => {
+    await Page.updateOne(
+      { _id: testPage._id },
+      {
+        $set: {
+          writeGrant: PageWriteGrant.WRITE_GRANT_OWNER,
+          writeGrantedUsers: [user2._id],
+        },
+      },
+    );
+
+    const app = await createApp(user1);
+    const response = await request(app)
+      .put(`/${testPage._id}/read-only-users`)
+      .send({ readOnlyUserIds: [] });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toContain('permission');
+  });
+});

--- a/apps/app/src/server/routes/apiv3/page/respond-with-single-page.spec.ts
+++ b/apps/app/src/server/routes/apiv3/page/respond-with-single-page.spec.ts
@@ -53,6 +53,7 @@ function createPageInfo(overrides: Partial<IPageInfo> = {}): IPageInfo {
     isDeletable: true,
     isAbleToDeleteCompletely: true,
     isRevertible: false,
+    isEditable: true,
     bookmarkCount: 0,
     ...overrides,
   };

--- a/apps/app/src/server/routes/apiv3/page/update-page.integ.ts
+++ b/apps/app/src/server/routes/apiv3/page/update-page.integ.ts
@@ -1,0 +1,160 @@
+import { PageWriteGrant } from '@growi/core';
+import type { NextFunction, Request, Response } from 'express';
+import express from 'express';
+import mockRequire from 'mock-require';
+import mongoose from 'mongoose';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { getInstance } from '^/test/setup/crowi';
+
+import type { ApiV3Response } from '../interfaces/apiv3-response';
+
+const passthroughMiddleware = (
+  _req: Request,
+  _res: Response,
+  next: NextFunction,
+) => next();
+
+vi.mock('~/server/middlewares/access-token-parser', () => ({
+  accessTokenParser: () => passthroughMiddleware,
+}));
+vi.mock('~/server/middlewares/login-required', () => ({
+  default: () => (req: Request, _res: Response, next: NextFunction) => next(),
+}));
+vi.mock('~/server/middlewares/exclude-read-only-user', () => ({
+  excludeReadOnlyUser: (_req: Request, _res: Response, next: NextFunction) =>
+    next(),
+}));
+
+describe('PUT /page (update-page)', () => {
+  let crowi: Awaited<ReturnType<typeof getInstance>>;
+  let User: mongoose.Model<any>;
+  let Page: mongoose.Model<any>;
+  let Revision: mongoose.Model<any>;
+  let user1: any;
+  let user2: any;
+  let testPage: any;
+  let testRevision: any;
+  let pageRouterFactory: any;
+
+  const createApp = async (user: any) => {
+    if (pageRouterFactory == null) {
+      const pageModule = await import('./index');
+      pageRouterFactory = (pageModule as any).default;
+    }
+
+    const app = express();
+    app.use(express.json());
+
+    app.use((_req: Request, res: ApiV3Response, next: NextFunction) => {
+      res.apiv3 = (data: any) => res.json(data);
+      res.apiv3Err = (error: any, statusCode?: number) => {
+        const status = statusCode ?? (Array.isArray(error) ? 400 : 500);
+        return res.status(status).json({ error: String(error) });
+      };
+      next();
+    });
+
+    app.use((req: any, _res: Response, next: NextFunction) => {
+      req.user = user;
+      req.crowi = crowi;
+      next();
+    });
+
+    const pageRouter = pageRouterFactory(crowi);
+    app.use('/', pageRouter);
+
+    return app;
+  };
+
+  beforeAll(async () => {
+    crowi = await getInstance();
+    User = mongoose.model('User');
+    Page = mongoose.model('Page');
+    Revision = mongoose.model('Revision');
+
+    user1 = await User.create({
+      name: 'User1',
+      username: 'user1',
+      email: 'user1@example.com',
+    });
+    user2 = await User.create({
+      name: 'User2',
+      username: 'user2',
+      email: 'user2@example.com',
+    });
+
+    const existingRootPage = await Page.findOne({ path: '/' });
+    if (existingRootPage == null) {
+      await Page.create({ path: '/', grant: 1 });
+    }
+
+    testPage = await Page.create({
+      path: '/test-update-page',
+      grant: 1,
+      creator: user1._id,
+      lastUpdateUser: user1._id,
+    });
+
+    testRevision = await Revision.create({
+      pageId: testPage._id,
+      body: 'initial body',
+      author: user1._id,
+    });
+
+    testPage.revision = testRevision._id;
+    await testPage.save();
+
+    mockRequire(
+      '../../../middlewares/certify-shared-page',
+      () => passthroughMiddleware,
+    );
+  });
+
+  afterAll(() => {
+    mockRequire.stopAll();
+  });
+
+  it('should return 403 when user is in readOnlyUserIds', async () => {
+    await Page.updateOne(
+      { _id: testPage._id },
+      { $set: { readOnlyUserIds: [user2._id] } },
+    );
+
+    const app = await createApp(user2);
+    const response = await request(app)
+      .put('/')
+      .send({
+        pageId: String(testPage._id),
+        body: 'malicious update',
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toContain('permission');
+  });
+
+  it('should return 403 when writeGrant is OWNER and user is not owner', async () => {
+    await Page.updateOne(
+      { _id: testPage._id },
+      {
+        $set: {
+          readOnlyUserIds: [],
+          writeGrant: PageWriteGrant.WRITE_GRANT_OWNER,
+          writeGrantedUsers: [user1._id],
+        },
+      },
+    );
+
+    const app = await createApp(user2);
+    const response = await request(app)
+      .put('/')
+      .send({
+        pageId: String(testPage._id),
+        body: 'malicious update',
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toContain('permission');
+  });
+});

--- a/apps/app/src/server/routes/apiv3/page/update-page.ts
+++ b/apps/app/src/server/routes/apiv3/page/update-page.ts
@@ -254,6 +254,20 @@ export const updatePageHandlersFactory = (crowi: Crowi): RequestHandler[] => {
         );
       }
 
+      const userRelatedGroups =
+        await crowi.pageGrantService.getUserRelatedGroups(req.user);
+      if (
+        !crowi.pageService.canEdit(currentPage, req.user, userRelatedGroups)
+      ) {
+        return res.apiv3Err(
+          new ErrorV3(
+            'You do not have permission to edit this page.',
+            'forbidden',
+          ),
+          403,
+        );
+      }
+
       const disableUserPages = configManager.getConfig(
         'security:disableUserPages',
       );

--- a/apps/app/src/server/routes/apiv3/page/write-grant.integ.ts
+++ b/apps/app/src/server/routes/apiv3/page/write-grant.integ.ts
@@ -1,0 +1,186 @@
+import { PageWriteGrant } from '@growi/core';
+import type { NextFunction, Request, Response } from 'express';
+import express from 'express';
+import mockRequire from 'mock-require';
+import mongoose from 'mongoose';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { getInstance } from '^/test/setup/crowi';
+
+import type { ApiV3Response } from '../interfaces/apiv3-response';
+
+const passthroughMiddleware = (
+  _req: Request,
+  _res: Response,
+  next: NextFunction,
+) => next();
+
+vi.mock('~/server/middlewares/access-token-parser', () => ({
+  accessTokenParser: () => passthroughMiddleware,
+}));
+vi.mock('~/server/middlewares/login-required', () => ({
+  default: () => (req: Request, _res: Response, next: NextFunction) => next(),
+}));
+vi.mock('~/server/middlewares/exclude-read-only-user', () => ({
+  excludeReadOnlyUser: (_req: Request, _res: Response, next: NextFunction) =>
+    next(),
+}));
+
+describe('PUT /:pageId/write-grant', () => {
+  let crowi: Awaited<ReturnType<typeof getInstance>>;
+  let User: mongoose.Model<any>;
+  let Page: mongoose.Model<any>;
+  let user1: any;
+  let user2: any;
+  let testPage: any;
+
+  let pageRouterFactory: any;
+
+  const createApp = async (user: any) => {
+    if (pageRouterFactory == null) {
+      const pageModule = await import('./index');
+      pageRouterFactory = (pageModule as any).default;
+    }
+
+    const app = express();
+    app.use(express.json());
+
+    app.use((_req: Request, res: ApiV3Response, next: NextFunction) => {
+      res.apiv3 = (data: any) => res.json(data);
+      res.apiv3Err = (error: any, statusCode?: number) => {
+        const status = statusCode ?? (Array.isArray(error) ? 400 : 500);
+        return res.status(status).json({ error: String(error) });
+      };
+      next();
+    });
+
+    app.use((req: any, _res: Response, next: NextFunction) => {
+      req.user = user;
+      req.crowi = crowi;
+      next();
+    });
+
+    const pageRouter = pageRouterFactory(crowi);
+    app.use('/', pageRouter);
+
+    return app;
+  };
+
+  beforeAll(async () => {
+    crowi = await getInstance();
+    User = mongoose.model('User');
+    Page = mongoose.model('Page');
+
+    user1 = await User.create({
+      name: 'User1',
+      username: 'user1',
+      email: 'user1@example.com',
+    });
+    user2 = await User.create({
+      name: 'User2',
+      username: 'user2',
+      email: 'user2@example.com',
+    });
+
+    const existingRootPage = await Page.findOne({ path: '/' });
+    if (existingRootPage == null) {
+      await Page.create({ path: '/', grant: 1 });
+    }
+
+    testPage = await Page.create({
+      path: '/test-write-grant-page',
+      grant: 1,
+      creator: user1._id,
+      lastUpdateUser: user1._id,
+    });
+
+    mockRequire(
+      '../../../middlewares/certify-shared-page',
+      () => passthroughMiddleware,
+    );
+  });
+
+  afterAll(() => {
+    mockRequire.stopAll();
+  });
+
+  it('should persist writeGrant to the page', async () => {
+    const app = await createApp(user1);
+    const response = await request(app)
+      .put(`/${testPage._id}/write-grant`)
+      .send({
+        writeGrant: PageWriteGrant.WRITE_GRANT_OWNER,
+        writeGrantUserGroupIds: [],
+      });
+
+    expect(response.status).toBe(200);
+
+    const updatedPage = await Page.findById(testPage._id);
+    expect(updatedPage.writeGrant).toBe(PageWriteGrant.WRITE_GRANT_OWNER);
+    expect(
+      updatedPage.writeGrantedUsers.map((id: any) => String(id)),
+    ).toContain(String(user1._id));
+  });
+
+  it('should persist WRITE_GRANT_PUBLIC', async () => {
+    await Page.updateOne(
+      { _id: testPage._id },
+      {
+        $set: {
+          writeGrant: PageWriteGrant.WRITE_GRANT_OWNER,
+          writeGrantedUsers: [user1._id],
+        },
+      },
+    );
+
+    const app = await createApp(user1);
+    const response = await request(app)
+      .put(`/${testPage._id}/write-grant`)
+      .send({
+        writeGrant: PageWriteGrant.WRITE_GRANT_PUBLIC,
+        writeGrantUserGroupIds: [],
+      });
+
+    expect(response.status).toBe(200);
+
+    const updatedPage = await Page.findById(testPage._id);
+    expect(updatedPage.writeGrant).toBe(PageWriteGrant.WRITE_GRANT_PUBLIC);
+    expect(updatedPage.writeGrantedUsers).toEqual([]);
+  });
+
+  it('should return 400 for non-existent pageId', async () => {
+    const app = await createApp(user1);
+    const fakeId = new mongoose.Types.ObjectId();
+    const response = await request(app).put(`/${fakeId}/write-grant`).send({
+      writeGrant: PageWriteGrant.WRITE_GRANT_PUBLIC,
+      writeGrantUserGroupIds: [],
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toContain('unreachable');
+  });
+
+  it('should return 403 when the user cannot edit the page', async () => {
+    await Page.updateOne(
+      { _id: testPage._id },
+      {
+        $set: {
+          writeGrant: PageWriteGrant.WRITE_GRANT_OWNER,
+          writeGrantedUsers: [user1._id],
+        },
+      },
+    );
+
+    const app = await createApp(user2);
+    const response = await request(app)
+      .put(`/${testPage._id}/write-grant`)
+      .send({
+        writeGrant: PageWriteGrant.WRITE_GRANT_PUBLIC,
+        writeGrantUserGroupIds: [],
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toContain('permission');
+  });
+});

--- a/apps/app/src/server/service/page/can-edit.spec.ts
+++ b/apps/app/src/server/service/page/can-edit.spec.ts
@@ -1,0 +1,133 @@
+import { PageWriteGrant } from '@growi/core';
+
+import { canEditPage } from './can-edit';
+
+describe('canEditPage', () => {
+  const adminUser = { _id: 'admin-id' as any, admin: true };
+  const readOnlyUser = { _id: 'ro-id' as any, readOnly: true };
+  const normalUser = { _id: 'user-id' as any };
+  const otherUser = { _id: 'other-id' as any };
+  const groupA = 'group-a-id' as any;
+  const groupB = 'group-b-id' as any;
+
+  const makePage = (overrides = {}) => ({
+    writeGrant: PageWriteGrant.WRITE_GRANT_PUBLIC,
+    writeGrantedUsers: [],
+    writeGrantedGroups: [],
+    readOnlyUserIds: [],
+    ...overrides,
+  });
+
+  describe('null / admin / readOnly checks', () => {
+    it('should return false when user is null', () => {
+      expect(canEditPage({ user: null, page: makePage() })).toBe(false);
+    });
+
+    it('should return true when user is admin (ignores writeGrant)', () => {
+      const page = makePage({
+        writeGrant: PageWriteGrant.WRITE_GRANT_OWNER,
+        writeGrantedUsers: [otherUser._id],
+      });
+      expect(canEditPage({ user: adminUser, page })).toBe(true);
+    });
+
+    it('should return false when user is readOnly', () => {
+      const page = makePage({ writeGrant: PageWriteGrant.WRITE_GRANT_PUBLIC });
+      expect(canEditPage({ user: readOnlyUser, page })).toBe(false);
+    });
+  });
+
+  describe('readOnlyUserIds', () => {
+    it('should return false when user is in readOnlyUserIds', () => {
+      const page = makePage({ readOnlyUserIds: [normalUser._id, otherUser._id] });
+      expect(canEditPage({ user: normalUser, page })).toBe(false);
+    });
+
+    it('should return true when user is not in readOnlyUserIds', () => {
+      const page = makePage({ readOnlyUserIds: [otherUser._id] });
+      expect(canEditPage({ user: normalUser, page })).toBe(true);
+    });
+
+    it('should return true when readOnlyUserIds is empty', () => {
+      expect(canEditPage({ user: normalUser, page: makePage() })).toBe(true);
+    });
+  });
+
+  describe('WRITE_GRANT_PUBLIC', () => {
+    it('should return true for any user', () => {
+      const page = makePage({ writeGrant: PageWriteGrant.WRITE_GRANT_PUBLIC });
+      expect(canEditPage({ user: normalUser, page })).toBe(true);
+    });
+  });
+
+  describe('WRITE_GRANT_OWNER', () => {
+    it('should return true when user is in writeGrantedUsers', () => {
+      const page = makePage({
+        writeGrant: PageWriteGrant.WRITE_GRANT_OWNER,
+        writeGrantedUsers: [normalUser._id],
+      });
+      expect(canEditPage({ user: normalUser, page })).toBe(true);
+    });
+
+    it('should return false when user is NOT in writeGrantedUsers', () => {
+      const page = makePage({
+        writeGrant: PageWriteGrant.WRITE_GRANT_OWNER,
+        writeGrantedUsers: [otherUser._id],
+      });
+      expect(canEditPage({ user: normalUser, page })).toBe(false);
+    });
+
+    it('should return false when writeGrantedUsers is empty', () => {
+      const page = makePage({
+        writeGrant: PageWriteGrant.WRITE_GRANT_OWNER,
+        writeGrantedUsers: [],
+      });
+      expect(canEditPage({ user: normalUser, page })).toBe(false);
+    });
+  });
+
+  describe('WRITE_GRANT_USER_GROUP', () => {
+    it('should return true when user belongs to a granted group', () => {
+      const page = makePage({
+        writeGrant: PageWriteGrant.WRITE_GRANT_USER_GROUP,
+        writeGrantedGroups: [{ item: groupA }],
+      });
+      const userRelatedGroups = [{ item: { _id: groupA } }] as any;
+      expect(canEditPage({ user: normalUser, page, userRelatedGroups })).toBe(
+        true,
+      );
+    });
+
+    it('should return false when user does NOT belong to any granted group', () => {
+      const page = makePage({
+        writeGrant: PageWriteGrant.WRITE_GRANT_USER_GROUP,
+        writeGrantedGroups: [{ item: groupA }],
+      });
+      const userRelatedGroups = [{ item: { _id: groupB } }] as any;
+      expect(canEditPage({ user: normalUser, page, userRelatedGroups })).toBe(
+        false,
+      );
+    });
+
+    it('should return false when user has no groups but groups are required', () => {
+      const page = makePage({
+        writeGrant: PageWriteGrant.WRITE_GRANT_USER_GROUP,
+        writeGrantedGroups: [{ item: groupA }],
+      });
+      expect(
+        canEditPage({ user: normalUser, page, userRelatedGroups: [] }),
+      ).toBe(false);
+    });
+
+    it('should return true when user belongs to one of multiple granted groups', () => {
+      const page = makePage({
+        writeGrant: PageWriteGrant.WRITE_GRANT_USER_GROUP,
+        writeGrantedGroups: [{ item: groupA }, { item: groupB }],
+      });
+      const userRelatedGroups = [{ item: { _id: groupB } }] as any;
+      expect(canEditPage({ user: normalUser, page, userRelatedGroups })).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/apps/app/src/server/service/page/can-edit.ts
+++ b/apps/app/src/server/service/page/can-edit.ts
@@ -1,0 +1,64 @@
+import { PageWriteGrant } from '@growi/core';
+import type { Ref } from '@growi/core/dist/interfaces';
+
+import type { PopulatedGrantedGroup } from '~/interfaces/page-grant';
+import type { ObjectIdLike } from '~/server/interfaces/mongoose-utils';
+import type { PageDocument } from '~/server/models/page';
+
+function toStringId(id: unknown): string {
+  return (id as any)?.toString?.() ?? String(id);
+}
+
+export type CanEditParams = {
+  user:
+    | ({ _id: ObjectIdLike } & { admin?: boolean; readOnly?: boolean })
+    | null;
+  page: Pick<
+    PageDocument,
+    'writeGrant' | 'writeGrantedUsers' | 'writeGrantedGroups' | 'readOnlyUserIds'
+  >;
+  userRelatedGroups?: PopulatedGrantedGroup[];
+};
+
+export function canEditPage({
+  user,
+  page,
+  userRelatedGroups = [],
+}: CanEditParams): boolean {
+  if (user == null) return false;
+  if (user.admin) return true;
+  if (user.readOnly) return false;
+
+  // Check per-page readOnly
+  const readOnlyUserIds = page.readOnlyUserIds;
+  if (readOnlyUserIds != null && readOnlyUserIds.length > 0) {
+    const isReadOnlyForPage = readOnlyUserIds.some((readOnlyUserId) => {
+      const id = toStringId(readOnlyUserId);
+      return id === toStringId(user._id);
+    });
+    if (isReadOnlyForPage) return false;
+  }
+
+  const writeGrant = page.writeGrant ?? PageWriteGrant.WRITE_GRANT_PUBLIC;
+
+  switch (writeGrant) {
+    case PageWriteGrant.WRITE_GRANT_PUBLIC:
+      return true;
+    case PageWriteGrant.WRITE_GRANT_OWNER:
+      return (page.writeGrantedUsers ?? []).some((u) => {
+        const id = toStringId(u);
+        return id === toStringId(user._id);
+      });
+    case PageWriteGrant.WRITE_GRANT_USER_GROUP: {
+      const grantedGroupIds = (page.writeGrantedGroups ?? []).map((g) =>
+        toStringId(g.item),
+      );
+      const userGroupIds = userRelatedGroups.map((g) =>
+        toStringId(g.item._id ?? g.item),
+      );
+      return grantedGroupIds.some((id) => userGroupIds.includes(id));
+    }
+    default:
+      return false;
+  }
+}

--- a/apps/app/src/server/service/page/find-page-and-meta-data-by-viewer.ts
+++ b/apps/app/src/server/service/page/find-page-and-meta-data-by-viewer.ts
@@ -148,6 +148,7 @@ export async function findPageAndMetaDataByViewer(
       data: page,
       meta: {
         ...pageInfo,
+        isEditable: false,
         isDeletable: false,
         isAbleToDeleteCompletely: false,
       } satisfies IPageInfo,
@@ -170,6 +171,8 @@ export async function findPageAndMetaDataByViewer(
 
     return await pageService.isUsersHomepageOwnerAbsent(page.path);
   })();
+
+  const isEditable = pageService.canEdit(page, user, userRelatedGroups);
 
   const isDeletable =
     canDeleteUserHomepage &&
@@ -194,6 +197,7 @@ export async function findPageAndMetaDataByViewer(
       data: page,
       meta: {
         ...pageInfo,
+        isEditable,
         isDeletable,
         isAbleToDeleteCompletely,
         isBookmarked,
@@ -215,6 +219,7 @@ export async function findPageAndMetaDataByViewer(
     data: page,
     meta: {
       ...pageInfo,
+      isEditable,
       isDeletable,
       isAbleToDeleteCompletely,
       isBookmarked,

--- a/apps/app/src/server/service/page/index.ts
+++ b/apps/app/src/server/service/page/index.ts
@@ -16,7 +16,7 @@ import type {
   IUserHasId,
   Ref,
 } from '@growi/core/dist/interfaces';
-import { PageGrant } from '@growi/core/dist/interfaces';
+import { PageGrant, PageWriteGrant } from '@growi/core/dist/interfaces';
 import {
   escapeStringForMongoRegex,
   pagePathUtils,
@@ -85,6 +85,7 @@ import { configManager } from '../config-manager';
 import type { IPageGrantService } from '../page-grant';
 import { preNotifyService } from '../pre-notify';
 import { getYjsService } from '../yjs';
+import { canEditPage } from './can-edit';
 import { BULK_REINDEX_SIZE, LIMIT_FOR_MULTIPLE_PAGE_OP } from './consts';
 import { onSeen } from './events/seen';
 import type { IPageService } from './page-service';
@@ -376,6 +377,14 @@ class PageService implements IPageService {
       singleAuthority,
       recursiveAuthority,
     );
+  }
+
+  canEdit(
+    page: PageDocument,
+    user: { _id: ObjectIdLike; admin?: boolean; readOnly?: boolean } | null,
+    userRelatedGroups?: PopulatedGrantedGroup[],
+  ): boolean {
+    return canEditPage({ user, page, userRelatedGroups });
   }
 
   canDeleteUserHomepageByConfig(): boolean {
@@ -3295,6 +3304,7 @@ class PageService implements IPageService {
         isEmpty: true,
         isMovable,
         isRevertible: false,
+        isEditable: false,
       } satisfies IPageInfoBasicForEmpty;
     }
 
@@ -3316,6 +3326,7 @@ class PageService implements IPageService {
       commentCount: page.commentCount,
       // biome-ignore lint/style/noNonNullAssertion: the page must have a revision if it is not empty
       latestRevisionId: getIdStringForRef(page.revision!),
+      isEditable: false,
     } satisfies IPageInfoBasicForEntity;
 
     return infoForEntity;
@@ -5126,6 +5137,49 @@ class PageService implements IPageService {
     return this.updatePage(page, null, null, user, options);
   }
 
+  async updateWriteGrant(
+    page: HydratedDocument<PageDocument>,
+    user: IUserHasId,
+    writeGrantData: {
+      writeGrant: PageWriteGrant;
+      writeGrantUserGroupIds?: IGrantedGroup[];
+    },
+  ): Promise<PageDocument> {
+    const { writeGrant, writeGrantUserGroupIds } = writeGrantData;
+
+    page.writeGrant = writeGrant;
+    page.lastUpdateUser = user;
+
+    switch (writeGrant) {
+      case PageWriteGrant.WRITE_GRANT_PUBLIC:
+        page.writeGrantedUsers = [];
+        page.writeGrantedGroups = [];
+        break;
+      case PageWriteGrant.WRITE_GRANT_OWNER:
+        page.writeGrantedUsers = [user._id];
+        page.writeGrantedGroups = [];
+        break;
+      case PageWriteGrant.WRITE_GRANT_USER_GROUP:
+        page.writeGrantedUsers = [];
+        page.writeGrantedGroups = writeGrantUserGroupIds ?? [];
+        break;
+      default:
+        throw new Error(`Invalid writeGrant: ${writeGrant}`);
+    }
+
+    return page.save();
+  }
+
+  async updateReadOnlyUsers(
+    page: HydratedDocument<PageDocument>,
+    user: IUserHasId,
+    readOnlyUserIds: string[],
+  ): Promise<PageDocument> {
+    page.readOnlyUserIds = readOnlyUserIds;
+    page.lastUpdateUser = user;
+    return page.save();
+  }
+
   async updatePageSubOperation(
     page,
     user,
@@ -5348,16 +5402,19 @@ class PageService implements IPageService {
       }
     } else {
       if (wasOnTree && isChildrenExist) {
-        // Update children's parent with new parent
-        const newParentForChildren = await Page.createEmptyPage(
-          clonedPageData.path,
-          clonedPageData.parent,
-          clonedPageData.descendantCount,
-        );
-        await Page.updateMany(
-          { parent: clonedPageData._id },
-          { parent: newParentForChildren._id },
-        );
+        if (clonedPageData.parent != null) {
+          // Update children's parent with new parent
+          const newParentForChildren = await Page.createEmptyPage(
+            clonedPageData.path,
+            clonedPageData.parent,
+            clonedPageData.descendantCount,
+          );
+          await Page.updateMany(
+            { parent: clonedPageData._id },
+            { parent: newParentForChildren._id },
+          );
+        }
+        // When parent is null (root page), children stay as direct children of root
       }
 
       newPageData.parent = null;
@@ -5383,6 +5440,9 @@ class PageService implements IPageService {
       );
       savedPage = await pushRevision(savedPage, newRevision, user);
       await savedPage.populateDataToShowRevision();
+    } else {
+      // populate revision for the event handler which requires populated revision
+      await savedPage.populate('revision');
     }
 
     this.pageEvent.emit('update', savedPage, user);
@@ -5482,6 +5542,8 @@ class PageService implements IPageService {
       );
       savedPage = await pushRevision(savedPage, newRevision, user);
       await savedPage.populateDataToShowRevision();
+    } else {
+      await savedPage.populate('revision');
     }
 
     // update scopes for descendants

--- a/apps/app/src/server/service/page/page-service.ts
+++ b/apps/app/src/server/service/page/page-service.ts
@@ -7,6 +7,7 @@ import type {
   IUser,
   IUserHasId,
   PageGrant,
+  PageWriteGrant,
 } from '@growi/core/dist/interfaces';
 import type { HydratedDocument, Types } from 'mongoose';
 
@@ -52,6 +53,24 @@ export interface IPageService {
     user: IUserHasId,
     grantData: { grant: PageGrant; userRelatedGrantedGroups: IGrantedGroup[] },
   ): Promise<PageDocument>;
+  updateReadOnlyUsers(
+    page: HydratedDocument<PageDocument>,
+    user: IUserHasId,
+    readOnlyUserIds: string[],
+  ): Promise<PageDocument>;
+  updateWriteGrant(
+    page: HydratedDocument<PageDocument>,
+    user: IUserHasId,
+    writeGrantData: {
+      writeGrant: PageWriteGrant;
+      writeGrantUserGroupIds?: IGrantedGroup[];
+    },
+  ): Promise<PageDocument>;
+  canEdit(
+    page: PageDocument,
+    user: { _id: ObjectIdLike; admin?: boolean; readOnly?: boolean } | null,
+    userRelatedGroups?: PopulatedGrantedGroup[],
+  ): boolean;
   deleteCompletelyOperation: (
     pageIds: ObjectIdLike[],
     pagePaths: string[],

--- a/apps/app/src/states/page/hooks.spec.tsx
+++ b/apps/app/src/states/page/hooks.spec.tsx
@@ -1,0 +1,94 @@
+import { renderHook } from '@testing-library/react';
+import { createStore, Provider } from 'jotai';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { _atomsForDerivedAbilities } from '../global';
+
+import { currentPageDataAtom } from './internal-atoms';
+
+import {
+  useCurrentPageReadOnlyUserIds,
+  useIsReadOnlyUserForPage,
+} from './hooks';
+
+describe('useCurrentPageReadOnlyUserIds', () => {
+  let store: ReturnType<typeof createStore>;
+
+  const renderHookWithProvider = () => {
+    return renderHook(() => useCurrentPageReadOnlyUserIds(), {
+      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
+  };
+
+  beforeEach(() => {
+    store = createStore();
+  });
+
+  it('should return empty array when no page data', () => {
+    const { result } = renderHookWithProvider();
+    expect(result.current).toEqual([]);
+  });
+
+  it('should return readOnlyUserIds from page data', () => {
+    store.set(currentPageDataAtom, {
+      readOnlyUserIds: ['user1', 'user2'],
+    } as any);
+    const { result } = renderHookWithProvider();
+    expect(result.current).toEqual(['user1', 'user2']);
+  });
+
+  it('should return empty array when readOnlyUserIds is undefined', () => {
+    store.set(currentPageDataAtom, {} as any);
+    const { result } = renderHookWithProvider();
+    expect(result.current).toEqual([]);
+  });
+});
+
+describe('useIsReadOnlyUserForPage', () => {
+  let store: ReturnType<typeof createStore>;
+
+  const renderHookWithProvider = () => {
+    return renderHook(() => useIsReadOnlyUserForPage(), {
+      wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+    });
+  };
+
+  beforeEach(() => {
+    store = createStore();
+    store.set(_atomsForDerivedAbilities.currentUserAtom, {
+      _id: 'currentUserId',
+      name: 'Test User',
+      username: 'testuser',
+      email: 'test@example.com',
+    } as any);
+  });
+
+  it('should return false when no page data', () => {
+    const { result } = renderHookWithProvider();
+    expect(result.current).toBe(false);
+  });
+
+  it('should return true when current user is in readOnlyUserIds', () => {
+    store.set(currentPageDataAtom, {
+      readOnlyUserIds: ['currentUserId', 'otherUser'],
+    } as any);
+    const { result } = renderHookWithProvider();
+    expect(result.current).toBe(true);
+  });
+
+  it('should return false when current user is not in readOnlyUserIds', () => {
+    store.set(currentPageDataAtom, {
+      readOnlyUserIds: ['otherUser1', 'otherUser2'],
+    } as any);
+    const { result } = renderHookWithProvider();
+    expect(result.current).toBe(false);
+  });
+
+  it('should return false when readOnlyUserIds is empty', () => {
+    store.set(currentPageDataAtom, {
+      readOnlyUserIds: [],
+    } as any);
+    const { result } = renderHookWithProvider();
+    expect(result.current).toBe(false);
+  });
+});

--- a/apps/app/src/states/page/hooks.ts
+++ b/apps/app/src/states/page/hooks.ts
@@ -7,7 +7,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { useAtomCallback } from 'jotai/utils';
 
 import { useIsGuestUser, useIsReadOnlyUser } from '../context';
-import { useCurrentPathname } from '../global';
+import { useCurrentPathname, useCurrentUser } from '../global';
 import {
   currentPageDataAtom,
   currentPageEmptyIdAtom,
@@ -117,9 +117,27 @@ export const useIsNotCreatable = (): boolean => {
 /**
  * Computed hook for checking if current page is editable
  */
+export const useCurrentPageReadOnlyUserIds = (): string[] => {
+  const currentPageData = useAtomValue(currentPageDataAtom);
+  return useMemo(() => {
+    return (currentPageData as any)?.readOnlyUserIds ?? [];
+  }, [currentPageData]);
+};
+
+export const useIsReadOnlyUserForPage = (): boolean => {
+  const currentUser = useCurrentUser();
+  const readOnlyUserIds = useCurrentPageReadOnlyUserIds();
+
+  return useMemo(() => {
+    if (currentUser == null) return false;
+    return readOnlyUserIds.some((userId) => userId === currentUser._id);
+  }, [currentUser, readOnlyUserIds]);
+};
+
 export const useIsEditable = () => {
   const isGuestUser = useIsGuestUser();
   const isReadOnlyUser = useIsReadOnlyUser();
+  const isReadOnlyUserForPage = useIsReadOnlyUserForPage();
   const isNotCreatable = useIsNotCreatable();
   const isForbidden = useAtomValue(isForbiddenAtom);
   const isIdenticalPath = useAtomValue(isIdenticalPathAtom);
@@ -128,6 +146,7 @@ export const useIsEditable = () => {
     return (
       !isGuestUser &&
       !isReadOnlyUser &&
+      !isReadOnlyUserForPage &&
       !isNotCreatable &&
       !isForbidden &&
       !isIdenticalPath
@@ -135,6 +154,7 @@ export const useIsEditable = () => {
   }, [
     isGuestUser,
     isReadOnlyUser,
+    isReadOnlyUserForPage,
     isNotCreatable,
     isForbidden,
     isIdenticalPath,

--- a/apps/app/src/states/page/use-fetch-current-page.spec.tsx
+++ b/apps/app/src/states/page/use-fetch-current-page.spec.tsx
@@ -7,6 +7,7 @@ import type {
   Lang,
   PageGrant,
   PageStatus,
+  PageWriteGrant,
 } from '@growi/core/dist/interfaces';
 import { act, renderHook, waitFor } from '@testing-library/react';
 // biome-ignore lint/style/noRestrictedImports: import only types
@@ -94,6 +95,10 @@ const createPageDataMock = (
     grant: 1 as PageGrant,
     grantedUsers: [],
     grantedGroups: [],
+    writeGrant: 1 as PageWriteGrant,
+    writeGrantedUsers: [],
+    writeGrantedGroups: [],
+    readOnlyUserIds: [],
     parent: null,
     descendantCount: 0,
     isEmpty: false,

--- a/packages/core/src/interfaces/page.spec.ts
+++ b/packages/core/src/interfaces/page.spec.ts
@@ -1,0 +1,181 @@
+import {
+  type IGrantedGroup,
+  type IPage,
+  type IPageInfo,
+  PageGrant,
+  PageWriteGrant,
+} from './page';
+
+describe('PageWriteGrant', () => {
+  it('should have WRITE_GRANT_PUBLIC with value 1', () => {
+    expect(PageWriteGrant.WRITE_GRANT_PUBLIC).toBe(1);
+  });
+
+  it('should have WRITE_GRANT_OWNER with value 2', () => {
+    expect(PageWriteGrant.WRITE_GRANT_OWNER).toBe(2);
+  });
+
+  it('should have WRITE_GRANT_USER_GROUP with value 4', () => {
+    expect(PageWriteGrant.WRITE_GRANT_USER_GROUP).toBe(4);
+  });
+
+  it('should have exactly 3 write grant constants', () => {
+    const keys = Object.keys(PageWriteGrant);
+    expect(keys).toHaveLength(3);
+    expect(keys).toEqual([
+      'WRITE_GRANT_PUBLIC',
+      'WRITE_GRANT_OWNER',
+      'WRITE_GRANT_USER_GROUP',
+    ]);
+  });
+});
+
+describe('IPage with write grant fields', () => {
+  it('should allow creating a page with write grant fields', () => {
+    const page: IPage = {
+      path: '/test',
+      status: 'published',
+      tags: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      seenUsers: [],
+      parent: null,
+      descendantCount: 0,
+      isEmpty: false,
+      grant: PageGrant.GRANT_PUBLIC,
+      grantedUsers: [],
+      grantedGroups: [],
+      liker: [],
+      commentCount: 0,
+      slackChannels: '',
+      deleteUser: null as any,
+      deletedAt: new Date(),
+      writeGrant: PageWriteGrant.WRITE_GRANT_PUBLIC,
+      writeGrantedUsers: [],
+      writeGrantedGroups: [],
+    };
+
+    expect(page.writeGrant).toBe(1);
+    expect(page.writeGrantedUsers).toEqual([]);
+    expect(page.writeGrantedGroups).toEqual([]);
+  });
+
+  it('should default writeGrant to WRITE_GRANT_PUBLIC', () => {
+    const page: IPage = {
+      path: '/test',
+      status: 'published',
+      tags: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      seenUsers: [],
+      parent: null,
+      descendantCount: 0,
+      isEmpty: false,
+      grant: PageGrant.GRANT_PUBLIC,
+      grantedUsers: [],
+      grantedGroups: [],
+      liker: [],
+      commentCount: 0,
+      slackChannels: '',
+      deleteUser: null as any,
+      deletedAt: new Date(),
+      writeGrant: PageWriteGrant.WRITE_GRANT_PUBLIC,
+      writeGrantedUsers: [],
+      writeGrantedGroups: [],
+    };
+
+    expect(page.writeGrant).toBe(PageWriteGrant.WRITE_GRANT_PUBLIC);
+  });
+
+  it('should accept WRITE_GRANT_OWNER with writeGrantedUsers', () => {
+    const page: IPage = {
+      path: '/test',
+      status: 'published',
+      tags: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      seenUsers: [],
+      parent: null,
+      descendantCount: 0,
+      isEmpty: false,
+      grant: PageGrant.GRANT_PUBLIC,
+      grantedUsers: [],
+      grantedGroups: [],
+      liker: [],
+      commentCount: 0,
+      slackChannels: '',
+      deleteUser: null as any,
+      deletedAt: new Date(),
+      writeGrant: PageWriteGrant.WRITE_GRANT_OWNER,
+      writeGrantedUsers: ['user123' as any],
+      writeGrantedGroups: [],
+    };
+
+    expect(page.writeGrant).toBe(PageWriteGrant.WRITE_GRANT_OWNER);
+    expect(page.writeGrantedUsers).toHaveLength(1);
+  });
+
+  it('should accept WRITE_GRANT_USER_GROUP with writeGrantedGroups', () => {
+    const grantedGroup: IGrantedGroup = {
+      type: 'UserGroup',
+      item: 'group123' as any,
+    };
+
+    const page: IPage = {
+      path: '/test',
+      status: 'published',
+      tags: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      seenUsers: [],
+      parent: null,
+      descendantCount: 0,
+      isEmpty: false,
+      grant: PageGrant.GRANT_PUBLIC,
+      grantedUsers: [],
+      grantedGroups: [],
+      liker: [],
+      commentCount: 0,
+      slackChannels: '',
+      deleteUser: null as any,
+      deletedAt: new Date(),
+      writeGrant: PageWriteGrant.WRITE_GRANT_USER_GROUP,
+      writeGrantedUsers: [],
+      writeGrantedGroups: [grantedGroup],
+    };
+
+    expect(page.writeGrant).toBe(PageWriteGrant.WRITE_GRANT_USER_GROUP);
+    expect(page.writeGrantedGroups).toHaveLength(1);
+    expect(page.writeGrantedGroups[0].type).toBe('UserGroup');
+  });
+});
+
+describe('IPageInfo with isEditable', () => {
+  it('should include isEditable in IPageInfo', () => {
+    const pageInfo: IPageInfo = {
+      isNotFound: false,
+      isV5Compatible: true,
+      isEmpty: false,
+      isMovable: true,
+      isDeletable: true,
+      isAbleToDeleteCompletely: true,
+      isRevertible: false,
+      bookmarkCount: 0,
+      isEditable: true,
+    };
+
+    expect(pageInfo.isEditable).toBe(true);
+  });
+});
+
+describe('PageWriteGrant type compatibility', () => {
+  it('should accept PageWriteGrant values as numbers', () => {
+    const values: number[] = [
+      PageWriteGrant.WRITE_GRANT_PUBLIC,
+      PageWriteGrant.WRITE_GRANT_OWNER,
+      PageWriteGrant.WRITE_GRANT_USER_GROUP,
+    ];
+
+    expect(values).toEqual([1, 2, 4]);
+  });
+});

--- a/packages/core/src/interfaces/page.ts
+++ b/packages/core/src/interfaces/page.ts
@@ -46,6 +46,14 @@ export type IPage = {
   expandContentWidth?: boolean;
   wip?: boolean;
   ttlTimestamp?: Date;
+
+  // write permission
+  writeGrant: PageWriteGrant;
+  writeGrantedUsers: Ref<IUser>[];
+  writeGrantedGroups: IGrantedGroup[];
+
+  // readOnly permission per page
+  readOnlyUserIds: Ref<IUser>[];
 };
 
 export type IPagePopulatedToShowRevision = Omit<
@@ -75,6 +83,14 @@ export const PageGrant = {
 type UnionPageGrantKeys = keyof typeof PageGrant;
 export type PageGrant = (typeof PageGrant)[UnionPageGrantKeys];
 
+export const PageWriteGrant = {
+  WRITE_GRANT_PUBLIC: 1,
+  WRITE_GRANT_OWNER: 2,
+  WRITE_GRANT_USER_GROUP: 4,
+} as const;
+type UnionPageWriteGrantKeys = keyof typeof PageWriteGrant;
+export type PageWriteGrant = (typeof PageWriteGrant)[UnionPageWriteGrantKeys];
+
 export const PageStatus = {
   STATUS_PUBLISHED: 'published',
   STATUS_DELETED: 'deleted',
@@ -97,6 +113,7 @@ export type IPageInfo = {
   isDeletable: boolean;
   isAbleToDeleteCompletely: boolean;
   isRevertible: boolean;
+  isEditable: boolean;
   bookmarkCount: number;
 };
 


### PR DESCRIPTION
## 編集権限の制御における課題

ページの閲覧権限（`readGrant`）を細かく制御できる一方で、編集権限を柔軟に制限できなかった。  

具体的には、特定のページに対して読み取り権限だけを付与し、書き込みを禁止するような個別制御が困難でした。    
ページ単位で編集権限を制御する機能と、特定のユーザーを閲覧専用にする機能を導入しました。  

---

## ページごとに編集権限を制限するデータ構造

新しく導入した機能では、ページごとに編集権限の種別を設定できます。  
この設定を**書き込み権限**（write grant）と呼びます。  
コア型定義（`packages/core`）およびデータベーススキーマに、以下の型とフィールドを追加しました。  

### データモデルの拡張

`IPage` インターフェースおよび Page スキーマに、以下のフィールドを定義しています。

* **`writeGrant`**：ページ全体の書き込み制限を決定する enum 値です。
* **`writeGrantedUsers`**：個別に書き込みを許可されたユーザーの ID 配列です。
* **`writeGrantedGroups`**：書き込みを許可されたユーザーグループの ID 配列です。
* **`readOnlyUserIds`**：ページ単位で閲覧専用（編集禁止）にするユーザーの ID 配列です。

### `PageWriteGrant` の定義

書き込み権限の種別は、以下のビットフラグまたは数値の列挙型として定義されます。

* **`PUBLIC`** (1)：すべてのユーザーに編集を許可する設定です。
* **`OWNER`** (2)：ページの所有者（`owner`）だけに編集を制限する設定です。
* **`USER_GROUP`** (4)：指定した特定のグループ（`writeGrantedGroups`）に所属するユーザーだけに編集を許可する設定です。

---

## サーバー側で実施する4段階の権限検証（`can-edit.ts`）

編集の可否を判定するため、バックエンドの権限サービス層（`apps/app/src/server/service/page/can-edit.ts`）に **`canEditPage`** ユーティリティを実装しました。
フロントエンドの画面制御だけでなく、APIレベルでもこのユーティリティによる検証を強制します。
これにより、URLへ直接アクセスされた場合や不正なAPIリクエストに対しても、権限のない編集を遮断できます。

`canEditPage` は、以下の4段階の手順で編集の可否を順に判定します。

1. **管理者バイパス**：リクエストユーザーがシステムの管理者（admin）である場合は、他の条件に関わらず常に編集を許可します。
2. **グローバル制限チェック**：ユーザーがシステム全体（グローバル設定）で閲覧専用ユーザー（Read-only User）に設定されている場合は、編集を禁止します。
3. **ページ単位の閲覧専用チェック**：対象ページの `readOnlyUserIds` に該当ユーザーの ID が含まれている場合は、編集を禁止します。
4. **書き込み権限ポリシーチェック**：ページに設定された `writeGrant` の値（`PUBLIC` / `OWNER` / `USER_GROUP`）を評価し、ユーザーが条件を満たさない場合は編集を禁止します。

---

## サーバー側サービスおよび API の実装変更

バックエンドの主要な処理は、新設された検証ロジックを統合するようにリファクタリングされました。

### ページサービス（`page-service.ts`）

`IPageService` インターフェースへ新たに `canEdit` メソッドを追加し、データ取得時や更新時に動的に権限評価ができるようにしました。
また、データの整合性を担保するため以下の修正を行っています。

* **`updateWriteGrant` の直接保存化**：従来の `updatePage` 経由の保存では、内部処理で書き込み制限オプションが無視される不具合があったため、対象フィールドを直接データベースへ永続化する専用処理にリファクタリングしました。
* **ルートページ変更時のクラッシュ防止**：ルートページの `GRANT_RESTRICTED` を変更する際、親ページが存在しない（null）ことによるエラーを防ぐため、`createEmptyPage(null)` によるガード処理を追加しました。

### API ルート（`apiv3/page/`）

* **`PUT /:pageId/write-grant`**：書き込み権限を更新するための専用エンドポイントを新設しました。リクエスト時にはバリデーターによる型チェックが走ります。
* **`GET /grant-data`**：フロントエンドが現在の権限状態を同期できるよう、レスポンス（`IResGrantData`）に `currentPageWriteGrant` を追加しました。
* **権限検証の強制**：コンテンツの更新（`PUT /page`）を含む、すべての書き込み系ルートの入り口に `canEdit` によるチェックを配置し、検証を通過しない場合は即座にステータスコード **403 Forbidden** を返します。

---

## フロントエンドおよび状態管理の実装

ユーザーが視覚的に権限を設定・確認できるよう、コンポーネントとカスタムフックを拡張しました。

### コンポーネントの変更

* **`PagePermissionModal.tsx`（新規）**：書き込み権限のドロップダウンメニューや、対象ユーザーグループを選択するための専用モーダルUIです。開いた際に `currentGrantData` から現在の `writeGrant` の値を初期化します。
* **`PageItemControl.tsx`**：ドキュメントツリーなどの3点リーダーメニューに、上記モーダルを呼び出すための「Permission」メニューアイテムを追加しました。
* **`GrowiContextualSubNavigation.tsx` / `PageControls.tsx**`：ナビゲーションバーやページ操作エリアからモーダルを表示できるようにワイヤリングを行いました。

### 状態管理（`hooks.ts`）

状態管理層（`apps/app/src/states/page/hooks.ts`）に、ページ単位の閲覧専用状態を解決するフックを追加しました。

* **`useCurrentPageReadOnlyUserIds`** / **`useIsReadOnlyUserForPage`**：現在のページに対する閲覧専用ユーザーの情報を取得・判定します。
* **`useIsEditable` の統合**：フロントエンドの編集ボタンやエディタの活性・非活性を制御する `useIsEditable` フックの内部に、上記の閲覧専用ユーザーチェックのロジックを統合しました。画面レベルでもシームレスに編集不可の状態が反映されます。

---

## テストによる品質保証

導入した権限ロジックと境界条件を検証するため、新規テストケースを実装しています。

* **単体テスト（`can-edit.spec.ts`）**：管理者によるバイパス、各 `writeGrant` ポリシー、閲覧専用ユーザーの組み合わせなど、`canEditPage` の挙動を網羅する14の検証ケースを実行します。
* **統合テスト（`write-grant.integ.ts` 他）**：データベースへの権限設定の永続化（4ケース）、`readOnlyUsers` の操作および権限不足時の 403 応答（5ケース）、権限のないユーザーによるページ更新のブロック（2ケース）を検証します。
* **コンポーネントテスト（`PagePermissionModal.spec.tsx`）**：モーダルが現在の権限データに基づいて正しく初期表示され、変更後に保存処理が正しく呼び出されるか（2ケース）を検証します。