### PR TITLE
fix: Include page listing conditions on bookmarks api

### DIFF
--- a/apps/app/src/server/models/page.ts
+++ b/apps/app/src/server/models/page.ts
@@ -130,6 +130,8 @@ export interface PageModel extends Model<PageDocument> {
     userGroups?,
     includeEmpty?: boolean,
     includeAnyoneWithTheLink?: boolean,
+    showPagesRestrictedByOwner?: boolean,
+    showPagesRestrictedByGroup?: boolean,
   ): Promise<HydratedDocument<PageDocument>[]>;
   findByPath(
     path: string,
@@ -811,6 +813,8 @@ schema.statics.findByIdsAndViewer = async function (
   userGroups?,
   includeEmpty?: boolean,
   includeAnyoneWithTheLink?: boolean,
+  showPagesRestrictedByOwner?: boolean,
+  showPagesRestrictedByGroup?: boolean,
 ): Promise<PageDocument[]> {
   const baseQuery = this.find({ _id: { $in: pageIds } });
   const queryBuilder = new PageQueryBuilder(baseQuery, includeEmpty);
@@ -819,6 +823,8 @@ schema.statics.findByIdsAndViewer = async function (
     user,
     userGroups,
     includeAnyoneWithTheLink,
+    showPagesRestrictedByOwner,
+    showPagesRestrictedByGroup,
   );
 
   return queryBuilder.query.exec();

--- a/apps/app/src/server/routes/apiv3/bookmarks.ts
+++ b/apps/app/src/server/routes/apiv3/bookmarks.ts
@@ -5,7 +5,7 @@ import {
   isUserPage,
   isUsersTopPage,
 } from '@growi/core/dist/utils/page-path-utils';
-import mongoose, { type HydratedDocument } from 'mongoose';
+import mongoose, { type HydratedDocument, type Types } from 'mongoose';
 
 import { SupportedAction, SupportedTargetModel } from '~/interfaces/activity';
 import type { IBookmarkInfo } from '~/interfaces/bookmark-info';
@@ -232,6 +232,10 @@ module.exports = (crowi: Crowi) => {
         HydratedDocument<BookmarkDocument>,
         BookmarkModel
       >('Bookmark');
+      const Page: PageModel = mongoose.model<
+        HydratedDocument<PageDocument>,
+        PageModel
+      >('Page');
 
       try {
         const bookmarkIdsInFolders = await BookmarkFolder.distinct(
@@ -253,18 +257,34 @@ module.exports = (crowi: Crowi) => {
           })
           .exec();
 
+        const bookmarkedPageIds = userRootBookmarks
+          .map((b) => b.page?._id)
+          .filter((id): id is Types.ObjectId => id != null);
+        const viewablePages = await Page.findByIdsAndViewer(
+          bookmarkedPageIds,
+          req.user,
+          null,
+        );
+        const viewableIdSet = new Set(
+          viewablePages.map((p) => p._id.toString()),
+        );
+
         const disabledUserPage = configManager.getConfig(
           'security:disableUserPages',
         );
 
-        const filteredBookmarks = disabledUserPage
-          ? userRootBookmarks.filter(
-              (bookmark) =>
-                bookmark.page != null &&
-                !isUserPage(bookmark.page.path) &&
-                !isUsersTopPage(bookmark.page.path),
-            )
-          : userRootBookmarks;
+        const filteredBookmarks = userRootBookmarks.filter((bookmark) => {
+          if (bookmark.page == null) return false;
+          if (bookmark.page._id == null) return false;
+          if (!viewableIdSet.has(bookmark.page._id.toString())) return false;
+          if (
+            disabledUserPage &&
+            (isUserPage(bookmark.page.path) ||
+              isUsersTopPage(bookmark.page.path))
+          )
+            return false;
+          return true;
+        });
 
         // serialize Bookmark
         const serializedUserRootBookmarks = filteredBookmarks.map((bookmark) =>

--- a/apps/app/src/server/routes/apiv3/bookmarks.ts
+++ b/apps/app/src/server/routes/apiv3/bookmarks.ts
@@ -260,10 +260,26 @@ module.exports = (crowi: Crowi) => {
         const bookmarkedPageIds = userRootBookmarks
           .map((b) => b.page?._id)
           .filter((id): id is Types.ObjectId => id != null);
+
+        const hideRestrictedByOwner = configManager.getConfig(
+          'security:list-policy:hideRestrictedByOwner',
+        );
+        const hideRestrictedByGroup = configManager.getConfig(
+          'security:list-policy:hideRestrictedByGroup',
+        );
+        // "Anyone with the link" pages are never listed anywhere, so the bookmark is
+        // often the owner's only path back to them: keep them visible on the owner's
+        // own list, but hide them from other users' bookmark listings.
+        const isOwnList = req.user?._id.toString() === userId;
+
         const viewablePages = await Page.findByIdsAndViewer(
           bookmarkedPageIds,
           req.user,
           null,
+          false,
+          isOwnList,
+          !hideRestrictedByOwner,
+          !hideRestrictedByGroup,
         );
         const viewableIdSet = new Set(
           viewablePages.map((p) => p._id.toString()),


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/186035
https://redmine.weseek.co.jp/issues/186037

Make sure bookmarks api only returns bookmaked pages that the user has access to