### PR TITLE
fix(app): contain PageSelectModal errors with an Error Boundary (#11422)

### DIFF
--- a/apps/app/src/client/components/PageSelectModal/dynamic.spec.tsx
+++ b/apps/app/src/client/components/PageSelectModal/dynamic.spec.tsx
@@ -1,0 +1,49 @@
+import type { ComponentType } from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { PageSelectModalLazyLoaded } from './dynamic';
+
+// The modal reports itself as opened.
+vi.mock('~/states/ui/modal/page-select', () => ({
+  usePageSelectModalStatus: () => ({ isOpened: true }),
+}));
+
+// Make the lazy loader return our component synchronously so we can control
+// whether it throws during render.
+let lazyComponent: ComponentType | null = null;
+vi.mock('~/components/utils/use-lazy-loader', () => ({
+  useLazyLoader: () => lazyComponent,
+}));
+
+const ThrowingModal = (): never => {
+  throw new Error('boom in modal subtree');
+};
+
+describe('PageSelectModalLazyLoaded error containment (issue #11422)', () => {
+  it('keeps sibling app content mounted when the modal subtree throws', () => {
+    lazyComponent = ThrowingModal;
+
+    // If the boundary did not contain the error, this render() call would throw
+    // and the sibling would be unmounted (the "blank screen" symptom).
+    expect(() =>
+      render(
+        <>
+          <div data-testid="app-content">editor and sidebar</div>
+          <PageSelectModalLazyLoaded />
+        </>,
+      ),
+    ).not.toThrow();
+
+    // The rest of the app survives.
+    expect(screen.getByTestId('app-content')).toBeInTheDocument();
+  });
+
+  it('renders the modal normally when it does not throw', () => {
+    const OkModal = () => <div data-testid="modal-ok">modal</div>;
+    lazyComponent = OkModal;
+
+    render(<PageSelectModalLazyLoaded />);
+
+    expect(screen.getByTestId('modal-ok')).toBeInTheDocument();
+  });
+});

--- a/apps/app/src/client/components/PageSelectModal/dynamic.tsx
+++ b/apps/app/src/client/components/PageSelectModal/dynamic.tsx
@@ -1,12 +1,33 @@
 import type { JSX } from 'react';
+import type { FallbackProps } from 'react-error-boundary';
+import { ErrorBoundary } from 'react-error-boundary';
 
 import { useLazyLoader } from '~/components/utils/use-lazy-loader';
 import { usePageSelectModalStatus } from '~/states/ui/modal/page-select';
+import loggerFactory from '~/utils/logger';
+
+const logger = loggerFactory('growi:components:PageSelectModal:dynamic');
 
 type PageSelectModalProps = Record<string, unknown>;
 
+/**
+ * Fallback rendered when the PageSelectModal subtree throws.
+ *
+ * Rendering `null` (instead of letting the exception propagate) is intentional:
+ * the modal is mounted near the app root (BasicLayout) and is NOT wrapped by any
+ * ancestor Error Boundary. Without this boundary, a throw anywhere inside the
+ * modal (its large lazily-mounted `@headless-tree` component tree) unmounts the
+ * whole React app, which then leaves the screen blank — see issue #11422. By
+ * containing the error here the rest of the application (editor, sidebar, …)
+ * stays mounted and usable.
+ */
+const PageSelectModalFallback = (_props: FallbackProps): JSX.Element | null => {
+  return null;
+};
+
 export const PageSelectModalLazyLoaded = (): JSX.Element => {
   const status = usePageSelectModalStatus();
+  const isOpened = status?.isOpened ?? false;
 
   const PageSelectModal = useLazyLoader<PageSelectModalProps>(
     'page-select-modal',
@@ -14,8 +35,20 @@ export const PageSelectModalLazyLoaded = (): JSX.Element => {
       import('./PageSelectModal').then((mod) => ({
         default: mod.PageSelectModal,
       })),
-    status?.isOpened ?? false,
+    isOpened,
   );
 
-  return PageSelectModal ? <PageSelectModal /> : <></>;
+  return (
+    <ErrorBoundary
+      FallbackComponent={PageSelectModalFallback}
+      onError={(error, info) => {
+        logger.error({ error, info }, 'Failed to render PageSelectModal');
+      }}
+      // Reset the boundary each time the modal is (re)opened so a previous
+      // failure does not permanently disable the modal.
+      resetKeys={[isOpened]}
+    >
+      {PageSelectModal ? <PageSelectModal /> : null}
+    </ErrorBoundary>
+  );
 };


### PR DESCRIPTION
## Summary

Fixes the "blank, unusable screen" reported in #11422 (opening the page-select modal from `PagePathHeader`'s `account_tree` button).

The `PageSelectModal` is mounted near the app root (`BasicLayout`) via `PageSelectModalLazyLoaded` and had **no ancestor React Error Boundary**. Any exception thrown while rendering the modal's large, lazily-mounted `@headless-tree` component tree therefore unmounted the **entire** React app. Next.js then tries to render the error page by re-running `_app.getInitialProps` on the client (where `req` is `undefined`), which throws again in `getLangAtServerSide` (`TypeError: e is undefined`), so even the error page fails to render — hence the blank screen.

This PR wraps the lazily-loaded modal in `react-error-boundary` so a render error is **contained**: the rest of the app (editor, sidebar) stays mounted and usable, and the error is logged. `resetKeys={[isOpened]}` clears a previous failure when the modal is reopened.

## Root cause

See the follow-up investigation comment on #11422 for the full write-up. Key points:

- I reproduced the exact reported action in a **real browser** (Chromium/Playwright) against a **real MongoDB** (`mongodb-memory-server`) on **Node 24**, across several tree shapes (3-level, 40 siblings, 4-level-deep, and a CJK path containing a full-width space `U+3000`). On current `master` the modal **opens correctly in every case** — the original "first exception" from 7.5.6 is no longer reproducible (fixes landed after 7.5.6, notably the PCRE-safe regex escaping in `bd28252c`/#11235 and the ObjectId-based page-tree fetch).
- The structural cause of the *blank, unusable* symptom — independent of whatever triggers the first exception — is the **absence of an Error Boundary** around the modal, exactly as noted in the issue body. Without it, any throw in the modal subtree unmounts the whole app.

## Changes

- `apps/app/src/client/components/PageSelectModal/dynamic.tsx`: wrap the lazily-loaded `PageSelectModal` in `react-error-boundary`'s `ErrorBoundary`. On error it renders `null` (so siblings survive), logs via the app logger, and resets on `isOpened` change.
- `apps/app/src/client/components/PageSelectModal/dynamic.spec.tsx`: regression test — a throwing modal subtree no longer unmounts sibling app content, and the modal still renders normally when it does not throw.

## Relationship to #11423

#11423 makes `_app.getInitialProps` resilient to a missing `req` (the *second* fault). That remains valuable as a complementary safety net for uncaught errors **outside** the modal. This PR addresses the structural root cause for the reported case by containing the failure at the modal boundary, so the two changes are complementary.

## Test Plan

- [x] `pnpm vitest run dynamic.spec` — new tests pass
- [x] `pnpm exec biome check` on changed files — clean
- [x] `pnpm run lint:typecheck` — passes
- [x] Real-browser smoke: editor → `PagePathHeader` `account_tree` → modal opens correctly (no regression) with the boundary in place

Closes #11422

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvGPnx5k5wLyMoXShqzuhU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvGPnx5k5wLyMoXShqzuhU)_