### PR TITLE
refactor(auth): loginSuccessHandler の isExternalAccount を respondWithRedirect にリネーム＋回帰テスト追加

### DIFF
--- a/apps/app/src/server/routes/login-passport.js
+++ b/apps/app/src/server/routes/login-passport.js
@@ -7,6 +7,7 @@ import { createRedirectToForUnauthenticated } from '~/server/util/createRedirect
 import loggerFactory from '~/utils/logger';
 
 import { externalAccountService } from '../service/external-account';
+import { sendLoginSuccessResponse } from './login-success-response';
 
 /** @param {import('~/server/crowi').default} crowi Crowi instance */
 module.exports = (crowi, app) => {
@@ -59,7 +60,7 @@ module.exports = (crowi, app) => {
     res,
     user,
     action,
-    isExternalAccount = false,
+    respondWithRedirect = false,
   ) => {
     // update lastLoginAt
     user.updateLastLoginAt(new Date(), (err, userData) => {
@@ -87,11 +88,7 @@ module.exports = (crowi, app) => {
     const redirectTo =
       redirectToForUnauthenticated ?? res.locals.redirectTo ?? '/';
 
-    if (isExternalAccount) {
-      return res.safeRedirect(redirectTo);
-    }
-
-    return res.apiv3({ redirectTo });
+    return sendLoginSuccessResponse(res, redirectTo, respondWithRedirect);
   };
 
   const injectRedirectTo = (req, res, next) => {
@@ -252,6 +249,10 @@ module.exports = (crowi, app) => {
         return next(err);
       }
 
+      // LDAP login is submitted through the AJAX login form (POST /_api/v3/login), the
+      // same as local login, so it must respond with JSON. Do NOT pass respondWithRedirect
+      // here even though LDAP is an external account: a 302 would leave the client stuck on
+      // the login page until a manual reload. See issue #11384.
       return loginSuccessHandler(
         req,
         res,

--- a/apps/app/src/server/routes/login-success-response.spec.ts
+++ b/apps/app/src/server/routes/login-success-response.spec.ts
@@ -1,0 +1,52 @@
+import { mock } from 'vitest-mock-extended';
+
+import type { ResWithSafeRedirect } from '~/server/middlewares/safe-redirect';
+
+import type { ApiV3Response } from './apiv3/interfaces/apiv3-response';
+import { sendLoginSuccessResponse } from './login-success-response';
+
+type LoginSuccessResponse = ApiV3Response & ResWithSafeRedirect;
+
+describe('sendLoginSuccessResponse', () => {
+  const redirectTo = '/path/to/redirect';
+
+  // Contract: the response TRANSPORT the client experiences (JSON body vs HTTP 302),
+  // not which internal helper is called. See issue #11384.
+
+  describe('when respondWithRedirect is omitted (AJAX login form: local & LDAP)', () => {
+    it('responds with JSON { redirectTo } and never issues a redirect', () => {
+      // Arrange
+      const res = mock<LoginSuccessResponse>();
+
+      // Act
+      sendLoginSuccessResponse(res, redirectTo);
+
+      // Assert: the client reads redirectTo from the body and navigates itself.
+      // A 302 here would be followed silently by the XHR (the #11384 regression).
+      expect(res.apiv3).toHaveBeenCalledWith({ redirectTo });
+      expect(res.safeRedirect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when respondWithRedirect is false', () => {
+    it('responds with JSON { redirectTo } and never issues a redirect', () => {
+      const res = mock<LoginSuccessResponse>();
+
+      sendLoginSuccessResponse(res, redirectTo, false);
+
+      expect(res.apiv3).toHaveBeenCalledWith({ redirectTo });
+      expect(res.safeRedirect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when respondWithRedirect is true (full-page callback: OAuth/SAML)', () => {
+    it('responds with an HTTP 302 and never returns a JSON body', () => {
+      const res = mock<LoginSuccessResponse>();
+
+      sendLoginSuccessResponse(res, redirectTo, true);
+
+      expect(res.safeRedirect).toHaveBeenCalledWith(redirectTo);
+      expect(res.apiv3).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/app/src/server/routes/login-success-response.ts
+++ b/apps/app/src/server/routes/login-success-response.ts
@@ -1,0 +1,35 @@
+import type { ResWithSafeRedirect } from '~/server/middlewares/safe-redirect';
+
+import type { ApiV3Response } from './apiv3/interfaces/apiv3-response';
+
+type LoginSuccessResponse = ApiV3Response & ResWithSafeRedirect;
+
+/**
+ * Send the response for a successful login.
+ *
+ * `respondWithRedirect` selects the response TRANSPORT, not whether the account is
+ * external:
+ * - `false` (default): reply with JSON `{ redirectTo }` via `res.apiv3`. Used by the
+ *   AJAX login form (`POST /_api/v3/login`) for BOTH local and LDAP login — the client
+ *   reads `redirectTo` from the body and navigates on its own (`router.push`).
+ * - `true`: reply with an HTTP 302 via `res.safeRedirect`. Used by the OAuth/SAML callback
+ *   routes (`GET`/`POST` under `/passport/`), which are full-page browser navigations that
+ *   the server itself must redirect.
+ *
+ * NOTE: LDAP is an external account but still uses `false`, because it is submitted
+ * through the AJAX form rather than a full-page callback. Passing `true` for LDAP returns
+ * a 302 that the XHR follows silently, so the client never receives `redirectTo` and the
+ * user stays on the login page until a manual reload. See issue #11384.
+ */
+export const sendLoginSuccessResponse = (
+  res: LoginSuccessResponse,
+  redirectTo: string,
+  respondWithRedirect = false,
+): void => {
+  if (respondWithRedirect) {
+    res.safeRedirect(redirectTo);
+    return;
+  }
+
+  res.apiv3({ redirectTo });
+};


### PR DESCRIPTION
## 概要

#11386（issue #11384 の修正）のフォローアップです。挙動の変更はなく、**再発防止のためのリネームと回帰テストの追加**を行います。

#11386 では `loginWithLdap` から `loginSuccessHandler(..., isExternalAccount=true)` の `true` を外すことで、LDAP ログイン成功時に 302 ではなく JSON `{ redirectTo }` を返すよう修正しました。ただし引数名 `isExternalAccount` が残っており、これが今回の不具合の温床でした。

## なぜリネームするのか

`isExternalAccount` は「external account かどうか」を表していません。実際に制御しているのは **応答の形式（transport）**、すなわち「HTTP 302 リダイレクトで返すか、JSON `{ redirectTo }` で返すか」だけです（[login-passport.js](../blob/master/apps/app/src/server/routes/login-passport.js) の該当分岐）。

- **JSON で返すべきもの** … AJAX のログインフォーム（`POST /_api/v3/login`）から来るログイン。クライアントはレスポンス本文の `redirectTo` を読んで `router.push` で自分で遷移する。→ **ローカルログインと LDAP ログイン**
- **302 で返すべきもの** … ブラウザの全画面遷移で来るコールバック（`GET`/`POST` の `/passport/` 配下）。サーバ側でリダイレクトさせる必要がある。→ **Google / GitHub / OIDC / SAML**

LDAP は **external account でありながら AJAX で来る唯一の方式**です。そのため「external account なら 302」という名前のフラグでまとめてしまうと、LDAP だけ誤って 302 になり、XHR が 302 を黙って追従してしまってクライアントが `redirectTo` を受け取れず、ログイン画面に留まる（リロードで解消）——というのが #11384 の根本原因でした。

名前が事実と食い違ったままだと、「LDAP は external account なのにフラグが付いていないのはバグでは？」と考えた人が `true` に戻し、同じ不具合を再発させるリスクがあります。そこで、フラグを役割どおりの名前に直します。

## 変更点

- `loginSuccessHandler` の引数 `isExternalAccount` を **`respondWithRedirect`** にリネーム（真偽の意味は同じなので値の変更は不要）。
- 応答形式の判定を純粋関数 **`sendLoginSuccessResponse()`** に切り出し（`login-success-response.ts`）。「なぜ LDAP は `false` なのか」を関数の doc コメントに明記。
- 上記純粋関数の**契約を回帰テスト**で固定（`login-success-response.spec.ts`）:
  - 省略時（既定）/ `false` → `res.apiv3({ redirectTo })`（JSON）を呼び、`res.safeRedirect` は呼ばない ← ローカル & LDAP の契約
  - `true` → `res.safeRedirect(redirectTo)`（302）を呼び、`res.apiv3` は呼ばない ← OAuth/SAML の契約
- LDAP 呼び出し箇所に、`respondWithRedirect` を渡さない理由（AJAX なので JSON が必要）を説明するコメントを追加。

## 影響範囲

**挙動の変更はありません。** OAuth/SAML の呼び出しは従来どおり `true`（302）、ローカル・LDAP は引数を省略（既定 `false` = JSON）です。リネームと純粋関数への委譲、コメント追加、テスト追加のみです。

## テスト

```
pnpm vitest run login-success-response
✓ 3 tests passed
```

- `pnpm run lint:biome`（`--diagnostic-level=error`）: 追加ファイルはエラー0。
- `pnpm run lint:typecheck`: 追加・変更ファイルに起因する型エラーはありません。
  （`get-related-groups-members.ts` / `get-related-groups.ts` の `USER_GROUP` スコープに関する 2 件の型エラーは **本 PR 適用前の master にも存在する既存事象**で、本変更とは無関係です。）

## 補足

`sendLoginSuccessResponse` の契約テストは応答形式の分岐を守ります。LDAP 呼び出し側の配線（`respondWithRedirect` を渡さないこと）は、LDAP ログインの完全な結合テストが LDAP サーバを要して現実的でないため、リネームと呼び出し箇所のコメントで担保しています。

Refs #11384, #11386

🤖 Generated with [Claude Code](https://claude.com/claude-code)
