### PR TITLE
fix: Prevent PageSelectModal infinite render loop (#11422)

### DIFF
--- a/apps/app/src/client/components/PageSelectModal/PageSelectModal.spec.tsx
+++ b/apps/app/src/client/components/PageSelectModal/PageSelectModal.spec.tsx
@@ -1,0 +1,80 @@
+import { act, render, screen } from '@testing-library/react';
+
+import { PageSelectModal } from './PageSelectModal';
+
+// --- Reproduce the "cold SWR cache" condition ---------------------------------
+// ItemsTree calls `useSWRxRootPage({ suspense: true })`, so on the very first
+// open (before the root page is cached) it SUSPENDS. We simulate that by
+// throwing a promise until it is resolved, then rendering real content.
+//
+// Root cause (issue #11422): the scroller <div> that owns the callback ref
+// lived INSIDE the <Suspense> boundary. When ItemsTree suspends, React hides
+// the boundary's primary content and detaches that ref (calls it with null),
+// which set `scrollerElem` back to null; that unmounts ItemsTree, the content
+// reveals again, the ref re-attaches (sets `scrollerElem` again), ItemsTree
+// suspends again -> an unbounded render loop ("Maximum update depth exceeded").
+let itemsTreeRenderCount = 0;
+let resolveRootPage: (() => void) | undefined;
+let rootPageReady = false;
+const rootPagePromise = new Promise<void>((resolve) => {
+  resolveRootPage = () => {
+    rootPageReady = true;
+    resolve();
+  };
+});
+
+vi.mock('~/features/page-tree/components', () => ({
+  ItemsTree: () => {
+    itemsTreeRenderCount += 1;
+    if (!rootPageReady) {
+      // Suspend, mimicking SWR's suspense on a cold cache.
+      throw rootPagePromise;
+    }
+    return <div data-testid="items-tree">tree loaded</div>;
+  },
+}));
+
+// TreeItemForModal is only passed as a prop to the (mocked) ItemsTree, so a
+// stub is enough and avoids pulling in its SCSS module.
+vi.mock('./TreeItemForModal', () => ({
+  TreeItemForModal: () => null,
+  treeItemForModalSize: 40,
+}));
+
+vi.mock('~/states/ui/modal/page-select', () => ({
+  usePageSelectModalStatus: () => ({ isOpened: true, opts: {} }),
+  usePageSelectModalActions: () => ({ open: vi.fn(), close: vi.fn() }),
+  useSelectedPageInModal: () => null,
+}));
+
+vi.mock('~/states/context', () => ({
+  useIsGuestUser: () => false,
+  useIsReadOnlyUser: () => false,
+}));
+
+vi.mock('~/states/page', () => ({
+  useCurrentPageData: () => ({ path: '/foo/bar' }),
+}));
+
+vi.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('PageSelectModal (issue #11422 root cause)', () => {
+  it('renders the tree after suspense without an infinite render loop', async () => {
+    // On the buggy structure this render() itself trips the render loop
+    // (React "Maximum update depth exceeded" / reentrancy), failing the test.
+    render(<PageSelectModal />);
+
+    // Resolve the root-page fetch so ItemsTree can stop suspending.
+    await act(async () => {
+      resolveRootPage?.();
+      await rootPagePromise;
+    });
+
+    expect(await screen.findByTestId('items-tree')).toBeInTheDocument();
+
+    // A healthy component suspends ItemsTree only a bounded number of times.
+    expect(itemsTreeRenderCount).toBeLessThan(10);
+  });
+});

--- a/apps/app/src/client/components/PageSelectModal/PageSelectModal.tsx
+++ b/apps/app/src/client/components/PageSelectModal/PageSelectModal.tsx
@@ -81,13 +81,21 @@ const PageSelectModalSubstance: FC = () => {
         {t('page_select_modal.select_page_location')}
       </ModalHeader>
       <ModalBody className="p-0">
-        <Suspense fallback={<ItemsTreeContentSkeleton />}>
-          {/* 133px = 63px(ModalHeader) + 70px(ModalFooter) */}
-          <div
-            ref={scrollerRefCallback}
-            className="p-3"
-            style={{ maxHeight: 'calc(85vh - 133px)', overflowY: 'auto' }}
-          >
+        {/* 133px = 63px(ModalHeader) + 70px(ModalFooter) */}
+        {/*
+          The scroller div MUST stay OUTSIDE <Suspense>. It owns the callback ref
+          that sets `scrollerElem`; if it were inside the boundary, ItemsTree
+          suspending would hide the primary content and detach this ref (call it
+          with null), resetting `scrollerElem`. That unmounts ItemsTree, the
+          content reveals, the ref re-attaches, ItemsTree suspends again — an
+          unbounded render loop ("Maximum update depth exceeded"). See #11422.
+        */}
+        <div
+          ref={scrollerRefCallback}
+          className="p-3"
+          style={{ maxHeight: 'calc(85vh - 133px)', overflowY: 'auto' }}
+        >
+          <Suspense fallback={<ItemsTreeContentSkeleton />}>
             {scrollerElem && (
               <ItemsTree
                 CustomTreeItem={TreeItemForModal}
@@ -99,8 +107,8 @@ const PageSelectModalSubstance: FC = () => {
                 scrollerElem={scrollerElem}
               />
             )}
-          </div>
-        </Suspense>
+          </Suspense>
+        </div>
       </ModalBody>
       <ModalFooter className="border-top d-flex flex-column">
         {isHierarchicalSelectionMode && (


### PR DESCRIPTION
## Summary

Fixes the **root cause** of #11422 (opening the page-select modal from `PagePathHeader`'s `account_tree` button leaves the screen blank/unusable).

The real fault is an **infinite render loop** in `PageSelectModal`, reproduced in a real dev environment as:

```
Uncaught Error: Maximum update depth exceeded.
  at PageSelectModalSubstance.useCallback[scrollerRefCallback] (PageSelectModal.tsx:27)
    setScrollerElem(node);
```

## Root cause

The scroller `<div>` that owns the callback ref setting `scrollerElem` lived **inside** the `<Suspense>` boundary:

```tsx
<Suspense fallback={<ItemsTreeContentSkeleton />}>
  <div ref={scrollerRefCallback} …>   {/* ref sets scrollerElem */}
    {scrollerElem && <ItemsTree … />}  {/* suspends via useSWRxRootPage({ suspense: true }) */}
  </div>
</Suspense>
```

This is a circular dependency:

1. Modal opens → `scrollerElem` is `null` → the `<div>` commits → ref fires → `setScrollerElem(node)`.
2. `<ItemsTree>` now renders and **suspends** (root page not cached yet).
3. React shows the fallback, which **hides the boundary's primary content and detaches the `<div>`'s ref** (`scrollerRefCallback(null)`) → `setScrollerElem(null)`.
4. `scrollerElem` is `null` again → `<ItemsTree>` unmounts → nothing suspends → React reveals the content → ref re-attaches → `setScrollerElem(node)` → back to step 2.

These re-renders run synchronously, far faster than the async root-page fetch resolves, so React trips **"Maximum update depth exceeded"** before the data ever loads. It **only reproduces on a cold SWR cache** (first open), which is why component tests that provide data synchronously never caught it.

## Fix

Move the ref-bearing scroller `<div>` **outside** `<Suspense>`; only `<ItemsTree>` stays inside the boundary. The scroller container is then never hidden/detached, so the ref fires exactly once on mount.

## Verification (measured, red → green)

Added `PageSelectModal.spec.tsx`, which makes `ItemsTree` suspend via a thrown promise (simulating the cold cache):

- **Before the fix**: the test fails with the exact reported error — `Maximum update depth exceeded`.
- **After the fix**: the test passes cleanly — skeleton → tree renders, `ItemsTree` renders a bounded number of times.

```
✓ src/client/components/PageSelectModal/PageSelectModal.spec.tsx (1 test)
```

- [x] `pnpm vitest run PageSelectModal.spec` — passes (and reproduces the loop before the fix)
- [x] `pnpm run lint:typecheck` — passes
- [x] `pnpm exec biome check` on changed files — no new findings

## Relationship to #11423 / #11424

Both of those PRs address the **blank-screen symptom** (Next.js error-page fallback resilience / an Error Boundary around the modal) but not this loop. This PR fixes the root cause; the other two remain useful as complementary defense-in-depth (see the review discussion on #11422).

Closes #11422

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
