### PR TITLE
fix: Suppress modifier shortcuts in editable elements

### DIFF
--- a/apps/app/src/client/components/Hotkeys/HotkeysManager.spec.tsx
+++ b/apps/app/src/client/components/Hotkeys/HotkeysManager.spec.tsx
@@ -97,4 +97,26 @@ describe('HotkeysManager', () => {
 
     document.body.removeChild(input);
   });
+
+  it('does NOT trigger modifier-key shortcut when target is an editable element', () => {
+    render(<HotkeysManager />);
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+
+    act(() => {
+      const event = new KeyboardEvent('keydown', {
+        key: '/',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      Object.defineProperty(event, 'getModifierState', {
+        value: (mod: string) => mod === 'Control',
+      });
+      input.dispatchEvent(event);
+    });
+    expect(ShowShortcutsModal).not.toHaveBeenCalled();
+
+    document.body.removeChild(input);
+  });
 });

--- a/apps/app/src/client/components/Hotkeys/HotkeysManager.tsx
+++ b/apps/app/src/client/components/Hotkeys/HotkeysManager.tsx
@@ -71,16 +71,15 @@ const HotkeysManager = (): JSX.Element => {
 
   useEffect(() => {
     const createHandler =
-      (component: SubscriberComponent, category: HotkeyCategory) =>
-      (event: KeyboardEvent) => {
-        if (category === 'single' && isEditableTarget(event)) return;
+      (component: SubscriberComponent) => (event: KeyboardEvent) => {
+        if (isEditableTarget(event)) return;
         event.preventDefault();
         addView(component);
       };
 
     const bindingMap: Record<string, (event: KeyboardEvent) => void> = {};
     for (const { component, bindings } of subscribers) {
-      const handler = createHandler(component, bindings.category);
+      const handler = createHandler(component);
       const keys = Array.isArray(bindings.keys)
         ? bindings.keys
         : [bindings.keys];


### PR DESCRIPTION
## Summary

- `Ctrl+/` をエディタ内で押すと、コメントトグルとショートカットヘルプモーダルが同時に起動する問題を修正
- `HotkeysManager` の `isEditableTarget()` ガードを `'single'` カテゴリのみでなく全カテゴリに適用
- v7.5.0 以前の `react-hotkeys` の挙動（editable 要素ではすべてのショートカットを無視）を再現

## Root Cause

`HotkeysManager.tsx:76` の条件が `category === 'single'` の場合のみ `isEditableTarget()` を適用していた。`ShowShortcutsModal` は `category: 'modifier'` を使用するため、CodeMirror にフォーカスがある状態でも tinykeys のハンドラが発火していた。

CodeMirror は `Ctrl+/` で `preventDefault()` は呼ぶが `stopPropagation()` は呼ばないため、keydown が `window` までバブリングし、グローバル登録された tinykeys ハンドラが反応する。

## Changes

- `HotkeysManager.tsx`: `createHandler` から `category` パラメータを削除し、`isEditableTarget()` チェックを全カテゴリに適用
- `HotkeysManager.spec.tsx`: modifier ショートカットも editable 要素内では発火しないことを確認するテストを追加

## Test Plan

- [ ] エディタ内で `Ctrl+/` を押すとコメントトグルのみ動作し、ヘルプモーダルが開かないことを確認
- [ ] エディタ外（通常ページ表示中）で `Ctrl+/` を押すとヘルプモーダルが開くことを確認
- [ ] 全ユニットテスト通過を確認

Closes #11339

---
_Generated by [Claude Code](https://claude.ai/code/session_01AB5vzKV4VbuaNRKja4gYCy)_