### PR TITLE
fix(auth): LDAP login stays on login page until manual reload

### DIFF
--- a/apps/app/src/server/routes/login-passport.js
+++ b/apps/app/src/server/routes/login-passport.js
@@ -257,7 +257,6 @@ module.exports = (crowi, app) => {
         res,
         user,
         SupportedAction.ACTION_USER_LOGIN_WITH_LDAP,
-        true,
       );
     });
   };


### PR DESCRIPTION
## 概要

- LDAP ログイン成功後、ページが遷移せず**ログイン画面が表示され続ける**不具合を修正します。
- リロード（Ctrl+R）するとトップページへ遷移するため、セッション自体は成立しています。
- ローカル（パスワード）ログインでは発生せず、**LDAP ログインのときのみ**発生します。

Closes #11384

## 根本原因

`POST /_api/v3/login` は AJAX エンドポイントで、ログインフォームはレスポンスの JSON `{ redirectTo }`（`res.apiv3`）を読み、`router.push` でクライアント側遷移します。

しかし `loginWithLdap` は `loginSuccessHandler(..., isExternalAccount=true)` を呼んでおり、この場合 JSON ではなく **HTTP 302（`res.safeRedirect`）** を返します。AJAX リクエストは 302 を自動追従して HTML を受け取るため、クライアントは `redirectTo` を取得できず遷移しません。`req.logIn` によりセッションは確立済みのため、リロード時にサーバ側の「認証済みならリダイレクト」処理でトップページへ遷移します（＝リロードで直る理由）。

ローカルログインは `isExternalAccount` の既定値 `false` のため JSON を返し、正常に遷移します。Google/GitHub/OIDC/SAML は `GET /passport/*/callback` の全画面遷移のため 302 が正しく、`isExternalAccount=true` のままで問題ありません。

## 変更点

- `apps/app/src/server/routes/login-passport.js` の `loginWithLdap` から、`loginSuccessHandler` 呼び出しの `isExternalAccount`（`true`）引数を削除し、ローカルログインと同様に JSON（`res.apiv3`）を返すようにしました。
- `isExternalAccount` は `loginSuccessHandler` 内の「302 を返すか JSON を返すか」を切り替える分岐でのみ使用されているため、影響範囲は **LDAP ログイン成功時のレスポンス形式のみ**です。新規に自動登録された LDAP ユーザーで発生する同症状も併せて解消されます。

## テスト計画

1. LDAP 認証を有効化・設定する
2. ログインフォームから LDAP アカウントでログインする
3. **修正前**: ログイン画面のままとなり、リロードで初めてトップページへ遷移する
   **修正後**: リロード無しでトップページ（または `redirectTo`）へ遷移する

- GROWI 7.5.6 で再現および修正を確認済み。