### PR TITLE
fix(i18n): Pass user locale to FormattedDistanceDate

### DIFF
--- a/apps/app/src/client/components/FormattedDistanceDate.jsx
+++ b/apps/app/src/client/components/FormattedDistanceDate.jsx
@@ -1,10 +1,15 @@
 import { differenceInSeconds } from 'date-fns/differenceInSeconds';
 import { format } from 'date-fns/format';
 import { formatDistanceStrict } from 'date-fns/formatDistanceStrict';
+import { useTranslation } from 'next-i18next';
 import PropTypes from 'prop-types';
 import { UncontrolledTooltip } from 'reactstrap';
 
+import { getLocale } from '~/utils/locale-utils';
+
 const FormattedDistanceDate = (props) => {
+  const { i18n } = useTranslation();
+
   // cast to date if string
   const date =
     typeof props.date === 'string' ? new Date(props.date) : props.date;
@@ -22,7 +27,11 @@ const FormattedDistanceDate = (props) => {
 
   return (
     <>
-      <span id={elemId}>{formatDistanceStrict(date, baseDate)}</span>
+      <span id={elemId}>
+        {formatDistanceStrict(date, baseDate, {
+          locale: getLocale(i18n.language),
+        })}
+      </span>
       {props.isShowTooltip && (
         <UncontrolledTooltip placement="bottom" fade={false} target={elemId}>
           {dateFormatted}


### PR DESCRIPTION
## What

`FormattedDistanceDate` calls `formatDistanceStrict(date, baseDate)` without a locale, so the relative time it renders ("3 days", "2 hours", "5 minutes") always comes out in English regardless of the user's selected language.

This component is used in several user-facing places — page comments (`PageComment/Comment.tsx`), in-app notifications (`InAppNotification/ModelNotification`), and the Recent Changes sidebar (`Sidebar/RecentChanges`) — so a Japanese user currently sees `3 days` instead of `3日` in all of them.

## Why this is the right fix

`RecentActivity/ActivityListItem.tsx` already handles this correctly: it reads `i18n.language`, resolves the date-fns locale via `getLocale`, and passes it to `formatDistanceToNow`. This PR applies the same approach to `FormattedDistanceDate` so its output matches the rest of the UI.

```js
// before  -> ja user sees "3 days"
formatDistanceStrict(date, baseDate)
// after   -> ja user sees "3日"
formatDistanceStrict(date, baseDate, { locale: getLocale(i18n.language) })
```

English output is unchanged. The fixed `yyyy/MM/dd HH:mm` string used for the tooltip and for dates older than the threshold has no locale-dependent tokens, so it is left as-is.

## Verification

- Confirmed the date-fns behavior in isolation: `formatDistanceStrict` with `getLocale('ja_JP')` yields `3日` / `2時間` / `5分`, while the default (current) output is `3 days` / `2 hours` / `5 minutes`; `en` output is unchanged.
- Ran Biome 2.4.12 against the changed file (clean).
- I have not run the full `@growi/app` test suite locally.
