### PR TITLE
fix(news): offset news-item anchors below the sticky header on /_news

### DIFF
--- a/apps/app/src/features/news/client/components/NewsFeed.module.scss
+++ b/apps/app/src/features/news/client/components/NewsFeed.module.scss
@@ -1,0 +1,8 @@
+@use 'styles/variables' as var;
+
+// Anchor offset so that `scrollIntoView` lands the target news item below the
+// sticky page header instead of being clipped by it. Reuses the same offset
+// constant as Wiki headings and PageComment anchors.
+.news-item {
+  scroll-margin-top: var.$grw-scroll-margin-top-in-view;
+}

--- a/apps/app/src/features/news/client/components/NewsFeed.tsx
+++ b/apps/app/src/features/news/client/components/NewsFeed.tsx
@@ -12,6 +12,8 @@ import { newsItemAnchorId } from '../consts';
 import { useSWRINFxNews } from '../hooks/use-news';
 import { resolveLocaleText } from '../utils/resolve-locale-text';
 
+import styles from './NewsFeed.module.scss';
+
 const NEWS_PER_PAGE = 10;
 const DEFAULT_EMOJI = '📢';
 
@@ -132,7 +134,7 @@ export const NewsFeed = (): JSX.Element => {
             <section
               key={id}
               id={newsItemAnchorId(id)}
-              className="list-group-item py-4"
+              className={`${styles['news-item']} list-group-item py-4`}
             >
               <div className="d-flex align-items-center mb-1">
                 <span


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/185930

## What
- `/_news` ページでサイドバーからニュースアイテムをクリックして遷移したとき、アンカー位置がページ最上部の sticky ヘッダーに隠れて見切れる UX bug を修正
- 既存知見の `\$grw-scroll-margin-top-in-view` (130px、Wiki 見出し / PageComment アンカーで利用中) を流用してヘッダー直下にスクロール位置を揃える

## How
- `<section>` 要素に `scroll-margin-top: var.\$grw-scroll-margin-top-in-view` を当てて、\`scrollIntoView({ block: 'start' })\` 時のアンカー位置をヘッダー直下に揃える
- 既存の Wiki 見出し / PageComment アンカーと共通の定数を使うことでヘッダー高との整合を維持

## Files
- 新規: \`apps/app/src/features/news/client/components/NewsFeed.module.scss\`
- 修正: \`apps/app/src/features/news/client/components/NewsFeed.tsx\` (CSS module の import + className 適用)

## Test plan
- [ ] サイドバーから古いニュースアイテムをクリックし、\`/_news\` のアンカー位置がヘッダーの裏に隠れないことを目視確認
- [ ] 既存テストが green であることを確認
- [ ] (任意) Wiki の見出しアンカー / PageComment アンカーで意図せず変化がないことを確認

## Note on integration branch
本 PR は \`integration/news-improvements\` ブランチをターゲットにしている。後続でニュース一覧 \`/_news\` のページネーション化を別 feature ブランチ (\`feat/news-pagination\`) として追加予定。両者が揃ったうえで integration → master の最終 PR を出す予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)