### PR TITLE
fix: Make activities.endpoint/ip nullable in Prisma schema

### DIFF
--- a/apps/app/prisma/schema.prisma
+++ b/apps/app/prisma/schema.prisma
@@ -54,10 +54,13 @@ model activities {
   v           Int                @map("__v")
   action      String
   createdAt   DateTime           @default(now())
-  endpoint    String
+  // ip/endpoint are optional as a safeguard: the legacy Mongoose schema never
+  // required them, and some write paths still omit them today, so documents
+  // without either field are expected, not corrupt.
+  endpoint    String?
   event       String?            @db.ObjectId
   eventModel  String?
-  ip          String
+  ip          String?
   snapshot    ActivitiesSnapshot
   target      String?            @db.ObjectId
   targetModel String?

--- a/apps/app/src/server/models/activity-model-schema.spec.ts
+++ b/apps/app/src/server/models/activity-model-schema.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import type { activities, Prisma } from '~/generated/prisma/client';
+
+/**
+ * Type-level contract for the `activities` model generated from
+ * prisma/schema.prisma.
+ *
+ * Legacy Mongoose-era Activity documents can lack `ip`/`endpoint` entirely
+ * (the Mongoose schema never required them). Declaring them as required
+ * `String` in schema.prisma makes Prisma throw
+ * `Error converting field "endpoint" ... found incompatible value of "null"`
+ * the moment a legacy document is read. These assertions are enforced by
+ * `pnpm run lint:typecheck`: they stop compiling if schema.prisma reverts
+ * `ip`/`endpoint` to required.
+ */
+describe('activities model (generated from schema.prisma)', () => {
+  it('types endpoint as nullable on the read model (optional in schema)', () => {
+    expectTypeOf<activities['endpoint']>().toEqualTypeOf<string | null>();
+  });
+
+  it('types ip as nullable on the read model (optional in schema)', () => {
+    expectTypeOf<activities['ip']>().toEqualTypeOf<string | null>();
+  });
+
+  it('accepts a create input without ip/endpoint (backward compat)', () => {
+    // Existing activity documents predate the ip/endpoint capture and may
+    // carry neither field; a create input providing neither must stay valid
+    // so that no destructive data migration is required.
+    const minimalActivity: Prisma.activitiesCreateInput = {
+      v: 0,
+      action: 'LOGIN',
+      createdAt: new Date(),
+      snapshot: { id: '675547e97f208f8050a361d4', username: 'alice' },
+    };
+    expect(minimalActivity.ip).toBeUndefined();
+    expect(minimalActivity.endpoint).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Legacy Mongoose `Activity` documents can lack `ip`/`endpoint` entirely (the Mongoose schema never required them, and some write paths — e.g. cascade deletion / empty-trash / group deletion — still omit them today), but the Prisma `activities` model declares both as required `String` fields.
- Any Prisma read that materializes these fields on such a document throws a field conversion error (`Error converting field "endpoint" ... found incompatible value of "null"`), discovered via `imprv/activity-log`'s audit-log-bulk-export integration tests, which read the `activities` collection through Prisma.
- Marks `ip`/`endpoint` nullable (`String?`) in `schema.prisma`, following the same precedent already used for `ActivitiesSnapshot.username`.
- On `dev/8.0.x` itself the `activities` Prisma model is currently unused by any application code (schema-only declaration), so this is a preventive fix: it stops the bug from reappearing once a Prisma-based reader for this collection lands here (as it already has on `imprv/activity-log`).

## Test plan
- [x] Added `apps/app/src/server/models/activity-model-schema.spec.ts` (TDD: written first, confirmed RED against the required-field schema, then GREEN after the schema change) pinning `endpoint`/`ip` as `string | null` and confirming `Prisma.activitiesCreateInput` accepts omitting both fields.
- [x] `tsgo --noEmit` — no new errors introduced (diffed before/after; only pre-existing, unrelated errors remain).
- [x] `biome check` on changed files — clean.
- [ ] Full `turbo run lint test build --filter @growi/app` — recommend running in a normal (non-worktree) checkout before merge; this branch was authored in an isolated worktree where the monorepo build isn't fully available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)