### PR TITLE
fix: Use req.user.username in LDAP Execute Sync instead of req.user.name

### DIFF
--- a/apps/app/src/features/external-user-group/server/routes/apiv3/external-user-group.ts
+++ b/apps/app/src/features/external-user-group/server/routes/apiv3/external-user-group.ts
@@ -961,7 +961,7 @@ module.exports = (crowi: Crowi): Router => {
 
       try {
         await crowi.ldapUserGroupSyncService?.init(
-          req.user.name,
+          req.user.username,
           req.body.password,
         );
       } catch (_e) {


### PR DESCRIPTION
## Summary

LDAP グループ同期（Execute Sync）実行時、`ldapUserGroupSyncService.init()` に渡す第一引数が `req.user.username`（loginId）ではなく `req.user.name`（表示名）になっていたバグを修正する。

## Root Cause

`apps/app/src/features/external-user-group/server/routes/apiv3/external-user-group.ts` の `/ldap/sync` エンドポイントにて、以下のコードが原因：

```typescript
// Before (bug)
await crowi.ldapUserGroupSyncService?.init(
  req.user.name,      // 表示名（例: "Taro Yamada"）を渡していた
  req.body.password,
);

// After (fix)
await crowi.ldapUserGroupSyncService?.init(
  req.user.username,  // loginId（例: "taro"）を使用
  req.body.password,
);
```

`LdapService.bind()` 内で `bindDN.replace(/{{username}}/, userBindUsername)` が実行されるため、`{{username}}` プレースホルダーが表示名で置換され、LDAP bind が失敗していた。

## Changes

- `external-user-group.ts`: `req.user.name` → `req.user.username` の1行修正

## Test Plan

- [ ] loginId と表示名が異なるユーザーで Execute Sync を実行し、LDAP bind が loginId で行われることを確認
- [ ] Manager Bind / User Bind 両モードで動作確認

Closes #11348

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRHxGpbSEhrmYLXYoVakAL)_