### PR TITLE
feat: Extract internal links from pages

### DIFF
--- a/.kiro/specs/backlinks/design.md
+++ b/.kiro/specs/backlinks/design.md
@@ -13,8 +13,9 @@ before changing/renaming/deleting a page; spot their own broken outgoing links),
 **Impact**: GROWI has no link index today — link handling is render-only and client-side. This
 feature introduces a new server-side directed **link graph** (`PageLink`), kept current through
 the existing page-lifecycle event bus and queried under the existing page-grant model. It adds
-storage, one service, one read endpoint, one panel, an index-creation migration, and a background
-backfill job; it changes no existing lifecycle, permission, or Markdown/wiki-link behavior.
+storage, one service, one read endpoint, one panel, and a background backfill job; it changes no
+existing lifecycle, permission, or Markdown/wiki-link behavior. The `PageLink` indexes are created
+by Mongoose `autoIndex` at model registration (new collection — no migration needed).
 
 ### Goals
 
@@ -35,7 +36,8 @@ backfill job; it changes no existing lifecycle, permission, or Markdown/wiki-lin
   contention during backfill) is explicitly deferred.
 - A **blocking boot-time** backfill (a migrate-mongo data migration). Ruled out: it would take
   the wiki offline for the full backfill duration, which scales with page count and is
-  unacceptable for large instances. Only fast index creation runs at boot.
+  unacceptable for large instances. Index creation is not boot-blocking either — `autoIndex`
+  builds the indexes on a new, empty collection at model registration.
 - Indexing attachments or `/share/*` targets (only creatable GROWI pages are indexed).
 
 ## Boundary Commitments
@@ -49,9 +51,9 @@ backfill job; it changes no existing lifecycle, permission, or Markdown/wiki-lin
 - Resolution of a stored `toPath` to a target page `_id` (`toPage` cache), including redirect
   following and direct `_id` resolution when `toPath` is a permalink.
 - Synchronization of `PageLink` rows in response to page-lifecycle events.
-- The one-time backfill: a migrate-mongo migration that creates the `PageLink` indexes, plus a
-  background `CronService` job that populates rows for pre-existing pages without taking the wiki
-  offline.
+- The one-time backfill: a background `CronService` job that populates rows for pre-existing pages
+  without taking the wiki offline. (The `PageLink` indexes themselves are created by `autoIndex`
+  at model registration, not by a migration.)
 - The read API + SWR hook + UI panel that present backlinks and forward-link health.
 
 ### Out of Boundary
@@ -73,7 +75,7 @@ backfill job; it changes no existing lifecycle, permission, or Markdown/wiki-lin
   `relative-links-by-pukiwiki-like-linker`, and `generateCommonOptions`'s plugin set.
 - Mongoose models: `Page` (`findByPath`, `findByIdsAndViewer`), `Revision`, `PageRedirect`.
 - `crowi.events.page` (subscribe only), apiv3 middleware (`accessTokenParser`, `loginRequired`),
-  migrate-mongo + `getModelSafely` + `createBatchStream`, `CronService` (node-cron base) and the
+  `getModelSafely` + `createBatchStream`, `CronService` (node-cron base) and the
   admin Socket.IO channel for backfill scheduling/progress (mirroring the page-bulk-export job).
 - **Constraint**: dependency direction is one-way — backlinks depends on page/render/grant
   subsystems; none of them may import backlinks.
@@ -164,9 +166,8 @@ graph TB
 | Frontend | React + SWR (existing) | Backlinks panel + data hook | New tab in `PageAccessoriesModal`; reuse `PageListItemS`/`PagePathLabel` |
 | Backend / Services | Express apiv3 + a new `PageLinkService` | Read endpoint + event listeners | Listener wired in `crowi` setup like `search.ts` |
 | Rendering | Existing unified remark/rehype plugins | Server-side link extraction | Node-compatible; trimmed processor (link plugins only) |
-| Data / Storage | MongoDB + Mongoose (existing) | `PageLink` collection | New model via `getOrCreateModel` |
+| Data / Storage | MongoDB + Mongoose (existing) | `PageLink` collection + indexes | New model via `getOrCreateModel`; indexes built by `autoIndex` at model registration (new collection — no migration) |
 | Messaging / Events | `crowi.events.page` (Node EventEmitter) | Sync triggers | Subscribe only |
-| Migration | migrate-mongo v11 (existing) | Create `PageLink` indexes (fast, may block boot) | Index creation **only** — never the heavy backfill |
 | Background job | `CronService` / node-cron (existing) | One-time backfill of pre-existing pages | Chunked + resumable + throttled; mirrors page-bulk-export job; admin Socket.IO progress |
 
 ## File Structure Plan
@@ -195,8 +196,8 @@ apps/app/src/features/backlinks/
         ├── BacklinksPanel.tsx          # incoming list + empty state + forward-health section
         └── BacklinkListItem.tsx        # one row (title + path + target-state badge)
 
-apps/app/src/migrations/
-└── YYYYMMDDHHMMSS-create-page-link-indexes.js   # create PageLink indexes only (fast); backfill is the cron job above
+# No migration file: PageLink indexes are created by Mongoose autoIndex at model
+# registration (new collection); the backfill is the cron job above.
 ```
 
 ### Modified Files
@@ -287,7 +288,7 @@ needs no write — derived state reads the restored page's status.
 | 3.2 | Update add/remove → reflected | create/update replace outbound rows | Save flow |
 | 3.3 | Deleted page not an active source | reconcile (permanent: remove rows; trashed: filtered at read) | Delete flow |
 | 3.4 | <~1s at ≥100k pages | indexes `{toPage}`,`{fromPage}`,`{toPath}` | — |
-| 4.1 | One-time backfill | index-creation migration + PageLinkBackfillCron | Backfill flow |
+| 4.1 | One-time backfill | PageLinkBackfillCron (indexes via `autoIndex` at model registration) | Backfill flow |
 | 4.2 | Backfilled == post-enablement | backfill reuses `extractInternalLinks`; emits same rows as the live path | Backfill flow |
 | 4.3 | Re-run / restart produces no duplicates | unique `{fromPage,toPath}` + upsert; resumable progress marker | Backfill flow |
 | 5.1 | Links survive rename/move | resolveToPage redirect-following + `_id`-stable cache | Reconcile notes |
@@ -310,7 +311,6 @@ needs no write — derived state reads the restored page's status.
 | get-page-backlinks route | API | Read endpoint | 1.1,1.7,2.x,6.4 | apiv3 middleware (P0), PageLinkService (P0) | API |
 | useSWRxBacklinks | Client store | Fetch backlinks | 1.1 | apiv3Get (P0) | Service |
 | BacklinksPanel / BacklinkListItem | UI | Render list, empty state, target-state badge | 1.1,1.7,1.8,6.4 | useSWRxBacklinks, PageListItemS (P1) | — |
-| index-creation migration | Batch | Create `PageLink` indexes (fast, boot-time) | 4.1 | migrate-mongo (P0) | Batch |
 | PageLinkBackfillCron | Batch | Populate pre-existing pages (chunked, resumable, throttled, online) | 4.1,4.2,4.3 | CronService (P0), extractInternalLinks (P0), Revision, in-memory path→id map (P0) | Batch, State |
 
 ### Data / Server logic
@@ -495,24 +495,17 @@ useSWRxBacklinks(pageId: string | null): SWRResponse<IBacklink[]>;
 
 ### Batch
 
-> **Why two components, not one migrate-mongo migration.** GROWI runs migrate-mongo migrations
-> *synchronously at boot, before the app serves traffic* (`docker-entrypoint.ts:247`). A data
-> migration that parses every page body would therefore make the wiki **offline for the full
-> backfill duration** — minutes on small wikis, but tens of minutes to hours on large-plan
-> instances. So the schema part (index creation) stays in migrate-mongo, and the heavy data part
-> runs **online** as a throttled background job after boot. Backlinks are simply incomplete for
-> pre-existing pages until the job finishes (acceptable per 4.2, which only requires completeness
-> *after* the process completes); newly edited pages index immediately via the event listener.
-
-#### index-creation migration
-
-**Contracts**: Batch [x]
-
-##### Batch / Job Contract
-- Trigger: `pnpm run migrate` (prod, at boot) — fast, safe to block on.
-- Action: create the `PageLink` collection indexes (`{fromPage}`, `{toPath}`, `{toPage}`, unique
-  `{fromPage,toPath}`). No row writes.
-- `down`: drop the `PageLink` collection.
+> **Why the backfill is an online job, not a boot-time migration.** GROWI runs migrate-mongo
+> migrations *synchronously at boot, before the app serves traffic* (`docker-entrypoint.ts:247`).
+> A data migration that parses every page body would therefore make the wiki **offline for the
+> full backfill duration** — minutes on small wikis, but tens of minutes to hours on large-plan
+> instances. So the heavy data part runs **online** as a throttled background job after boot.
+> Nothing schema-related blocks boot either: `PageLink` is a new collection, so its indexes
+> (`{fromPage}`, `{toPath}`, `{toPage}`, unique `{fromPage,toPath}`) are created by Mongoose
+> `autoIndex` at model registration — no migration is involved. Backlinks are simply incomplete
+> for pre-existing pages until the job finishes (acceptable per 4.2, which only requires
+> completeness *after* the process completes); newly edited pages index immediately via the event
+> listener.
 
 #### PageLinkBackfillCron
 
@@ -671,11 +664,12 @@ interface ILinkTarget {
 
 ## Migration Strategy
 
-Two phases: a fast index-creation migration at boot, then an online throttled backfill job.
+No migration: `PageLink` indexes are created by Mongoose `autoIndex` at model registration (new,
+empty collection). The only bulk step is the online throttled backfill job after boot.
 
 ```mermaid
 graph TB
-    Boot[boot: migrate-mongo] --> Idx[create PageLink indexes only]
+    Boot[boot: model registration] --> Idx[autoIndex creates PageLink indexes]
     Idx --> Serve[app serves traffic]
     Serve --> Claim{atomic claim job doc}
     Claim -- not claimed/complete --> Tick[cron tick: process one chunk]
@@ -688,10 +682,10 @@ graph TB
     Done -- yes --> Mark[mark job complete]
 ```
 
-- **No boot downtime** beyond index creation (milliseconds). The wiki is online throughout the
-  backfill; pre-existing backlinks fill in progressively.
+- **No boot downtime**: `autoIndex` on the empty `PageLink` collection is effectively instant. The
+  wiki is online throughout the backfill; pre-existing backlinks fill in progressively.
 - **Estimated backfill wall-clock** (≈5 ms/page CPU; in-memory resolution): ~10 min/100k pages at
   full speed, scaled up by the inverse duty cycle (e.g. ~40 min/100k at 25% duty) and by average
   page size. See `research.md` for the benchmark and the scale/duty-cycle table.
-- Rollback: stop the cron and drop `PageLink` (the `down` migration). Recovery from a crash =
-  resume from the progress marker; idempotent upserts make partial progress safe.
+- Rollback: stop the cron and drop the `PageLink` collection (indexes go with it). Recovery from a
+  crash = resume from the progress marker; idempotent upserts make partial progress safe.

--- a/.kiro/specs/backlinks/design.md
+++ b/.kiro/specs/backlinks/design.md
@@ -175,7 +175,7 @@ graph TB
 ```
 apps/app/src/features/backlinks/
 ├── interfaces/
-│   └── page-link.ts              # IPageLink, IBacklinkPage DTO, LinkTargetState union
+│   └── page-link.ts              # IPageLink, IBacklink & ILinkTarget DTOs, LinkTargetState union
 ├── server/
 │   ├── models/
 │   │   ├── page-link.ts          # Mongoose model (getOrCreateModel) + statics
@@ -275,7 +275,7 @@ needs no write — derived state reads the restored page's status.
 | 1.5 | One source listed once | unique `{fromPage,toPath}` + dedupe in extraction | Save flow |
 | 1.6 | Exclude self-link (path or own permalink) | extractInternalLinks (drop `toPath == page.path`) + sync (drop `toPage == fromPage`) | Save flow |
 | 1.7 | Empty state | BacklinksPanel | Read flow |
-| 1.8 | Show title + path | IBacklinkPage DTO, BacklinkListItem | Read flow |
+| 1.8 | Show title + path | IBacklink DTO, BacklinkListItem | Read flow |
 | 1.9 | Permalink (`/{id}`) link targets page by id | extractInternalLinks (verbatim) + resolveToPage permalink branch | Save flow |
 | 1.10 | Same-host absolute URL → internal | extractInternalLinks classifier (`app:siteUrl` host match) | — |
 | 1.11 | Unset `app:siteUrl` → absolute URLs not internal | extractInternalLinks classifier (no base origin) | — |
@@ -441,16 +441,16 @@ function resolveToPage(toPath: string): Promise<ObjectId | null>;
 
 ##### Service Interface
 ```typescript
-interface IBacklinkResult { backlinks: IBacklinkPage[]; }
-findBacklinks(toPageId: ObjectId, user: IUser | null): Promise<IBacklinkPage[]>;
-findForwardLinkHealth(fromPageId: ObjectId, user: IUser | null): Promise<IBacklinkPage[]>;
+interface IBacklinkResult { backlinks: IBacklink[]; }
+findBacklinks(toPageId: ObjectId, user: IUser | null): Promise<IBacklink[]>;
+findForwardLinkHealth(fromPageId: ObjectId, user: IUser | null): Promise<ILinkTarget[]>;
 ```
 - `findBacklinks`: `findBacklinkSources(toPageId)` → ids → `findByIdsAndViewer` with the user's
-  groups, **excluding trashed source pages** → map to `IBacklinkPage` (2.1–2.3). Empty array
+  groups, **excluding trashed source pages** → map to `IBacklink` (2.1–2.3). Empty array
   when none (1.7).
 - `findForwardLinkHealth`: rows where `fromPage == X`; derive each target's
   `LinkTargetState` (`toPage == null` → `broken`; target trashed → `trashed`; else `normal`);
-  return rows that are `trashed`/`broken` for the editor's attention (6.4).
+  return the `trashed`/`broken` rows as `ILinkTarget` for the editor's attention (6.4).
 
 **Implementation Notes**
 - Integration: register in `crowi` page-service setup; never edit `PageService`.
@@ -472,7 +472,7 @@ findForwardLinkHealth(fromPageId: ObjectId, user: IUser | null): Promise<IBackli
 ##### API Contract
 | Method | Endpoint | Request | Response | Errors |
 |--------|----------|---------|----------|--------|
-| GET | `/_api/v3/page/backlinks` | query: `pageId` (MongoId) | `{ backlinks: IBacklinkPage[] }` | 400, 403, 500 |
+| GET | `/_api/v3/page/backlinks` | query: `pageId` (MongoId) | `{ backlinks: IBacklink[] }` | 400, 403, 500 |
 
 - Middleware: `accessTokenParser([SCOPE.READ.FEATURES.PAGE])`, `loginRequired` (guest per ACL),
   `apiV3FormValidator`; `req.user` is the viewer. Delegates to `PageLinkService.findBacklinks`.
@@ -482,7 +482,7 @@ findForwardLinkHealth(fromPageId: ObjectId, user: IUser | null): Promise<IBackli
 
 #### useSWRxBacklinks (summary)
 ```typescript
-useSWRxBacklinks(pageId: string | null): SWRResponse<IBacklinkPage[]>;
+useSWRxBacklinks(pageId: string | null): SWRResponse<IBacklink[]>;
 ```
 - Key `['/page/backlinks', pageId, isGuestUser]`; fetch via `apiv3Get(...).then(r => r.data.backlinks)`.
   `useSWRImmutable`; key `null` when `pageId == null`.
@@ -578,12 +578,18 @@ type LinkTargetState = 'normal' | 'trashed' | 'broken';
 // normal  := toPage resolves to an active page
 ```
 
-### DTO
+### DTOs
 ```typescript
-interface IBacklinkPage {
+// Incoming backlinks (findBacklinks): always live, readable source pages — no health to report.
+interface IBacklink {
   pageId: string;
   path: string;
-  targetState?: LinkTargetState; // present for forward-link-health rows
+}
+// Outgoing link health (findForwardLinkHealth): a page the subject links out to, plus its state.
+interface ILinkTarget {
+  pageId: string;
+  path: string;
+  targetState: LinkTargetState; // required — a health row is meaningless without it
 }
 ```
 

--- a/.kiro/specs/backlinks/tasks.md
+++ b/.kiro/specs/backlinks/tasks.md
@@ -10,8 +10,9 @@
 
 - [ ] 1. Foundation: data model, types, and indexes
 - [ ] 1.1 Define backlinks interfaces and shared types
-  - Define the `PageLink` shape (`fromPage`, `toPath`, `toPage`), the backlink DTO returned to
-    clients (page id + path, optional target state), and the `LinkTargetState` union
+  - Define the `IPageLink` edge shape (`fromPage`, `toPath`, `toPage`), the two client DTOs —
+    `IBacklink` (page id + path; incoming backlinks, always healthy) and `ILinkTarget` (page id +
+    path + required target state; outgoing link health) — and the `LinkTargetState` union
     (`normal` / `trashed` / `broken`)
   - Done when the types compile and are importable by both server and client code
   - _Requirements: 1.8, 6.4_
@@ -97,8 +98,8 @@
 
 - [ ] 3.3 Implement the permission-filtered read queries
   - Implement `findBacklinks` (sources pointing at a page, filtered to readable, non-trashed pages
-    via the shared viewer/grant filter, mapped to the DTO) and `findForwardLinkHealth` (a page's
-    outbound rows whose derived target state is trashed/broken)
+    via the shared viewer/grant filter, mapped to `IBacklink`) and `findForwardLinkHealth` (a page's
+    outbound rows whose derived target state is trashed/broken, mapped to `ILinkTarget`)
   - Never return unfiltered paths; any count is derived only from the filtered set; derive target
     state from `toPage`/target status rather than a stored flag
   - Done when integration tests show restricted source pages are omitted from results, and forward

--- a/.kiro/specs/backlinks/tasks.md
+++ b/.kiro/specs/backlinks/tasks.md
@@ -55,7 +55,7 @@ extraction and resolution for all of them as one unit; there is no separable "na
   - _Requirements: 1.5, 3.4_
   - _Depends: B1.1_
 
-- [ ] B1.3 Implement internal-link extraction from a page body — all link forms
+- [x] B1.3 Implement internal-link extraction from a page body — all link forms
   - Build a pure function that takes a Markdown body, the page's path, and the wiki's site URL, and
     returns a deduplicated list of resolved internal page paths, reusing the existing remark/rehype
     link plugins (pukiwiki + relative-links) in a trimmed server processor

--- a/.kiro/specs/backlinks/tasks.md
+++ b/.kiro/specs/backlinks/tasks.md
@@ -23,18 +23,14 @@
     index that enforces "one source listed once"
   - Declare the statics the service will use (replace-outbound, find-backlink-sources,
     reconcile-deleted, re-resolve-by-path) with typed signatures
+  - `PageLink` is a **new** collection, so the four indexes are created from these schema
+    declarations by Mongoose `autoIndex` at model registration — no migrate-mongo migration is
+    needed (same as the `PageTagRelation` precedent, whose unique compound index is schema-declared
+    with no migration). A migration would only be required to *drop/alter* an index later.
   - Done when the model registers and a unit test confirms the unique index rejects a duplicate
     `{fromPage, toPath}` insert
   - _Requirements: 1.5, 3.4_
   - _Depends: 1.1_
-
-- [ ] 1.3 Add the index-creation migration
-  - Create a migrate-mongo migration that creates the `PageLink` collection indexes only (no data
-    writes), with a `down` that drops the collection
-  - This runs at boot regardless of the backfill decision; it must stay fast (no body parsing)
-  - Done when running the migration creates the four indexes and the changelog records it once
-  - _Requirements: 3.4, 4.1_
-  - _Depends: 1.2_
 
 - [ ] 2. Core: link extraction and target resolution (pure logic)
 - [ ] 2.1 (P) Implement internal-link extraction from a page body

--- a/.kiro/specs/backlinks/tasks.md
+++ b/.kiro/specs/backlinks/tasks.md
@@ -1,39 +1,61 @@
 # Implementation Plan
 
-> **Backfill approach (decided): online, throttled, auto-started `CronService` job.** Tasks 1–5 and
-> 7.1–7.3 are independent of the backfill and can be implemented immediately. The backfill is isolated
-> in **Task 6** (+ test 7.4): an online, throttled job that **auto-starts** after boot — no admin
-> action (an admin-triggered start was deferred as a one-line future change). It reuses the
-> page-bulk-export scaffolding (`CronService` base, `createBatchStream`, the cursor→resume→`pipeline`
-> skeleton, the watchdog start/stop logic); the new code is link extraction/resolution, the in-memory
-> `{path→_id}` map, the `bulkWrite` upsert sink, and an atomic claim. **Task 6 is now unblocked.**
+> **Organized by story, not by architectural layer.** The five stories (B1–B5) are vertical,
+> shippable slices; this plan is sequenced so each story is a **contiguous block** you can build and
+> verify end-to-end before starting the next — no skipping around. B1 carries the shared foundation
+> (model, indexes, extractor, service, read path, panel) because the first vertical slice always
+> carries the walking skeleton; B2–B5 graft onto it.
+>
+> **Where a capability was split across stories**, the task notes call it out explicitly:
+> `resolveToPage`, the sync ops, the lifecycle handlers, the read queries, `BacklinkListItem`,
+> `BacklinksPanel`, and the event subscription each get their B1 half here and their B4/B5 half in
+> the later story.
+>
+> **Manual-implementation guide.** This plan is written to be worked by hand as a checklist (not via
+> `/kiro-impl`). Each task states what to build, a **Done when** acceptance line, the requirements it
+> satisfies, the **Boundary** (the symbol/module it lands in — see design.md § File Structure Plan),
+> and its dependencies. Tasks with no dependency between them can be done in any order.
+>
+> **Story independence:** B2 (perf), B3 (backfill), B4 (rename/move), and B5 (delete/broken) are all
+> independent of one another — each depends only on B1. Do them in whatever order you like after B1.
 
-- [ ] 1. Foundation: data model, types, and indexes
-- [ ] 1.1 Define backlinks interfaces and shared types
+---
+
+## Story B1 — See which pages link here (all link forms, permission-filtered)
+
+**Nature:** Foundation. Introduces the `PageLink` collection, the extractor, the live create/edit
+sync, the permission-filtered read, the API, and the panel. All five link forms (Markdown, wiki-link,
+raw HTML anchor, permalink `/{id}`, same-host absolute URL) ship together — the design builds
+extraction and resolution for all of them as one unit; there is no separable "naive query" or
+"wiki-links later" stage. Lifecycle coverage is **create/update only**.
+
+- [x] B1.1 Define backlinks interfaces and shared types
   - Define the `IPageLink` edge shape (`fromPage`, `toPath`, `toPage`), the two client DTOs —
     `IBacklink` (page id + path; incoming backlinks, always healthy) and `ILinkTarget` (page id +
     path + required target state; outgoing link health) — and the `LinkTargetState` union
     (`normal` / `trashed` / `broken`)
+  - Define `ILinkTarget` and the full union now even though outgoing health (`trashed`/`broken`)
+    isn't produced until B5 — declaring them up front is harmless and avoids a later type change
   - Done when the types compile and are importable by both server and client code
   - _Requirements: 1.8, 6.4_
 
-- [ ] 1.2 Implement the PageLink model with indexes and statics
+- [x] B1.2 Implement the PageLink model with indexes and the B1 statics
   - Create the Mongoose model following the `PageTagRelation` precedent (`getOrCreateModel`)
   - Declare indexes `{fromPage}`, `{toPath}`, `{toPage}` and the **unique** `{fromPage, toPath}`
     index that enforces "one source listed once"
-  - Declare the statics the service will use (replace-outbound, find-backlink-sources,
-    reconcile-deleted, re-resolve-by-path) with typed signatures
   - `PageLink` is a **new** collection, so the four indexes are created from these schema
     declarations by Mongoose `autoIndex` at model registration — no migrate-mongo migration is
     needed (same as the `PageTagRelation` precedent, whose unique compound index is schema-declared
     with no migration). A migration would only be required to *drop/alter* an index later.
-  - Done when the model registers and a unit test confirms the unique index rejects a duplicate
-    `{fromPage, toPath}` insert
+  - Implement the two statics B1 needs: replace-outbound and find-backlink-sources. You may declare
+    the typed signatures for re-resolve-by-path (implemented in B4) and reconcile-deleted
+    (implemented in B5) now, but do not implement them here
+  - Done when the model registers, its indexes exist, and a unit test confirms the unique index
+    rejects a duplicate `{fromPage, toPath}` insert
   - _Requirements: 1.5, 3.4_
-  - _Depends: 1.1_
+  - _Depends: B1.1_
 
-- [ ] 2. Core: link extraction and target resolution (pure logic)
-- [ ] 2.1 (P) Implement internal-link extraction from a page body
+- [ ] B1.3 Implement internal-link extraction from a page body — all link forms
   - Build a pure function that takes a Markdown body, the page's path, and the wiki's site URL, and
     returns a deduplicated list of resolved internal page paths, reusing the existing remark/rehype
     link plugins (pukiwiki + relative-links) in a trimmed server processor
@@ -43,194 +65,325 @@
     in-page `#` anchors and links inside code spans/blocks; strip query/anchor; normalize paths;
     gate on `isCreatablePage`; pass page-permalink (`/{id}`) targets through unchanged; drop the
     page's own-**path** self-link only (a link to the page's own permalink cannot be detected here —
-    the extractor has no page `_id` — and is dropped later at sync, task 3.1)
+    the extractor has no page `_id` — and is dropped later at sync, task B1.5)
   - Done when unit tests cover each link form and each exclusion rule, plus a same-host absolute URL
     kept as its path, a different-host URL and a (site-URL-unset) absolute URL both excluded, and a
     permalink returned verbatim; the deduped result excludes the page's own-path self-link
   - _Requirements: 1.2, 1.3, 1.4, 1.5, 1.6, 1.9, 1.10, 1.11_
   - _Boundary: extractInternalLinks_
-  - _Depends: 1.1_
+  - _Depends: B1.1 (independent of B1.2)_
 
-- [ ] 2.2 (P) Implement target-page resolution with redirect following
+- [ ] B1.4 Implement target-page resolution — direct path + permalink only
   - Build the live-path resolver: a **permalink** path (`/{id}`) resolves directly to that page id
     with no path lookup or redirect-following; otherwise a path resolves by direct path lookup, else
-    by following the redirect chain to its endpoint, else null
-  - Handle multi-hop renames (A→B→C) via the redirect endpoint lookup; null when neither a page nor
-    a redirect resolves (the broken case); a permalink to a non-existent id also resolves to null
-  - Done when unit tests cover direct hit, single and double redirect chains, the unresolved (null)
-    case, and a permalink resolving by id (and to null when no page has that id)
-  - _Requirements: 1.9, 5.1, 5.2, 5.3, 5.4_
+    null. A permalink to a non-existent id also resolves to null
+  - **B1 scope: no redirect-chain following.** Following the redirect chain to its endpoint (for
+    renamed/moved targets, multi-hop A→B→C) is deferred to **B4.1**. In B1, a link to a page that has
+    since moved resolves to null until B4 is built — acceptable for the create/update-only slice
+  - Done when unit tests cover a direct path hit, a permalink resolving by id, and both null cases
+    (no page at path; no page with that id)
+  - _Requirements: 1.9_
   - _Boundary: resolveToPage_
-  - _Depends: 1.1_
+  - _Depends: B1.1 (independent of B1.2, B1.3)_
 
-- [ ] 3. Core: synchronization logic and the backlinks service
-- [ ] 3.1 Implement the index synchronization operations
-  - Implement the row operations on top of the model: replace a source page's outbound rows from a
+- [ ] B1.5 Implement the index synchronization operations — replace-outbound + self-drop only
+  - Implement the row operation on top of the model: replace a source page's outbound rows from a
     freshly extracted+resolved set, **dropping any resolved row whose target is the source page
-    itself** (covers a page linking to its own permalink); re-resolve inbound rows matching a given
-    path (to repoint stale caches when a page appears at that path); reconcile a deleted page by
-    checking its current DB state (still trashed → no-op; truly gone → remove its outbound rows and
-    null inbound `toPage`)
-  - Done when unit tests show: replacing outbound rows is idempotent and excludes a self-permalink
-    row; reconcile no-ops a trashed page and nulls inbound `toPage` for a permanently-gone page
-  - _Requirements: 1.6, 3.1, 3.2, 3.3, 6.2_
+    itself** (covers a page linking to its own permalink, and any alias that resolves back to the
+    source — the self-permalink half of 1.6)
+  - **B1 scope:** skip reconcile-deleted (B5.2) and re-resolve-by-path (B4.2)
+  - Done when unit tests show replacing outbound rows is idempotent and excludes a self-permalink row
+  - _Requirements: 1.6, 3.1, 3.2_
   - _Boundary: page-link-sync, PageLink_
-  - _Depends: 1.2, 2.1, 2.2_
+  - _Depends: B1.2, B1.3, B1.4_
 
-- [ ] 3.2 Implement the lifecycle event handlers in the backlinks service
-  - Implement service handlers that, given a page lifecycle event, drive the sync operations:
-    create/update re-extract the body and replace outbound rows (create also re-resolves inbound
-    matches); delete/deleteCompletely/syncDescendantsDelete route to the state-based reconcile
-  - The service reads the configured site URL and passes it into extraction (so same-wiki absolute
-    URLs are recognized), keeping the extractor itself config-free
-  - Handlers are idempotent and tolerate missing/empty bodies and already-removed pages; they read
-    the body from the latest revision when the event payload lacks it
-  - Done when unit tests invoke each handler with a fake event payload and assert the resulting row
-    changes (created/replaced/removed/nulled), including a same-wiki absolute link recorded as an
+- [ ] B1.6 Implement the create/update lifecycle handlers in the backlinks service
+  - Implement the service handlers for create and update: re-extract the body and replace the source
+    page's outbound rows via B1.5. The service reads the configured site URL and passes it into
+    extraction (so same-wiki absolute URLs are recognized), keeping the extractor itself config-free.
+    Read the body from the latest revision when the event payload lacks it
+  - Handlers are idempotent and tolerate missing/empty bodies
+  - **B1 scope:** create does **not** re-resolve inbound matches here — repointing stale caches when
+    a page appears at a previously-occupied path is deferred to **B4.3**. Skip the delete-family
+    handlers (B5.3)
+  - Done when unit tests invoke the create and update handlers with a fake event payload and assert
+    the resulting row changes (created/replaced), including a same-wiki absolute link recorded as an
     internal row
-  - _Requirements: 1.10, 1.11, 3.1, 3.2, 3.3, 6.2_
+  - _Requirements: 1.10, 1.11, 3.1, 3.2_
   - _Boundary: PageLinkService_
-  - _Depends: 3.1_
+  - _Depends: B1.5_
 
-- [ ] 3.3 Implement the permission-filtered read queries
+- [ ] B1.7 Implement the permission-filtered read query — findBacklinks only
   - Implement `findBacklinks` (sources pointing at a page, filtered to readable, non-trashed pages
-    via the shared viewer/grant filter, mapped to `IBacklink`) and `findForwardLinkHealth` (a page's
-    outbound rows whose derived target state is trashed/broken, mapped to `ILinkTarget`)
-  - Never return unfiltered paths; any count is derived only from the filtered set; derive target
-    state from `toPage`/target status rather than a stored flag
-  - Done when integration tests show restricted source pages are omitted from results, and forward
-    health reports trashed/broken targets with the correct state
-  - _Requirements: 1.1, 2.1, 2.2, 2.3, 2.4, 5.3, 6.1, 6.3, 6.4_
+    via the shared viewer/grant filter, mapped to `IBacklink`)
+  - Never return unfiltered paths; any count is derived only from the filtered set
+  - **B1 scope:** skip `findForwardLinkHealth` (B5.4)
+  - Done when integration tests show restricted source pages are omitted from results, and the query
+    returns the readable, non-trashed sources as `IBacklink` DTOs
+  - _Requirements: 1.1, 2.1, 2.2, 2.3, 2.4_
   - _Boundary: PageLinkService_
-  - _Depends: 3.1_
+  - _Depends: B1.2_
 
-- [ ] 4. Read API and UI
-- [ ] 4.1 (P) Add the backlinks read endpoint
+- [ ] B1.8 Add the backlinks read endpoint
   - Add an authenticated apiv3 GET route that validates a page id, resolves the viewer from the
     request, and returns the permission-filtered backlinks for that page
   - Done when the endpoint returns backlinks for a readable page and 400/403 for invalid id /
     no-access, delegating filtering to the service
   - _Requirements: 1.1, 2.1, 6.4_
   - _Boundary: get-page-backlinks route_
-  - _Depends: 3.3_
+  - _Depends: B1.7_
 
-- [ ] 4.2 Add the client data hook
+- [ ] B1.9 Add the client data hook
   - Add an SWR hook keyed by page id (and guest state) that fetches from the backlinks endpoint and
     returns the backlink list
   - Done when the hook returns data for a page and revalidates when the page id changes
   - _Requirements: 1.1_
   - _Boundary: useSWRxBacklinks_
-  - _Depends: 4.1_
+  - _Depends: B1.8_
 
-- [ ] 4.3 (P) Build the backlink list-item component
+- [ ] B1.10 Build the backlink list-item component — title + path only
   - Build a presentational row showing a linked page's title and path (reusing existing page-path
-    label components) plus a target-state badge for trashed/broken targets
-  - Done when the component renders title + path for a normal link and shows the badge for
-    trashed/broken targets
-  - _Requirements: 1.8, 6.4_
+    label components)
+  - **B1 scope:** skip the trashed/broken target-state badge (B5.5)
+  - Done when the component renders title + path for a normal link
+  - _Requirements: 1.8_
   - _Boundary: BacklinkListItem_
-  - _Depends: 1.1_
+  - _Depends: B1.1_
 
-- [ ] 4.4 Build the backlinks panel
-  - Build the panel that lists incoming links via the hook, renders an explicit empty state when
-    there are none, and shows a secondary "outgoing links needing attention" section from forward
-    health
-  - Done when the panel shows the backlink list, the empty state with no backlinks, and the
-    forward-health section flags trashed/broken outgoing links
-  - _Requirements: 1.1, 1.7, 1.8, 6.4_
+- [ ] B1.11 Build the backlinks panel — incoming list + empty state
+  - Build the panel that lists incoming links via the hook and renders an explicit empty state when
+    there are none
+  - **B1 scope:** skip the secondary "outgoing links needing attention" forward-health section (B5.6)
+  - Done when the panel shows the backlink list and the empty state when there are no backlinks
+  - _Requirements: 1.1, 1.7, 1.8_
   - _Boundary: BacklinksPanel_
-  - _Depends: 4.2, 4.3_
+  - _Depends: B1.9, B1.10_
 
-- [ ] 5. Integration: wire into the running app
-- [ ] 5.1 Subscribe the backlinks service to page lifecycle events
-  - Instantiate and initialize the backlinks service in the server setup phase (mirroring the
-    search service), subscribing its handlers to create/update/delete/deleteCompletely/
-    syncDescendantsDelete; do not modify the page service
-  - Done when creating, editing, and deleting a page through the app changes `PageLink` rows
-    accordingly (verified by an integration test that drives real lifecycle calls)
-  - _Requirements: 3.1, 3.2, 3.3_
+- [ ] B1.12 Subscribe the service to create/update lifecycle events
+  - Instantiate and initialize the backlinks service in the server setup phase (mirroring the search
+    service), subscribing its handlers to create/update only; do not modify the page service
+  - **B1 scope:** skip the delete-family subscriptions (delete/deleteCompletely/
+    syncDescendantsDelete) — B5.7
+  - Done when creating and editing a page through the app changes `PageLink` rows accordingly
+    (verified by B1.15's lifecycle integration test)
+  - _Requirements: 3.1, 3.2_
   - _Boundary: crowi setup, PageLinkService_
-  - _Depends: 3.2_
+  - _Depends: B1.6_
 
-- [ ] 5.2 (P) Register the backlinks endpoint
+- [ ] B1.13 Register the backlinks endpoint
   - Register the read route in the apiv3 router
   - Done when the endpoint is reachable over HTTP and returns backlinks for a seeded page
   - _Requirements: 1.1_
   - _Boundary: apiv3 router_
-  - _Depends: 4.1_
+  - _Depends: B1.8 (independent of B1.12)_
 
-- [ ] 5.3 (P) Add the Backlinks tab to the page accessories UI
+- [ ] B1.14 Add the Backlinks tab to the page accessories UI
   - Add a Backlinks entry to the page-accessories tab mapping that renders the panel
   - Done when opening the tab on a page displays the backlinks panel
   - _Requirements: 1.1_
   - _Boundary: PageAccessoriesModal_
-  - _Depends: 4.4_
+  - _Depends: B1.11_
 
-- [ ] 6. Backfill of pre-existing pages — online, throttled, auto-started CronService job
-  - An online, throttled, resumable background job that auto-starts after boot. Reuses the
-    page-bulk-export scaffolding; the extract→resolve→bulkWrite core reuses 2.1.
-- [ ] 6.1 Add the backfill job state model
+- [ ] B1.15 Integration tests (B1 slice)
+  - Cover: create/update add and remove backlinks; backlinks exclude pages the viewer cannot read and
+    reflect grant changes; a source linking B→A more than once is listed once; a page linking to its
+    own permalink is excluded from its own backlinks
+  - **B1 scope:** skip rename/move (B4.4) and trash/delete/restore (B5.8) scenarios
+  - Done when these scenarios pass against the wired service through real create/update lifecycle calls
+  - _Requirements: 1.6, 2.1, 2.2, 2.3, 2.4, 3.1, 3.2_
+  - _Depends: B1.12, B1.13_
+
+- [ ] B1.16 E2E test for the backlinks panel (B1 slice)
+  - Verify the Backlinks tab lists linking pages with title + path, and shows the empty state when
+    none exist
+  - **B1 scope:** skip trashed/deleted-target-indicator assertions (B5.8)
+  - Done when the E2E flow passes for the populated and empty cases
+  - _Requirements: 1.1, 1.7, 1.8_
+  - _Depends: B1.14_
+
+---
+
+## Story B2 — Backlinks retrieval at scale (perf validation)
+
+**Nature:** Validation-only. No new production code — it exercises the B1 read path against a large
+dataset. Depends only on B1.
+
+- [ ] B2.1 Performance check for backlinks retrieval at scale
+  - Verify a heavily-linked page's backlinks return in interactive time (<~1s) on a large
+    (~100k-page) dataset, exercising the `{toPage}` index and the viewer filter
+  - Done when a measured retrieval against the large dataset meets the latency target
+  - _Requirements: 3.4_
+  - _Depends: B1.12, B1.13_
+
+---
+
+## Story B3 — Backfill of pre-existing pages
+
+**Nature:** Online, throttled, resumable, auto-started `CronService` job that populates rows for pages
+that existed before the feature. Reuses the page-bulk-export scaffolding (`CronService` base,
+`createBatchStream`, cursor→resume→`pipeline` skeleton, watchdog start/stop) and the B1 extractor; the
+new code is the in-memory `{path→_id}` map, the `bulkWrite` upsert sink, and the atomic claim. An
+admin-triggered start was deferred as a one-line future change. Independent of B4/B5.
+
+- [ ] B3.1 Add the backfill job state model
   - Add a single-document model tracking backfill status, a progress marker (resume point), and an
     atomic-claim field so only one instance runs the job and it stops once complete
-  - Done when a unit test shows the claim succeeds once and is rejected for a second concurrent
-    claimant
+  - Done when a unit test shows the claim succeeds once and is rejected for a second concurrent claimant
   - _Requirements: 4.3_
   - _Boundary: PageLinkBackfillJob_
-  - _Depends: 1.2_
+  - _Depends: B1.2_
 
-- [ ] 6.2 Implement the throttled, resumable backfill job
+- [ ] B3.2 Implement the throttled, resumable backfill job
   - Implement a cron-based job that, per tick, processes a bounded chunk of pages: build/reuse an
-    in-memory path→id map (one projection query) for resolution instead of per-link lookups,
-    extract links via the core extractor (passing the configured site URL), resolve permalink
-    targets via an id-existence check against the known page ids (not the path map), and bulk-upsert
-    rows; persist the progress marker after each chunk and resume from it on restart
+    in-memory path→id map (one projection query) for resolution instead of per-link lookups, extract
+    links via the B1 extractor (passing the configured site URL), resolve permalink targets via an
+    id-existence check against the known page ids (not the path map), and bulk-upsert rows; persist
+    the progress marker after each chunk and resume from it on restart
   - Throttle via cron cadence × chunk size; skip immediately once the job document is complete
   - Done when running the job over a seeded dataset (including pages linked by permalink and by
     same-wiki absolute URL) populates rows equivalent to the live path, a re-run/resume adds no
     duplicates, and progress is emitted on the admin channel
   - _Requirements: 4.1, 4.2, 4.3_
   - _Boundary: PageLinkBackfillCron_
-  - _Depends: 6.1, 2.1, 1.2_
+  - _Depends: B3.1, B1.3, B1.2_
 
-- [ ] 6.3 Register and auto-start the backfill job
+- [ ] B3.3 Register and auto-start the backfill job
   - Register the backfill cron in server setup and auto-start it (throttled) after boot, mirroring
     the page-bulk-export watchdog start/stop; stop permanently once the job document is marked complete
-  - Note: this edits the same server-setup file as 5.1; sequence after 5.1 to avoid a merge
-  - Done when, after boot, the job claims and runs to completion on a fresh dataset and marks
-    itself complete so it does not re-run
+  - Note: edits the same server-setup file as B1.12 — sequence after it to avoid a merge
+  - Done when, after boot, the job claims and runs to completion on a fresh dataset and marks itself
+    complete so it does not re-run
   - _Requirements: 4.1_
   - _Boundary: crowi setup, PageLinkBackfillCron_
-  - _Depends: 6.2, 5.1_
+  - _Depends: B3.2, B1.12_
 
-- [ ] 7. Validation
-- [ ] 7.1 Integration tests for lifecycle, permissions, rename/move, and delete states
-  - Cover: create/update add and remove backlinks; deleted page is no longer an active source;
-    backlinks exclude pages the viewer cannot read and reflect grant changes; inbound links survive
-    rename/move (including descendants) with no index writes; a permalink-based backlink keeps
-    resolving after its target is renamed/moved with no index writes; a page linking to its own
-    permalink is excluded from its own backlinks; trash → trashed, permanent delete → broken,
-    restore → normal
-  - Done when these scenarios pass against the wired service through real lifecycle operations
-  - _Requirements: 1.6, 1.9, 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 5.1, 5.2, 5.4, 6.1, 6.2, 6.3_
-  - _Depends: 5.1_
-
-- [ ] 7.2 E2E test for the backlinks panel
-  - Verify the Backlinks tab lists linking pages with title + path, shows the empty state when none
-    exist, and indicates trashed/deleted targets for outgoing links
-  - Done when the E2E flow passes for the populated, empty, and trashed/broken-target cases
-  - _Requirements: 1.1, 1.7, 1.8, 6.4_
-  - _Depends: 5.3_
-
-- [ ] 7.3 Performance check for backlinks retrieval at scale
-  - Verify a heavily-linked page's backlinks return in interactive time (<~1s) on a large
-    (~100k-page) dataset, exercising the `{toPage}` index and the viewer filter
-  - Done when a measured retrieval against the large dataset meets the latency target
-  - _Requirements: 3.4_
-  - _Depends: 5.1, 5.2_
-
-- [ ] 7.4 Backfill tests
-  - Verify backfill output matches the live path; running twice or resuming after an interrupted
-    chunk produces no duplicates; the atomic claim prevents two instances/ticks double-processing
+- [ ] B3.4 Backfill tests
+  - Verify backfill output matches the live path; running twice or resuming after an interrupted chunk
+    produces no duplicates; the atomic claim prevents two instances/ticks double-processing
   - Done when these pass against a seeded dataset
   - _Requirements: 4.1, 4.2, 4.3_
-  - _Depends: 6.2_
+  - _Depends: B3.2_
+
+---
+
+## Story B4 — Link integrity across rename / move
+
+**Nature:** Extends resolution so inbound links survive a target's rename/move. Rename/move emit no
+usable event and need none: `_id`-stable `toPage` keeps links cached before the move valid, and
+redirect-following keeps links resolvable when the source is re-saved after the move. This story adds
+the redirect-following half of resolution plus the re-resolve-by-path repointing. Independent of
+B3/B5.
+
+- [ ] B4.1 Add redirect-chain following to resolveToPage
+  - Extend the resolver with the redirect step deferred from B1.4: when direct path lookup misses,
+    follow the redirect chain to its endpoint and resolve there; handle multi-hop renames (A→B→C) via
+    the redirect endpoint lookup; null when neither a page nor a redirect resolves (the broken case).
+    A permalink `toPath` still short-circuits by id (never needs redirect-following — 5.4)
+  - Done when unit tests cover single and double redirect chains resolving to the endpoint, and the
+    unresolved (null) case
+  - _Requirements: 1.9, 5.1, 5.2, 5.3, 5.4_
+  - _Boundary: resolveToPage_
+  - _Depends: B1.4_
+
+- [ ] B4.2 Implement the re-resolve-by-path sync operation
+  - Implement the row op deferred from B1.5: re-resolve inbound rows matching a given path (to repoint
+    stale caches when a page appears at that path)
+  - Done when a unit test shows inbound rows for a path get their `toPage` repointed when a page
+    resolves at that path
+  - _Requirements: 5.1, 5.2_
+  - _Boundary: page-link-sync, PageLink_
+  - _Depends: B1.2, B4.1_
+
+- [ ] B4.3 Wire re-resolve into the create handler
+  - Extend the B1.6 create handler to re-resolve inbound matches (`reResolveByToPath(page.path)`)
+    after replacing outbound rows, so links that previously pointed at this path (from a prior
+    occupant or a broken state) are corrected when the page is (re)created at it
+  - Done when a unit test shows creating a page at a path repoints inbound rows that referenced that path
+  - _Requirements: 5.1, 5.2_
+  - _Boundary: PageLinkService_
+  - _Depends: B4.2, B1.6_
+
+- [ ] B4.4 Integration tests (rename/move)
+  - Cover: inbound links survive a target's rename/move (including descendant moves) with **no index
+    writes** — resolution + `_id`-stable cache keep them valid; a permalink-based backlink keeps
+    resolving after its target is renamed/moved with no index writes (5.4)
+  - Done when these scenarios pass against the wired service through real rename/move operations
+  - _Requirements: 1.9, 5.1, 5.2, 5.4_
+  - _Depends: B4.3, B1.12_
+
+---
+
+## Story B5 — Broken / trashed link handling on deletion
+
+**Nature:** Adds the delete-family reconcile, the derived target-state (`trashed`/`broken`), the
+forward-link-health read, and the UI that surfaces it. Restore needs no write — derived state reads
+the restored page's status. Independent of B3/B4.
+
+- [ ] B5.1 Add the reconcile static and target-state derivation
+  - Implement the reconcile-deleted static on the model (signature declared in B1.2) and the
+    `LinkTargetState` derivation helper (`toPage == null` → `broken`; target trashed → `trashed`; else
+    `normal`) — state is derived, never stored
+  - Done when unit tests cover the three derived states from `toPage`/target status
+  - _Requirements: 6.1, 6.2, 6.3_
+  - _Boundary: PageLink, page-link-sync_
+  - _Depends: B1.2_
+
+- [ ] B5.2 Implement the reconcile-deleted sync operation
+  - Implement the reconcile op deferred from B1.5: reconcile a deleted page by checking its current DB
+    state — still trashed → no-op (derived state shows trashed); truly gone → remove its outbound rows
+    and null inbound `toPage` (broken)
+  - Done when unit tests show reconcile no-ops a trashed page and nulls inbound `toPage` for a
+    permanently-gone page
+  - _Requirements: 3.3, 6.1, 6.2_
+  - _Boundary: page-link-sync_
+  - _Depends: B5.1_
+
+- [ ] B5.3 Implement the delete-family lifecycle handlers
+  - Implement the service handlers deferred from B1.6: delete/deleteCompletely/syncDescendantsDelete
+    all route to the state-based reconcile. Idempotent; tolerate already-removed pages
+  - Done when unit tests invoke each handler with a fake event payload and assert the resulting row
+    changes (removed/nulled)
+  - _Requirements: 3.3, 6.1, 6.2_
+  - _Boundary: PageLinkService_
+  - _Depends: B5.2, B1.6_
+
+- [ ] B5.4 Implement the forward-link-health read query
+  - Implement `findForwardLinkHealth` (a page's outbound rows whose derived target state is
+    trashed/broken, mapped to `ILinkTarget`); derive target state from `toPage`/target status rather
+    than a stored flag
+  - Done when an integration test shows forward health reports trashed/broken targets with the correct
+    state
+  - _Requirements: 5.3, 6.1, 6.2, 6.3, 6.4_
+  - _Boundary: PageLinkService_
+  - _Depends: B5.1, B1.7_
+
+- [ ] B5.5 Add the target-state badge to the list-item
+  - Extend `BacklinkListItem` (from B1.10) with a trashed/broken target-state badge
+  - Done when the component shows the badge for trashed/broken targets and renders unchanged for normal ones
+  - _Requirements: 6.4_
+  - _Boundary: BacklinkListItem_
+  - _Depends: B1.10_
+
+- [ ] B5.6 Add the forward-health section to the panel
+  - Extend `BacklinksPanel` (from B1.11) with the secondary "outgoing links needing attention" section
+    that flags trashed/broken outgoing links from the forward-health read
+  - Done when the panel flags trashed/broken outgoing links; the incoming list and empty state are unchanged
+  - _Requirements: 6.4_
+  - _Boundary: BacklinksPanel_
+  - _Depends: B5.4, B5.5, B1.11_
+
+- [ ] B5.7 Subscribe the delete-family lifecycle events
+  - Extend the B1.12 subscription with delete/deleteCompletely/syncDescendantsDelete → the B5.3 handlers
+  - Done when deleting a page through the app reconciles `PageLink` rows accordingly
+  - _Requirements: 3.3, 6.1, 6.2_
+  - _Boundary: crowi setup, PageLinkService_
+  - _Depends: B5.3, B1.12_
+
+- [ ] B5.8 Integration + E2E tests (delete/broken states)
+  - Integration: deleted page is no longer an active source; trash → trashed; permanent delete →
+    broken; restore → normal. E2E: an editor viewing a page that links to a trashed/deleted target
+    sees the trashed/broken indicator for outgoing links
+  - Done when these scenarios pass against the wired service through real trash/delete/restore
+    operations and the E2E indicator flow passes
+  - _Requirements: 3.3, 6.1, 6.2, 6.3, 6.4_
+  - _Depends: B5.7, B5.6_

--- a/apps/app/src/features/backlinks/interfaces/page-link.ts
+++ b/apps/app/src/features/backlinks/interfaces/page-link.ts
@@ -26,5 +26,8 @@ export interface PageLinkModel extends Model<PageLinkDocument> {
     resolvedRows: IPageLink[],
   ): Promise<void>;
   findBacklinkSources(toPageId: ObjectId): Promise<ObjectId[]>;
+  // Declared here for downstream stories; implemented later (re-resolve-by-path in B4,
+  // reconcile-deleted in B5) — not implemented in B1.
+  reResolveByToPath(toPath: string): Promise<void>;
   reconcileDeletedPages(pageIds: ObjectId[]): Promise<void>;
 }

--- a/apps/app/src/features/backlinks/interfaces/page-link.ts
+++ b/apps/app/src/features/backlinks/interfaces/page-link.ts
@@ -21,4 +21,8 @@ export interface IPageLink {
 }
 
 export interface PageLinkDocument extends IPageLink, Document {}
-export interface PageLinkModel extends Model<PageLinkDocument> {}
+export interface PageLinkModel extends Model<PageLinkDocument> {
+  replaceOutboundLinks(fromPageId: ObjectId, resolvedRows: IPageLink[]): void;
+  findBacklinkSources(toPageId: ObjectId): ObjectId[];
+  reconcileDeletedPages(pageIds: ObjectId[]): void;
+}

--- a/apps/app/src/features/backlinks/interfaces/page-link.ts
+++ b/apps/app/src/features/backlinks/interfaces/page-link.ts
@@ -1,0 +1,11 @@
+import type { Document, ObjectId } from 'mongodb';
+import type { Model } from 'mongoose';
+
+export interface PageLink {
+  fromPage: ObjectId;
+  toPath: string;
+  toPage: ObjectId | null;
+}
+
+export interface PageLinkDocument extends PageLink, Document {}
+export interface PageLinkModel extends Model<PageLinkDocument> {}

--- a/apps/app/src/features/backlinks/interfaces/page-link.ts
+++ b/apps/app/src/features/backlinks/interfaces/page-link.ts
@@ -1,11 +1,24 @@
 import type { Document, ObjectId } from 'mongodb';
 import type { Model } from 'mongoose';
 
-export interface PageLink {
+export type LinkTargetState = 'normal' | 'trashed' | 'broken';
+
+export interface IBacklink {
+  pageId: string;
+  path: string;
+}
+
+export interface ILinkTarget {
+  pageId: string;
+  path: string;
+  targetState: LinkTargetState;
+}
+
+export interface IPageLink {
   fromPage: ObjectId;
   toPath: string;
   toPage: ObjectId | null;
 }
 
-export interface PageLinkDocument extends PageLink, Document {}
+export interface PageLinkDocument extends IPageLink, Document {}
 export interface PageLinkModel extends Model<PageLinkDocument> {}

--- a/apps/app/src/features/backlinks/interfaces/page-link.ts
+++ b/apps/app/src/features/backlinks/interfaces/page-link.ts
@@ -1,5 +1,4 @@
-import type { Document, ObjectId } from 'mongodb';
-import type { Model } from 'mongoose';
+import type { Document, Model, ObjectId } from 'mongoose';
 
 export type LinkTargetState = 'normal' | 'trashed' | 'broken';
 
@@ -22,7 +21,10 @@ export interface IPageLink {
 
 export interface PageLinkDocument extends IPageLink, Document {}
 export interface PageLinkModel extends Model<PageLinkDocument> {
-  replaceOutboundLinks(fromPageId: ObjectId, resolvedRows: IPageLink[]): void;
-  findBacklinkSources(toPageId: ObjectId): ObjectId[];
-  reconcileDeletedPages(pageIds: ObjectId[]): void;
+  replaceOutboundLinks(
+    fromPageId: ObjectId,
+    resolvedRows: IPageLink[],
+  ): Promise<void>;
+  findBacklinkSources(toPageId: ObjectId): Promise<ObjectId[]>;
+  reconcileDeletedPages(pageIds: ObjectId[]): Promise<void>;
 }

--- a/apps/app/src/features/backlinks/server/models/page-link.ts
+++ b/apps/app/src/features/backlinks/server/models/page-link.ts
@@ -3,12 +3,12 @@ import { Schema } from 'mongoose';
 import { getOrCreateModel } from '~/server/util/mongoose-utils';
 
 import type {
-  PageLink,
+  IPageLink,
   PageLinkDocument,
   PageLinkModel,
 } from '../../interfaces/page-link';
 
-const PageLinkSchema = new Schema<PageLink>({
+const PageLinkSchema = new Schema<IPageLink>({
   fromPage: {
     type: Schema.Types.ObjectId,
   },

--- a/apps/app/src/features/backlinks/server/models/page-link.ts
+++ b/apps/app/src/features/backlinks/server/models/page-link.ts
@@ -38,7 +38,7 @@ pageLinkSchema.index({ fromPage: 1, toPath: 1 }, { unique: true });
 pageLinkSchema.statics.replaceOutboundLinks = async function (
   fromPageId: ObjectId,
   resolvedRows: IPageLink[],
-) {
+): Promise<void> {
   const toPaths = resolvedRows.map((r) => r.toPath);
 
   if (resolvedRows.length > 0) {
@@ -74,7 +74,7 @@ pageLinkSchema.statics.findBacklinkSources = async function (
  */
 pageLinkSchema.statics.reconcileDeletedPages = async function (
   pageIds: ObjectId[],
-) {
+): Promise<void> {
   await this.updateMany(
     { toPage: { $in: pageIds } },
     { $set: { toPage: null } },

--- a/apps/app/src/features/backlinks/server/models/page-link.ts
+++ b/apps/app/src/features/backlinks/server/models/page-link.ts
@@ -1,4 +1,4 @@
-import type { ObjectId } from 'mongodb';
+import type { ObjectId } from 'mongoose';
 import { Schema } from 'mongoose';
 
 import { getOrCreateModel } from '~/server/util/mongoose-utils';
@@ -67,22 +67,6 @@ pageLinkSchema.statics.findBacklinkSources = async function (
   toPageId: ObjectId,
 ): Promise<ObjectId[]> {
   return await this.distinct('fromPage', { toPage: toPageId });
-};
-
-/**
- * Delete links from permanently deleted pages and set links linking there to broken.
- */
-pageLinkSchema.statics.reconcileDeletedPages = async function (
-  pageIds: ObjectId[],
-): Promise<void> {
-  await this.updateMany(
-    { toPage: { $in: pageIds } },
-    { $set: { toPage: null } },
-  );
-
-  await this.deleteMany({
-    fromPage: { $in: pageIds },
-  });
 };
 
 export default getOrCreateModel<PageLinkDocument, PageLinkModel>(

--- a/apps/app/src/features/backlinks/server/models/page-link.ts
+++ b/apps/app/src/features/backlinks/server/models/page-link.ts
@@ -3,25 +3,33 @@ import { Schema } from 'mongoose';
 import { getOrCreateModel } from '~/server/util/mongoose-utils';
 
 import type {
-  IPageLink,
   PageLinkDocument,
   PageLinkModel,
 } from '../../interfaces/page-link';
 
-const PageLinkSchema = new Schema<IPageLink>({
+const pageLinkSchema = new Schema<PageLinkDocument, PageLinkModel>({
   fromPage: {
     type: Schema.Types.ObjectId,
+    ref: 'Page',
+    required: true,
+    index: true,
   },
   toPath: {
     type: String,
+    required: true,
+    index: true,
   },
   toPage: {
     type: Schema.Types.ObjectId,
+    ref: 'Page',
     default: null,
+    index: true,
   },
 });
 
+pageLinkSchema.index({ fromPage: 1, toPath: 1 }, { unique: true });
+
 export default getOrCreateModel<PageLinkDocument, PageLinkModel>(
   'PageLink',
-  PageLinkSchema,
+  pageLinkSchema,
 );

--- a/apps/app/src/features/backlinks/server/models/page-link.ts
+++ b/apps/app/src/features/backlinks/server/models/page-link.ts
@@ -1,0 +1,27 @@
+import { Schema } from 'mongoose';
+
+import { getOrCreateModel } from '~/server/util/mongoose-utils';
+
+import type {
+  PageLink,
+  PageLinkDocument,
+  PageLinkModel,
+} from '../../interfaces/page-link';
+
+const PageLinkSchema = new Schema<PageLink>({
+  fromPage: {
+    type: Schema.Types.ObjectId,
+  },
+  toPath: {
+    type: String,
+  },
+  toPage: {
+    type: Schema.Types.ObjectId,
+    default: null,
+  },
+});
+
+export default getOrCreateModel<PageLinkDocument, PageLinkModel>(
+  'PageLink',
+  PageLinkSchema,
+);

--- a/apps/app/src/features/backlinks/server/models/page-link.ts
+++ b/apps/app/src/features/backlinks/server/models/page-link.ts
@@ -1,8 +1,10 @@
+import type { ObjectId } from 'mongodb';
 import { Schema } from 'mongoose';
 
 import { getOrCreateModel } from '~/server/util/mongoose-utils';
 
 import type {
+  IPageLink,
   PageLinkDocument,
   PageLinkModel,
 } from '../../interfaces/page-link';
@@ -28,6 +30,60 @@ const pageLinkSchema = new Schema<PageLinkDocument, PageLinkModel>({
 });
 
 pageLinkSchema.index({ fromPage: 1, toPath: 1 }, { unique: true });
+
+/**
+ * Replace a page's outbound links with the freshly extracted set:
+ * insert new links, refresh existing ones, and delete links no longer present.
+ */
+pageLinkSchema.statics.replaceOutboundLinks = async function (
+  fromPageId: ObjectId,
+  resolvedRows: IPageLink[],
+) {
+  const toPaths = resolvedRows.map((r) => r.toPath);
+
+  if (resolvedRows.length > 0) {
+    await this.bulkWrite(
+      resolvedRows.map((r) => ({
+        updateOne: {
+          filter: { fromPage: fromPageId, toPath: r.toPath },
+          update: { $set: { toPage: r.toPage } },
+          upsert: true,
+        },
+      })),
+      { ordered: false },
+    );
+  }
+
+  await this.deleteMany({
+    fromPage: fromPageId,
+    toPath: { $nin: toPaths },
+  });
+};
+
+/**
+ * Find IDs to all pages linking to this page.
+ */
+pageLinkSchema.statics.findBacklinkSources = async function (
+  toPageId: ObjectId,
+): Promise<ObjectId[]> {
+  return await this.distinct('fromPage', { toPage: toPageId });
+};
+
+/**
+ * Delete links from permanently deleted pages and set links linking there to broken.
+ */
+pageLinkSchema.statics.reconcileDeletedPages = async function (
+  pageIds: ObjectId[],
+) {
+  await this.updateMany(
+    { toPage: { $in: pageIds } },
+    { $set: { toPage: null } },
+  );
+
+  await this.deleteMany({
+    fromPage: { $in: pageIds },
+  });
+};
 
 export default getOrCreateModel<PageLinkDocument, PageLinkModel>(
   'PageLink',

--- a/apps/app/src/features/backlinks/server/services/extract-internal-links.spec.ts
+++ b/apps/app/src/features/backlinks/server/services/extract-internal-links.spec.ts
@@ -139,6 +139,15 @@ describe('extractInternalLinks()', () => {
     expect(links).toStrictEqual(['/docs/v2']);
   });
 
+  it('skips a link with invalid percent-encoding without dropping valid ones', async () => {
+    const pageString = '[bad](/deals/50%off) [good](/docs/v2)';
+    const pagePath = '/page/test';
+
+    const links = await extractInternalLinks(pageString, pagePath);
+
+    expect(links).toStrictEqual(['/docs/v2']);
+  });
+
   it('strips hash and query from internal link', async () => {
     const pageString = '[a](/docs/v2#section?x=1)';
     const pagePath = '/page/test';

--- a/apps/app/src/features/backlinks/server/services/extract-internal-links.spec.ts
+++ b/apps/app/src/features/backlinks/server/services/extract-internal-links.spec.ts
@@ -94,6 +94,15 @@ describe('extractInternalLinks()', () => {
     expect(links).toStrictEqual([]);
   });
 
+  it('does not extract an absolute URL when siteUrl is unset', async () => {
+    const pageString = 'https://test.com/folders/doc';
+    const pagePath = '/page/test';
+
+    const links = await extractInternalLinks(pageString, pagePath);
+
+    expect(links).toStrictEqual([]);
+  });
+
   it('does not extract anchor link', async () => {
     const pageString = '[jump to 5](#section-5)';
     const pagePath = '/page/test';

--- a/apps/app/src/features/backlinks/server/services/extract-internal-links.spec.ts
+++ b/apps/app/src/features/backlinks/server/services/extract-internal-links.spec.ts
@@ -1,0 +1,188 @@
+import { extractInternalLinks } from './extract-internal-links';
+
+describe('extractInternalLinks()', () => {
+  it('extracts HTML relative path link', async () => {
+    const pageString = '<a href="./new">here</a>';
+    const pagePath = '/page/test';
+
+    const links = await extractInternalLinks(pageString, pagePath);
+
+    expect(links).toStrictEqual(['/page/new']);
+  });
+
+  it('extracts markdown relative path link', async () => {
+    const pageString = '[test](./new)';
+    const pagePath = '/page/test';
+
+    const links = await extractInternalLinks(pageString, pagePath);
+
+    expect(links).toStrictEqual(['/page/new']);
+  });
+
+  it('extracts HTML absolute path link', async () => {
+    const pageString = '<a href="/docs/v2">here</a>';
+    const pagePath = '/page/test';
+
+    const links = await extractInternalLinks(pageString, pagePath);
+
+    expect(links).toStrictEqual(['/docs/v2']);
+  });
+
+  it('extracts markdown absolute path link', async () => {
+    const pageString = '[one](/docs/v2)';
+    const pagePath = '/page/test';
+
+    const links = await extractInternalLinks(pageString, pagePath);
+
+    expect(links).toStrictEqual(['/docs/v2']);
+  });
+
+  it('extracts absolute wiki-link', async () => {
+    const pageString = '[[/docs/old]]';
+    const pagePath = '/page/test';
+
+    const links = await extractInternalLinks(pageString, pagePath);
+
+    expect(links).toStrictEqual(['/docs/old']);
+  });
+
+  it('extracts relative wiki-link', async () => {
+    const pageString = '[[docs]]';
+    const pagePath = '/page/test';
+
+    const links = await extractInternalLinks(pageString, pagePath);
+
+    expect(links).toStrictEqual(['/page/test/docs']);
+  });
+
+  it('extracts internal URL link', async () => {
+    const pageString = 'https://test.com/folders/doc';
+    const pagePath = '/page/test';
+    const siteUrl = 'https://test.com/';
+
+    const links = await extractInternalLinks(pageString, pagePath, siteUrl);
+
+    expect(links).toStrictEqual(['/folders/doc']);
+  });
+
+  it('extracts permalink', async () => {
+    const pageString = 'https://test.com/6a4b6790f4032d50076f8eba';
+    const pagePath = '/page/test';
+    const siteUrl = 'https://test.com';
+
+    const links = await extractInternalLinks(pageString, pagePath, siteUrl);
+
+    expect(links).toStrictEqual(['/6a4b6790f4032d50076f8eba']);
+  });
+
+  it('extracts and decodes a non-ASCII path', async () => {
+    const pageString = '[x](/親ページ/子)';
+    const pagePath = '/page/test';
+
+    const links = await extractInternalLinks(pageString, pagePath);
+
+    expect(links).toStrictEqual(['/親ページ/子']);
+  });
+
+  it('does not extract external link', async () => {
+    const pageString = 'https://other.com/folders/doc';
+    const pagePath = '/page/test';
+    const siteUrl = 'https://test.com/';
+
+    const links = await extractInternalLinks(pageString, pagePath, siteUrl);
+
+    expect(links).toStrictEqual([]);
+  });
+
+  it('does not extract anchor link', async () => {
+    const pageString = '[jump to 5](#section-5)';
+    const pagePath = '/page/test';
+
+    const links = await extractInternalLinks(pageString, pagePath);
+
+    expect(links).toStrictEqual([]);
+  });
+
+  it('does not extract link to self', async () => {
+    const pageString = '[self](/page/test)';
+    const pagePath = '/page/test';
+
+    const links = await extractInternalLinks(pageString, pagePath);
+
+    expect(links).toStrictEqual([]);
+  });
+
+  it('does not extract link to non-creatable page', async () => {
+    const pageString = '<a href="/trash/old-page">here</a>';
+    const pagePath = '/page/test';
+
+    const links = await extractInternalLinks(pageString, pagePath);
+
+    expect(links).toStrictEqual([]);
+  });
+
+  it('skips a malformed link without dropping valid ones', async () => {
+    const pageString = '[good](/docs/v2) [bad](http://)';
+    const pagePath = '/page/test';
+
+    const links = await extractInternalLinks(pageString, pagePath);
+
+    expect(links).toStrictEqual(['/docs/v2']);
+  });
+
+  it('strips hash and query from internal link', async () => {
+    const pageString = '[a](/docs/v2#section?x=1)';
+    const pagePath = '/page/test';
+
+    const links = await extractInternalLinks(pageString, pagePath);
+
+    expect(links).toStrictEqual(['/docs/v2']);
+  });
+
+  it('normalized and deduplicates trailing-slash variants', async () => {
+    const pageString = '[a](/docs/v2) [a](/docs/v2/)';
+    const pagePath = '/page/test';
+
+    const links = await extractInternalLinks(pageString, pagePath);
+
+    expect(links).toStrictEqual(['/docs/v2']);
+  });
+
+  it('deduplicates links pointing to the same site', async () => {
+    const pageString = '[one](/docs/v2) [two](/docs/v2)';
+    const pagePath = '/page/test';
+
+    const links = await extractInternalLinks(pageString, pagePath);
+
+    expect(links).toStrictEqual(['/docs/v2']);
+  });
+
+  it('extracts multiple distinct links', async () => {
+    const pageString = '[one](/docs/v1) [two](/docs/v2)';
+    const pagePath = '/page/test';
+
+    const links = await extractInternalLinks(pageString, pagePath);
+
+    expect(links).toStrictEqual(['/docs/v1', '/docs/v2']);
+  });
+
+  it('keeps internal links while dropping external and self in one body', async () => {
+    const pageString =
+      '[keep](/docs/v2) [ext](https://other.com/x) [self](/page/test)';
+    const pagePath = '/page/test';
+    const siteUrl = 'https://test.com';
+
+    const links = await extractInternalLinks(pageString, pagePath, siteUrl);
+
+    expect(links).toStrictEqual(['/docs/v2']);
+  });
+
+  it('returns empty array on empty body', async () => {
+    const pageString = '';
+    const pagePath = '/page/test';
+
+    const links = await extractInternalLinks(pageString, pagePath);
+
+    expect(links).toStrictEqual([]);
+  });
+});

--- a/apps/app/src/features/backlinks/server/services/extract-internal-links.ts
+++ b/apps/app/src/features/backlinks/server/services/extract-internal-links.ts
@@ -18,6 +18,14 @@ const isAnchorLink = (href: string): boolean => {
   return href.length > 0 && href[0] === '#';
 };
 
+/**
+ * Extract internal page links from a page revision's markdown body.
+ *
+ * Resolves each link to a page path, dropping external, anchor, self, and
+ * non-creatable links, and deduplicates the result.
+ *
+ * @returns Resolved internal page paths the body links to.
+ */
 export const extractInternalLinks = async (
   markdown: string,
   pagePath: string,

--- a/apps/app/src/features/backlinks/server/services/extract-internal-links.ts
+++ b/apps/app/src/features/backlinks/server/services/extract-internal-links.ts
@@ -67,7 +67,14 @@ export const extractInternalLinks = async (
     const isInternalAbsolute = siteHost != null && url.host === siteHost;
     if (!isRelative && !isInternalAbsolute) continue;
 
-    const path = normalizePath(decodeURIComponent(url.pathname));
+    // Skip links with malformed path.
+    let decodedPath: string;
+    try {
+      decodedPath = decodeURIComponent(url.pathname);
+    } catch {
+      continue;
+    }
+    const path = normalizePath(decodedPath);
 
     if (!pagePathUtils.isCreatablePage(path) || path === normalizedSelf)
       continue;

--- a/apps/app/src/features/backlinks/server/services/extract-internal-links.ts
+++ b/apps/app/src/features/backlinks/server/services/extract-internal-links.ts
@@ -1,0 +1,69 @@
+import { pagePathUtils } from '@growi/core/dist/utils';
+import { normalizePath } from '@growi/core/dist/utils/path-utils';
+import type { Nodes } from 'hast';
+import { selectAll } from 'hast-util-select';
+import rehypeRaw from 'rehype-raw';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+import { unified } from 'unified';
+
+import { relativeLinks } from '~/services/renderer/rehype-plugins/relative-links';
+import { relativeLinksByPukiwikiLikeLinker } from '~/services/renderer/rehype-plugins/relative-links-by-pukiwiki-like-linker';
+import { pukiwikiLikeLinker } from '~/services/renderer/remark-plugins/pukiwiki-like-linker';
+
+const isAnchorLink = (href: string): boolean => {
+  return href.toString().length > 0 && href[0] === '#';
+};
+
+const isExternalLink = (href: string, siteUrl?: string) => {
+  try {
+    const baseUrl = new URL(siteUrl ?? 'https://example.com');
+    const hrefUrl = new URL(href, baseUrl);
+    return baseUrl.host !== hrefUrl.host;
+  } catch {
+    return false;
+  }
+};
+
+export const extractInternalLinks = async (
+  markdown: string,
+  pagePath: string,
+  siteUrl?: string,
+): Promise<string[]> => {
+  const processor = unified()
+    .use(remarkParse)
+    .use(pukiwikiLikeLinker)
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeRaw)
+    .use(relativeLinksByPukiwikiLikeLinker, { pagePath })
+    .use(relativeLinks, { pagePath });
+
+  const hastTree = processor.parse(markdown);
+  const runTree = await processor.run(hastTree);
+
+  const anchors = selectAll('a[href]', runTree as Nodes);
+  const base = new URL(siteUrl ?? 'https://example.com');
+  const normalizedSelf = normalizePath(pagePath);
+
+  const linkSet = new Set<string>();
+
+  for (const a of anchors) {
+    const href = a.properties.href;
+
+    if (
+      typeof href !== 'string' ||
+      isAnchorLink(href) ||
+      isExternalLink(href, siteUrl)
+    )
+      continue;
+
+    const path = normalizePath(new URL(href, base).pathname);
+
+    if (!pagePathUtils.isCreatablePage(path) || path === normalizedSelf)
+      continue;
+
+    linkSet.add(path);
+  }
+
+  return Array.from(linkSet);
+};

--- a/apps/app/src/features/backlinks/server/services/extract-internal-links.ts
+++ b/apps/app/src/features/backlinks/server/services/extract-internal-links.ts
@@ -12,18 +12,10 @@ import { relativeLinks } from '~/services/renderer/rehype-plugins/relative-links
 import { relativeLinksByPukiwikiLikeLinker } from '~/services/renderer/rehype-plugins/relative-links-by-pukiwiki-like-linker';
 import { pukiwikiLikeLinker } from '~/services/renderer/remark-plugins/pukiwiki-like-linker';
 
-const isAnchorLink = (href: string): boolean => {
-  return href.toString().length > 0 && href[0] === '#';
-};
+const RELATIVE_BASE = new URL('https://relative.invalid');
 
-const isExternalLink = (href: string, siteUrl?: string) => {
-  try {
-    const baseUrl = new URL(siteUrl ?? 'https://example.com');
-    const hrefUrl = new URL(href, baseUrl);
-    return baseUrl.host !== hrefUrl.host;
-  } catch {
-    return false;
-  }
+const isAnchorLink = (href: string): boolean => {
+  return href.length > 0 && href[0] === '#';
 };
 
 export const extractInternalLinks = async (
@@ -44,26 +36,38 @@ export const extractInternalLinks = async (
   const runTree = await processor.run(hastTree);
 
   const anchors = selectAll('a[href]', runTree as Nodes);
-  const base = new URL(siteUrl ?? 'https://example.com');
+
+  let siteHost: string | null = null;
+  if (siteUrl != null) {
+    try {
+      siteHost = new URL(siteUrl).host;
+    } catch {
+      siteHost = null;
+    }
+  }
+
   const normalizedSelf = normalizePath(pagePath);
   const linkSet = new Set<string>();
 
   for (const a of anchors) {
     const href = a.properties.href;
 
-    if (
-      typeof href !== 'string' ||
-      isAnchorLink(href) ||
-      isExternalLink(href, siteUrl)
-    )
-      continue;
+    if (typeof href !== 'string' || isAnchorLink(href)) continue;
 
-    let path: string;
+    let url: URL;
     try {
-      path = normalizePath(decodeURIComponent(new URL(href, base).pathname));
+      url = new URL(href, RELATIVE_BASE);
     } catch {
       continue;
     }
+
+    // Relative hrefs resolve to RELATIVE_BASE's host (internal by construction);
+    // absolute hrefs are internal only when their host matches the site host.
+    const isRelative = url.host === RELATIVE_BASE.host;
+    const isInternalAbsolute = siteHost != null && url.host === siteHost;
+    if (!isRelative && !isInternalAbsolute) continue;
+
+    const path = normalizePath(decodeURIComponent(url.pathname));
 
     if (!pagePathUtils.isCreatablePage(path) || path === normalizedSelf)
       continue;

--- a/apps/app/src/features/backlinks/server/services/extract-internal-links.ts
+++ b/apps/app/src/features/backlinks/server/services/extract-internal-links.ts
@@ -3,6 +3,7 @@ import { normalizePath } from '@growi/core/dist/utils/path-utils';
 import type { Nodes } from 'hast';
 import { selectAll } from 'hast-util-select';
 import rehypeRaw from 'rehype-raw';
+import gfm from 'remark-gfm';
 import remarkParse from 'remark-parse';
 import remarkRehype from 'remark-rehype';
 import { unified } from 'unified';
@@ -32,6 +33,7 @@ export const extractInternalLinks = async (
 ): Promise<string[]> => {
   const processor = unified()
     .use(remarkParse)
+    .use(gfm)
     .use(pukiwikiLikeLinker)
     .use(remarkRehype, { allowDangerousHtml: true })
     .use(rehypeRaw)

--- a/apps/app/src/features/backlinks/server/services/extract-internal-links.ts
+++ b/apps/app/src/features/backlinks/server/services/extract-internal-links.ts
@@ -46,7 +46,6 @@ export const extractInternalLinks = async (
   const anchors = selectAll('a[href]', runTree as Nodes);
   const base = new URL(siteUrl ?? 'https://example.com');
   const normalizedSelf = normalizePath(pagePath);
-
   const linkSet = new Set<string>();
 
   for (const a of anchors) {
@@ -59,7 +58,12 @@ export const extractInternalLinks = async (
     )
       continue;
 
-    const path = normalizePath(new URL(href, base).pathname);
+    let path: string;
+    try {
+      path = normalizePath(decodeURIComponent(new URL(href, base).pathname));
+    } catch {
+      continue;
+    }
 
     if (!pagePathUtils.isCreatablePage(path) || path === normalizedSelf)
       continue;


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/185819
https://redmine.weseek.co.jp/issues/186422

## B1.3 Implement internal-link extraction from a page body — all link forms
  - Build a pure function that takes a Markdown body, the page's path, and the wiki's site URL, and
    returns a deduplicated list of resolved internal page paths, reusing the existing remark/rehype
    link plugins (pukiwiki + relative-links) in a trimmed server processor
  - Recognize standard Markdown, wiki-link (`[[alias>/path]]`), and raw-HTML anchors; classify
    scheme-bearing absolute URLs by host (same host as the configured site URL → keep its path
    component; different host → external; site URL unset → no absolute URL is internal); exclude
    in-page `#` anchors and links inside code spans/blocks; strip query/anchor; normalize paths;
    gate on `isCreatablePage`; pass page-permalink (`/{id}`) targets through unchanged; drop the
    page's own-**path** self-link only (a link to the page's own permalink cannot be detected here —
    the extractor has no page `_id` — and is dropped later at sync, task B1.5)
  - Done when unit tests cover each link form and each exclusion rule, plus a same-host absolute URL
    kept as its path, a different-host URL and a (site-URL-unset) absolute URL both excluded, and a
    permalink returned verbatim; the deduped result excludes the page's own-path self-link
  - _Requirements: 1.2, 1.3, 1.4, 1.5, 1.6, 1.9, 1.10, 1.11_
  - _Boundary: extractInternalLinks_
  - _Depends: B1.1 (independent of B1.2)_