### PR TITLE
feat: Page Markdown endpoint (.md URL / Accept: text/markdown) with navigation footer

### DIFF
--- a/.kiro/specs/page-markdown-endpoint/design.md
+++ b/.kiro/specs/page-markdown-endpoint/design.md
@@ -1,0 +1,358 @@
+# Technical Design: page-markdown-endpoint
+
+## Overview
+
+**Purpose**: URL を渡された対話型 AI エージェント（および認証付きツール）が、JavaScript を実行せずに 1 回の取得で GROWI ページの本文と近傍ナビゲーションを得られるようにする。GROWI の各ページに対し `text/markdown` 表現を返す HTTP エンドポイントを追加する。
+
+**Users**: `.md` URL を貼り付けられた AI エージェント、ページ URL を `Accept: text/markdown` で取得するツール／クローラ、および「AI 用 URL」をコピーする GROWI 利用者。
+
+**Impact**: 既存のページ配信（Next.js 委譲）の手前に薄い interception を追加し、既存の認可・本文取得・ページツリーを再利用して Markdown を返す。既存の HTML 配信・API・認可には変更を加えない（追加のみ）。
+
+**Base**: 実装ブランチは `origin/dev/8.0.x` から切る（master ではない）。本設計は 2026-07-11 に origin/dev/8.0.x 基準で再検証済み。設計思想は master 時点から変わらないが、dev/8.0.x での差分として (1) `routes/index.js` が ESM 化し catch-all の行番号が変わった、(2) `findPageAndMetaDataByViewer` が bookmark 集計を Prisma で行う（認可契約は不変・結合テストで Prisma 初期化が必要）の 2 点を各所へ反映した。literal-wins の前提（`.md` 予約）・認可ミドルウェア API・populate 手本は dev/8.0.x でも健在。
+
+### Goals
+- `/{pageId}.md`・`{pagePath}.md`・`Accept: text/markdown`（`?format=md`）で本文 Markdown を返す。
+- 本文末尾に親・子・兄弟・正規 URL・permalink・更新情報を含む近傍ナビゲーション footer を付ける。
+- 既存のページ閲覧と同一の認可に従う（新しい認可を作らない）。
+- 人間（CopyDropdown）と機械（`<link rel="alternate">` / `Link` ヘッダ）の双方に `.md` URL の発見手段を提供する。
+
+### Non-Goals
+- SEO / GEO 向けの sitemap.xml / JSON-LD / Open Graph / SEO 用 canonical メタ / llms.txt / robots.txt と管理画面トグル（Phase 2・別スペック）。
+- 子ページ一覧専用の Markdown エンドポイント（`/{pageId}/children.md` 等）。footer から既存のページ一覧 API へ案内する。
+- 本文 Markdown の加工（lsx 等の動的展開、相対リンクの絶対化、HTML 化）。`revision.body` を逐語で返す。
+- 応答のキャッシュ層（ETag / Cache-Control）。将来の NFR。
+
+## Boundary Commitments
+
+### This Spec Owns
+- `.md` サフィックスおよび `Accept: text/markdown` / `?format=md` を検出し、ページを Markdown で返す HTTP 経路。
+- `.md` サフィックスと実在ページの衝突解決規則（literal-wins）。
+- Markdown 応答の本文組立（`revision.body` ＋近傍ナビゲーション footer）と、空ページ時の応答形。
+- 対象ページの Markdown 版を指す `.md` URL の生成規則（共有ユーティリティ）と、その発見手段（CopyDropdown 項目、`<link rel="alternate">`、`Link` ヘッダ）。
+
+### Out of Boundary
+- ページの grant／閲覧権限の判定ロジック（既存の viewer 付きファインダに委譲）。
+- ページ本文・リビジョンの永続化と取得の実装（既存 Page/Revision モデル）。
+- 子ページ・ツリーの列挙アルゴリズム（既存 `pageListingService`）。
+- Phase 2 の SEO/GEO 機能および管理画面トグル。
+
+### Allowed Dependencies
+- `findPageAndMetaDataByViewer`（`Page.findByIdAndViewer` / `Page.findByPathAndViewer` 経由）で**閲覧可否の判定とページ本体の解決**を行う。※この finder は `revision`／`parent`／`lastUpdateUser` を populate せず ObjectId のまま返す点に注意。※dev/8.0.x ではこの finder が bookmark 集計を Prisma（`prisma.bookmarks.count` / `findByPageIdAndUserId`）で行う。認可・not-found/forbidden の契約は master と同一で設計ロジックに影響しないが、**この経路を通る結合テストは bootstrap で Prisma 初期化が必要**（下記 Testing Strategy 参照）。
+- `page.initLatestRevisionField(revisionId?)` + `page.populateDataToShowRevision(false)` で本文（`revision.body`）と更新者を populate する。読み取りエンドポイントでは **route 層で populate するのが慣習**（`respond-with-single-page.ts:78-81`, `page-data-props.ts:226-237`）。
+- 親ページの path/title は `page.parent`（ObjectId）から**追加クエリ**で解決する（populate では得られない）。
+- 子・兄弟導出は page-listing サービスの **limit 付き取得＋viewer-aware count**（id 指定で regex を作らない）。子リンクは `limit(N+1)`、直下子の正確な総数は `addViewerCondition` を重ねた `countDocuments({ parent: id })`（`countByIdAndViewer` `page.ts:722-729` と同流儀）。既存の全件返し `findChildrenByParentPathOrIdAndViewer` はメモリ観点で本用途には使わない。
+- `accessTokenParser([SCOPE.READ.FEATURES.PAGE], { acceptLegacy: true })` + `loginRequired`（ゲスト許可）。
+- `@growi/core` の `isPermalink` / `isValidObjectId` / `encodeSpaces`、`serializeUserSecurely`。
+- 依存の向きは一方向（下記 Dependency Direction）。上位（route/UI）→下位（pure util）へのみ。
+
+### Revalidation Triggers
+- `findPageAndMetaDataByViewer` / `findChildrenByParentPathOrIdAndViewer` のシグネチャや forbidden/not-found 意味論が変わったとき。
+- `routes/index.js` の catch-all の順序・パスが変わったとき（interception の登録位置に影響）。
+- `.md` URL の形（`/{pageId}.md`）を変えたとき（CopyDropdown・`<link rel="alternate">`・footer 内リンク・Phase 2 の全消費者に波及）。
+- `isCreatablePage` の `.md` 予約（`/.+\.md$/`）が撤廃されたとき（literal-wins の前提が崩れる）。
+
+## Architecture
+
+### Existing Architecture Analysis
+- ページ配信は `apps/app/src/server/routes/index.js` の catch-all（dev/8.0.x では `:402` `/*/$` と `:403` `/*`、`loginRequired` = ゲスト許可）が Next.js の `[[...path]]` に委譲する。permalink `/{pageId}` も専用ルートが無く同経路。このモジュールは dev/8.0.x で **ESM 化**されており、エントリは `export const setup = (crowi, app) => {…}`、子ルーターは `import { setup as setupPage } from './page'` ＋ `setupPage(crowi, app)` で組む（catch-all の手前に `/vault.git`(:82) が追加されているが接頭辞が異なり衝突しない）。
+- 認可はファインダ内包（`find-page-and-meta-data-by-viewer.ts:87,89`）。forbidden/not-found は「フィルタ無しで再カウントし count>0 なら forbidden」で区別（同 `:93-105`）。
+- `isCreatablePage`（`packages/core/src/utils/page-path-utils/index.ts:119`）が `/.+\.md$/`（同 `:110`）で末尾 `.md` パスの作成を禁止。→ **`.md` 名前空間は予約済みで空いており**、literal-wins が守る「`.md` で終わる通常ページ」は通常操作では生じない（安全網）。
+
+### Architecture Pattern & Boundary Map
+
+```mermaid
+graph LR
+    Client --> Catchall_Guard
+    subgraph Server
+      Catchall_Guard[md interception before catchall] --> Authz[accessTokenParser plus loginRequired]
+      Authz --> Responder[respond-with-page-markdown route helper]
+      Responder --> Parse[parseMarkdownRequest pure]
+      Responder --> Finder[findPageAndMetaDataByViewer]
+      Responder --> Populate[initLatestRevisionField plus populateDataToShowRevision]
+      Responder --> ParentQuery[resolve parent page by id]
+      Responder --> Listing[pageListingService children for kids and siblings]
+      Responder --> Build[buildPageMarkdown pure]
+      Build --> UrlUtil[page-markdown-url pure]
+      Catchall_Guard -->|non md or literal page| Next[delegateToNext existing HTML]
+    end
+    subgraph Client_Discovery
+      Head[head link rel alternate] --> UrlUtil
+      CopyDropdown --> UrlUtil
+    end
+```
+
+**Architecture Integration**:
+- Selected pattern: 既存 catch-all の**手前に置く単一 interception ハンドラ**＋route 層のレスポンスヘルパ。該当しなければ `next()` でフォールスルー。
+- Domain/feature boundaries: HTTP 関心（検出・認可合成・Content-Type・ステータス）と、解決・populate・親子兄弟ロード・組立オーケストレーションは **route 層のレスポンスヘルパ**（既存 `respond-with-single-page.ts` と同じ層。読み取りページの populate は route 層で行うのが GROWI の慣習）。純ロジック（リクエスト解釈・footer・`.md` URL）は pure util に分離。
+- Existing patterns preserved: TS factory ルート（`getBrandLogoRouterFactory` 型）、`accessTokenParser`+`loginRequired` 合成、viewer 付きファインダ、`serializeUserSecurely`。
+- New components rationale: 既存ファイルを肥大化させず、footer・URL 生成を純関数化してテスト可能にするため。
+- Steering compliance: server/client 境界を守り、`.md` URL util は client 安全な `src/utils/` に置く。`any` を使わず discriminated union で結果を表現。
+
+### Dependency Direction
+`page-markdown-url (pure)` / `parseMarkdownRequest (pure)` / `buildPageMarkdown (pure)` → `respond-with-page-markdown (route helper)` → `page-markdown route factory` → `routes/index.js`。UI（CopyDropdown）と SSR head は `page-markdown-url` のみを参照。各層は左の層のみ import し、上位へは import しない。
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| Backend / Services | Express (既存) | interception ルート＋route 層レスポンスヘルパ | catch-all 手前に登録 |
+| Backend / Domain | 既存 Page/Revision モデル, pageListingService | 本文・親子・兄弟・認可 | 変更なし・再利用 |
+| Frontend | React + reactstrap（既存 CopyDropdown） | `.md` URL コピー項目 | 拡張のみ |
+| Shared util | TypeScript pure（`src/utils/`） | `.md` URL 生成 | client 安全・server/client 共用 |
+| Data / Storage | 変更なし | — | スキーマ追加なし |
+
+新規依存パッケージ: なし。
+
+## File Structure Plan
+
+### New Files
+```
+apps/app/src/
+├── utils/
+│   ├── page-markdown-url.ts            # pure: pageId/path/origin → .md URL（permalink形/パス形）。client安全・server/client共用
+│   └── page-markdown-url.spec.ts
+└── server/routes/page-markdown/
+    ├── index.ts                        # factory(crowi): RequestHandler。md検出→認可合成→responder呼出→next()フォールスルー
+    ├── respond-with-page-markdown.ts   # route層ヘルパ: 解決(literal-wins)→finder→initLatestRevisionField+populateDataToShowRevision(false)→親解決→子/兄弟(listing)→buildPageMarkdown→res。respond-with-single-page.ts と同じ層で populate を担う
+    ├── parse-markdown-request.ts       # pure: (path, headers, query) → MarkdownRequestIntent
+    ├── parse-markdown-request.spec.ts
+    ├── build-page-markdown.ts          # pure: (PageMarkdownInput) → markdown文字列（本文＋footer）
+    ├── build-page-markdown.spec.ts
+    ├── constants.ts                    # MARKDOWN_FOOTER_MAX_LINKS 等
+    └── page-markdown.integ.ts          # supertest 統合テスト
+```
+
+### Modified Files
+- `apps/app/src/server/routes/index.js` — `page-markdown` ルートを catch-all（dev/8.0.x では `:402` `/*/$` と `:403` `/*`）の**直前**に登録。このモジュールは ESM のため、TS factory を名前付き export（`getBrandLogoRouterFactory` と同型）にして `import` し、`setup` 内で `app.use(...)` する（CJS の `require(...)` は使わない）。
+- `apps/app/src/server/service/page-listing/page-listing.ts` — footer 用に **limit 付きの子取得** と **viewer-aware な直下子カウント**（`countDocuments({ parent: id })` ＋ `addViewerCondition`）のメソッドを追加。既存の全件返し `findChildrenByParentPathOrIdAndViewer` はメモリ観点で本用途に使わない。
+- `apps/app/src/pages/[[...path]]/index.page.tsx` — `<Head>` に `<link rel="alternate" type="text/markdown" href={mdUrl}>` を追加。`mdUrl` は `pageId` があれば `/{pageId}.md`、無ければ（空ページ等で props に `_id` が無いケース）`currentPathname` から `{path}.md` にフォールバックする。
+- `apps/app/src/pages/[[...path]]/page-data-props.ts` — GSSP の `context.res` に `Link` ヘッダを設定。空ページの早期 return（`data:null` 化）**より前**に、スコープに残る実体の `_id` を使って `</{pageId}.md>; rel="alternate"; type="text/markdown"` を付ける（空ページでも pageId 形の Link を出せる）。
+- `apps/app/src/client/components/Common/CopyDropdown/CopyDropdown.tsx` — 「Markdown URL (.md)」の `DropdownItem` を追加（共有リンクモード時は非表示）。
+- `apps/app/public/static/locales/en_US/commons.json` — `copy_to_clipboard."Markdown URL"` を追加（他 4 言語は同キーを英語値で追加、翻訳は後続タスク）。
+
+## System Flows
+
+```mermaid
+flowchart TD
+    A[GET request reaches md interception] --> B{md request?}
+    B -->|no accept, no format, path not end with md| Z[next to existing HTML delegate]
+    B -->|yes| C[parseMarkdownRequest]
+    C --> D{explicit accept or format?}
+    D -->|yes| E[target equals requested path or id, no strip]
+    D -->|no, md suffix| F{literal page at R exists for viewer?}
+    F -->|yes, legacy| Z
+    F -->|no| G[strip trailing md then target equals base]
+    E --> H[findPageAndMetaDataByViewer]
+    G --> H
+    H --> I{result}
+    I -->|forbidden| J[403 text markdown with guidance]
+    I -->|not found| K[404 text markdown with guidance]
+    I -->|ok| L[load parent, children, siblings via listing]
+    L --> M[buildPageMarkdown body plus footer]
+    M --> N[200 text markdown]
+```
+
+- 判定順: `Accept: text/markdown` または `?format=md`（明示）が最優先で、この場合は末尾 `.md` を除去しない。次に `.md` サフィックス（糖衣）で、literal-wins（実在すれば HTML へフォールスルー、なければ base へ）。
+- permalink 形（`/{pageId}.md`）は path の実在チェック不要（id 解決）。path 形のみ literal→base の二段解決。
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces / Flows |
+|-------------|---------|------------|--------------------|
+| 1.1, 1.2, 1.3 | `/{pageId}.md`・`{path}.md`・`Accept`/`?format=md` で md 返却 | Route, Responder, parseMarkdownRequest | API Contract / Resolution flow |
+| 1.4 | 本文は最新リビジョンを逐語 | Responder(populate), buildPageMarkdown | populate→`revision.body` 逐語 |
+| 1.5 | 非存在は 404 | Route, Responder | Resolution flow |
+| 2.1 | literal `.md` 実在ページは HTML 表示 | Route, Responder | Passthrough branch |
+| 2.2 | base 実在なら base の md | Responder, parseMarkdownRequest | Resolution flow |
+| 2.3 | R も base も無ければ 404 | Route, Responder | Resolution flow |
+| 2.4 | `Accept`/`?format=md` は除去せず要求パスの md | parseMarkdownRequest | Explicit branch |
+| 3.1, 3.2 | 既存認可踏襲・権限外 403 | Authz middleware, Responder | 既存 viewer ファインダ |
+| 3.3, 3.4 | ゲスト設定＋grant に従う匿名可否 | Authz middleware | `loginRequired` ゲスト許可 |
+| 3.5 | 403/404 に認証/MCP 案内 | Route, buildPageMarkdown | Error bodies |
+| 4.1, 4.2, 4.4, 4.5 | footer に URL/permalink/親/兄弟/更新情報 | buildPageMarkdown, Responder, page-markdown-url | Footer 組立 |
+| 4.3 | 直下子リンク＋直下子総数（listing 長）＋子孫合計 `descendantCount` を併記 | Responder, buildPageMarkdown | Footer 組立 |
+| 4.6 | 件数不問でページ一覧 API 案内 | buildPageMarkdown | Footer 組立 |
+| 4.7 | 上限超過時は総数・残数明記 | buildPageMarkdown, constants | Footer 組立 |
+| 4.8 | ルートは親リンク省略（兄弟も parent=null ガード） | buildPageMarkdown, Responder | Footer 組立 |
+| 5.1, 5.2, 5.3 | 空ページはエラーにせずナビ中心 md | Responder, buildPageMarkdown | Empty branch |
+| 6.1, 6.2, 6.3 | `<link rel=alternate>` ＋ `Link` ヘッダ（CSR 時も。pageId 無→path 形） | index.page.tsx Head, page-data-props, page-markdown-url | SSR head |
+| 7.1, 7.2, 7.3, 7.4 | CopyDropdown に `.md` URL 項目 | CopyDropdown, page-markdown-url | UI |
+
+## Components and Interfaces
+
+| Component | Layer | Intent | Req Coverage | Key Dependencies | Contracts |
+|-----------|-------|--------|--------------|------------------|-----------|
+| PageMarkdownRoute | server/route | md 検出・認可合成・Content-Type/status・フォールスルー | 1.x, 2.x, 3.x, 5.x | respondWithPageMarkdown (P0), authz middleware (P0) | API |
+| respondWithPageMarkdown | server/route (helper) | 解決(literal-wins)＋populate＋親子兄弟ロード＋組立 | 1.x, 2.x, 4.x, 5.x | viewer finders (P0), populate methods (P0), pageListingService (P0), buildPageMarkdown (P0) | Service |
+| parseMarkdownRequest | server/pure | リクエスト→取得意図の解釈 | 1.1-1.3, 2.2, 2.4 | なし | Service |
+| buildPageMarkdown | server/pure | 本文＋footer の文字列生成 | 3.5, 4.x, 5.x | page-markdown-url (P0), serializeUserSecurely (P1) | Service |
+| pageMarkdownUrl | shared/pure | `.md` URL 生成（唯一の情報源） | 4.2-4.4, 6.1, 7.2, 7.3 | `@growi/core` encodeSpaces (P1) | Service |
+| CopyDropdown (拡張) | client/UI | `.md` URL コピー項目 | 7.1-7.4 | pageMarkdownUrl (P0) | State |
+| Page Head (拡張) | client/SSR | alternate link ＋ Link ヘッダ | 6.1-6.3 | pageMarkdownUrl (P0) | State |
+
+### server/route (page-markdown)
+
+#### respondWithPageMarkdown (route helper)
+
+| Field | Detail |
+|-------|--------|
+| Intent | リクエストからページを解決・populate し、Markdown 文書（本文＋footer）または権限/未存在/passthrough を返す |
+| Requirements | 1.1–1.5, 2.1–2.4, 4.1–4.8, 5.1–5.3 |
+
+**Responsibilities & Constraints**
+- `parseMarkdownRequest` の意図に従い、permalink は id、path は literal→base の順で `findPageAndMetaDataByViewer` を用いて解決。
+- forbidden / not-found は既存ファインダの判定をそのまま反映（独自判定を作らない）。
+- ok の場合、**finder は populate しない**ため `page.initLatestRevisionField()` ＋ `page.populateDataToShowRevision(false)` で本文（`revision.body`）と更新者を populate し、`page.parent`（ObjectId）から親を**追加クエリ**で path/title 解決する（`respond-with-single-page.ts:78-81` と同じ役割を route 層で担う）。
+- 子・兄弟は page-listing サービスの **id 指定・limit 付き取得**でリンク用に最大 `MARKDOWN_FOOTER_MAX_LINKS + 1` 件だけロードし、直下子の**正確な総数**は `addViewerCondition` を重ねた `countDocuments({ parent: id })` で得る（`addViewerCondition` を find と count で**共有**＝grant ロジックを二重実装せず drift を避ける）。子孫合計 `page.descendantCount` は別途併記。兄弟も対象の `parent` id で同様に取得し自分を除外。`parent == null`（ルート）は親・兄弟を省略。メモリは最大 N+1 件に固定（全件ロード・cursor は不要）。
+- 公開するユーザ情報（更新者）は `serializeUserSecurely` を通す。
+
+**Contracts**: Service [x]
+
+##### Interface
+```typescript
+type MarkdownResolution =
+  | { type: 'ok'; markdown: string }
+  | { type: 'forbidden'; markdown: string }
+  | { type: 'notFound'; markdown: string }
+  | { type: 'passthrough' }; // literal .md page exists → let Next serve HTML
+
+// route 層ヘルパ。MarkdownResolution を返し、route factory が res へ書く（passthrough は next()）。
+function respondWithPageMarkdown(crowi: Crowi, input: {
+  reqPath: string;
+  accept: string | undefined;
+  formatQuery: string | undefined;
+  user: IUserHasId | undefined;
+  origin: string;
+}): Promise<MarkdownResolution>;
+```
+- Preconditions: 認可ミドルウェアを通過済み（`user` は session/PAT/guest いずれかで解決済み、または未認証）。finder 直後の `page` は `revision.body`／`parent`／`lastUpdateUser` が未 populate。
+- Postconditions: `ok`/`forbidden`/`notFound` は `text/markdown` 本文を持つ。`passthrough` は本文を持たず、route factory が `next()` する。
+- Invariants: 認可判定は viewer 付きファインダ由来のみ。本文は `revision.body` を改変しない。
+
+#### parseMarkdownRequest（pure）
+```typescript
+type MarkdownRequestIntent =
+  | { kind: 'none' } // not a markdown request → caller does next()
+  | { kind: 'permalink'; pageId: string; explicit: boolean }
+  | { kind: 'path'; path: string; explicit: boolean };
+// explicit=true: Accept/​?format=md（末尾 .md を除去しない）
+// explicit=false: .md サフィックス（path の場合は literal→base）
+function parseMarkdownRequest(reqPath: string, accept: string | undefined, formatQuery: string | undefined): MarkdownRequestIntent;
+```
+- 判定順は System Flows のとおり（明示 > `.md` サフィックス）。permalink 判定は `isPermalink`/`isValidObjectId`。
+
+#### buildPageMarkdown（pure）
+```typescript
+interface FooterLink { title: string; mdUrl: string }
+interface PageMarkdownInput {
+  path: string;
+  origin: string;
+  permalinkUrl: string;      // host + /{pageId}
+  canonicalUrl: string;      // host + path（「host+パスで開ける」ヒント）
+  body: string;              // revision.body（空ページは空文字）
+  isEmpty: boolean;
+  parent: FooterLink | null; // ルートは null（4.8）
+  children: FooterLink[];    // 上限まで
+  childrenTotal: number;     // 直下子の正確な総数（viewer-aware countDocuments({parent:id})）
+  descendantCount: number;   // 子孫合計（page.descendantCount。直下子数とは別物として併記・4.3）
+  siblings: FooterLink[];    // 上限まで（自分を除外済み）
+  siblingsTotal: number;     // 兄弟の正確な総数（viewer-aware count）
+  pageListApiHint: string;   // 常に添える（4.6）
+  updatedAt: string;
+  updatedByUsername: string;
+}
+function buildPageMarkdown(input: PageMarkdownInput): string;
+function buildErrorMarkdown(kind: 'forbidden' | 'notFound'): string; // 3.5
+```
+- 上限は `MARKDOWN_FOOTER_MAX_LINKS`。footer には直下子総数と子孫合計 `descendantCount` を別個に載せ、超過時は総数と残数を明記（4.7）。空ページは本文の代わりに「本文なし」の一文＋footer（5.1-5.3）。
+
+#### PageMarkdownRoute (route factory)
+| Field | Detail |
+|-------|--------|
+| Intent | md 検出・認可合成・応答生成・フォールスルー |
+| Requirements | 1.x, 2.1, 3.1–3.5, 5.x |
+
+**Responsibilities & Constraints**
+- `factory(crowi): RequestHandler`。GET のみ対象。`parseMarkdownRequest.kind === 'none'` は即 `next()`。
+- md 要求時は `accessTokenParser([SCOPE.READ.FEATURES.PAGE], { acceptLegacy: true })` と `loginRequired`（ゲスト許可）を経て `respondWithPageMarkdown` を呼ぶ。
+- 結果に応じ `res.type('text/markdown; charset=utf-8')` で 200/403/404、`passthrough` は `next()`。
+
+**Contracts**: API [x]
+
+##### API Contract
+| Method | Endpoint | Request | Response | Errors |
+|--------|----------|---------|----------|--------|
+| GET | `/{pageId}.md` | — | 200 `text/markdown` | 403, 404 |
+| GET | `{pagePath}.md` | — | 200 `text/markdown` / HTML passthrough | 404 |
+| GET | 任意ページ URL + `Accept: text/markdown` or `?format=md` | — | 200 `text/markdown` | 403, 404 |
+
+**Implementation Notes**
+- Integration: `routes/index.js` の catch-all（dev/8.0.x では `:402`/`:403`）直前に登録し、API・静的・`_next`・admin・attachment・ogp・share・`/`・`/vault.git` 等の既存ルートより後段に置く（それらは先に解決される）。ESM 化済みのため名前付き export ＋ `import` で組み込む。
+- Content negotiation: `Accept` は**メディアタイプの明示一致のみ**で判定（`req.accepts('text/markdown')` は `*/*`＝curl 既定にも一致するため使わない）。`.md` サフィックスは末尾が厳密に `.md` のときのみ（`.mdx` 等は対象外）。
+- Listing: 子・兄弟は id 指定で呼び MongoDB regex を生成しない（`escapeStringForMongoRegex` を不要にする）。
+- Validation: permalink は `isValidObjectId` で 24-hex を検証。
+- Known limitation: トップページ `/` は専用ルート（`routes/index.js:84`）が interception より先に解決するため、`/` への `Accept`/`?format=md` は md 化されない（`/{pageId}.md` permalink 形では取得可能）。
+- Risks: 登録順序の誤りが唯一の重大リスク（通常配信を飲み込む恐れ）→ 統合テストで通常ページの HTML 配信が維持されることを検証。
+
+### client（拡張）
+
+#### CopyDropdown / Page Head
+- CopyDropdown: 既存の並びに `DropdownItem`（`t('copy_to_clipboard.Markdown URL')`）を追加。値は `pageMarkdownUrl.toPathMdUrl(pagePathUrl)`（クエリ/ハッシュの前に `.md`）。`isShareLinkMode` 時は非表示（7.4）。
+- Page Head: `index.page.tsx` の `<Head>` に `<link rel="alternate" type="text/markdown" href={mdUrl}>`。`mdUrl` は `currentPage?._id` があれば `pageMarkdownUrl.toPermalinkMdUrl(_id)`、無ければ（空ページ等で props に `_id` が無い）`pageMarkdownUrl.toPathMdUrl(currentPathname)` にフォールバック（6.1）。`Link` ヘッダは GSSP（`context.res`）で、空ページの早期 return より前のスコープに残る `_id` を使って設定する（6.2, 6.3）。
+
+## Data Models
+
+スキーマ変更なし。新規は上記 DTO（`MarkdownResolution` / `MarkdownRequestIntent` / `PageMarkdownInput`）のみ。既存フィールドを読み取り専用で使用: `page.parent`（`models/page.ts:208-213`。親解決の起点、ルートは null）、`page.updatedAt`（`:262`）、`page.lastUpdateUser`（`:255`。populate 後に username のみ露出）、`page.descendantCount`（`:214`。**子孫合計であり直下子数ではない**。footer には併記のみ）、`revision.body`（populate 後）。直下子総数は viewer-aware `countDocuments({ parent: id })`（リンク用の limit 付き取得と `addViewerCondition` を共有）で得る。
+
+## Error Handling
+
+### Error Strategy
+- 認可・存在判定は viewer 付きファインダ由来のみ（Fail Fast、独自判定なし）。
+- 応答は常に `text/markdown`。エラー本文も Markdown（3.5）。
+
+### Error Categories and Responses
+- **404 notFound**: R も base も解決不可。本文に「ページが見つからない／権限が無い可能性。認証付き取得または GROWI MCP が必要」を Markdown で提示（内容は漏らさない）。
+- **403 forbidden**: 存在するが閲覧権限なし（既存の再カウント判定）。本文に認証/MCP 案内（ページ内容は含めない）。
+- **passthrough**: literal `.md` 実在ページ → `next()` で既存 HTML 配信（2.1）。
+- **guest 不可**: ゲスト読み取り無効インスタンスの未認証要求は `loginRequired` の既存挙動に従う（3.4）。
+
+### Monitoring
+- 既存の `loggerFactory`（pino）で md 経路の解決結果（ok/forbidden/notFound/passthrough）を debug ログ。新規メトリクスは追加しない。
+
+## Testing Strategy
+
+### Unit Tests
+- `parseMarkdownRequest`: `.md` サフィックス検出 / `?format=md` / `Accept: text/markdown` / permalink 判定 / `.md.md` の除去（1.1-1.3, 2.2, 2.4）。
+- `buildPageMarkdown`: footer に canonical/permalink/親/兄弟/更新情報＋**直下子リンク＋直下子総数（listing 長）＋子孫合計 descendantCount** を含む・ページ一覧 API 案内を常時含む（4.6）・上限超過で総数と残数明記（4.7）・ルートで親/兄弟省略（4.8）・空ページは「本文なし」＋footer（5.1-5.3）・`buildErrorMarkdown` が案内を含む（3.5）。
+- `pageMarkdownUrl`: `/{pageId}.md`・パス形 `.md`・クエリ/ハッシュ前挿入（7.2, 7.3）。
+
+### Integration Tests（supertest + `getInstance()`、手本 `apiv3/page/get-page-info.integ.ts`）
+> **dev/8.0.x 前提**: `findPageAndMetaDataByViewer` が Prisma（bookmarks）に依存するため、integ の bootstrap で Prisma が初期化されていること。着手前に手本 `get-page-info.integ.ts` が dev/8.0.x で green になることを確認し、この経路を通る本 spec の integ が Prisma 未初期化で落ちないことを担保する。
+- 公開ページ `GET /{pageId}.md` → 200 `text/markdown`＋body＋footer（1.1, 4.x）。
+- `GET {path}.md` → 200（1.2）／非存在 → 404（1.5, 2.3）。
+- 平文 URL + `Accept: text/markdown` → 200（1.3）。
+- 権限外ページ（viewer に grant 無し）→ 403＋案内本文（3.2, 3.5）。
+- ゲスト許可＋公開 → 匿名 200（3.3）／ゲスト不可 → ログイン挙動（3.4）。
+- literal `.md` ページ（`isCreatablePage` を迂回して直接 seed）→ HTML passthrough（2.1）。
+- 空ページ／コンテナページ → 200 ナビ中心 md（5.1）。
+- populate 回帰: 返る md に本文（`revision.body`）と更新者名が含まれる（1.4, 4.5。finder 単体では populate されないため回帰を防ぐ）。
+- 空ページの HTML `<head>` が path 形 `{path}.md` の alternate を持つ（6.1・空ページのフォールバック）。
+- 直下子が上限超のページ: 子リンクは最大 N 件に制限され（全件ロードしない）、直下子総数は正確（viewer-aware count 由来）で残数が明記される（4.3, 4.7）。
+
+### Component Tests（RTL）
+- CopyDropdown に「Markdown URL (.md)」が表示され `{path}.md` をコピー（7.1, 7.2）／共有リンクモードで非表示（7.4）。
+
+### E2E（任意）
+- ページ HTML の `<head>` に `<link rel="alternate" type="text/markdown">` が存在（6.1, 6.3）。
+
+## Security Considerations
+- 認可は既存のページ閲覧と同一（`accessTokenParser`+`loginRequired`＋viewer ファインダ）。公開ページの本文はすでに HTML 表示で匿名到達可能なため、`.md` 経路で新たな露出面は増えない。
+- forbidden/not-found の意味論は既存 apiv3 と同一（新たな情報漏洩なし）。エラー本文にページ内容は含めない。
+- footer の更新者などユーザ情報は `serializeUserSecurely` を通す。
+- `<link rel="alternate">` / `Link` の href は既存の permalink と同一情報（新規情報の露出なし）。取得時は認可が適用される。
+
+## Open Questions / Risks
+- `MARKDOWN_FOOTER_MAX_LINKS` の既定値は Phase 1 では定数（例: 50）。将来 Phase 2 の管理画面トグルで config 化しうる。
+- interception の登録順序ミスが唯一の重大リスク → 統合テストで通常 HTML 配信の維持を担保。
+- トップページ `/` の `Accept`/`?format=md` 経路は既存 `/` ルート優先のため非対応（`/{pageId}.md` permalink 形で代替可能）。許容済みの既知の限界。
+- 直下子/兄弟が多いページのメモリ対策として、リンクは `limit(N+1)`、総数は viewer-aware `countDocuments({ parent: id })` で取得し全件ロード・cursor を回避する（`addViewerCondition` を find/count で共有し drift を防ぐ）。実装は page-listing サービス層（viewer フィルタの所在に合わせ model 層でなく service 層）。

--- a/.kiro/specs/page-markdown-endpoint/requirements.md
+++ b/.kiro/specs/page-markdown-endpoint/requirements.md
@@ -1,0 +1,109 @@
+# Requirements Document
+
+## Project Description (Input)
+
+### 背景・痛点
+GROWI の URL だけを AI（対話エージェント）や検索エンジンに渡しても、コンテンツを十分に活用できない。実測で判明した 3 つの壁:
+
+1. 本文が設定閾値 `app:ssrMaxRevisionBodyLength` を超えると SSR から CSR に切り替わり、JavaScript を実行しない HTTP 取得では本文 Markdown が取れない。
+2. 兄弟ページ・配下ページの辿り方が URL 単体からは分からない。
+3. 「ホスト + ページパスでもアクセスできる」というヒントが URL から得られない。
+
+結果として AI・検索エンジンの視点で情報活用が弱く、SEO / GEO (Generative Engine Optimization) に対しても弱い。
+
+### スコープ（Phase 1 のみ）
+- 最優先は「URL を渡された対話エージェント」。ここで詰まると人間の UX に直結するため。
+- OSS core に入れる。公開ページ・社内イントラ（認証付き）の両対応。
+- SEO / GEO 向けの sitemap.xml / JSON-LD / Open Graph / canonical メタ / llms.txt / robots.txt と、それらの管理画面トグル群は **Phase 2 として別スペックに分離**する（このスペックには含めない）。
+
+## Introduction
+
+本機能は、GROWI の各ページに対して **Markdown 表現を返す HTTP エンドポイント**を追加する。URL を渡された対話型 AI エージェント（および認証付きツール）が、JavaScript を実行しなくても 1 回の取得でページ本文と近傍ナビゲーション（親・子・兄弟・正規 URL）を得られるようにし、そこからリンクを辿ってナレッジベースを探索できるようにする。既存のページ閲覧と同一のアクセス制御に従うことで、非公開情報を新しい経路から漏らさない。あわせて、この Markdown 版 URL を人間（コピー操作）と機械（HTML からの自動発見）の双方が入手できる導線を用意する。
+
+## Boundary Context
+
+- **In scope**:
+  - `/{pageId}.md`・`{pagePath}.md`・`Accept: text/markdown`（および `?format=md`）による Markdown 取得。
+  - `.md` サフィックスと実在ページの衝突解決（後方互換の維持）。
+  - 応答への近傍ナビゲーション footer の付加。
+  - 本文を持たない空ページ（コンテナ）の扱い。
+  - HTML への機械可読な発見情報（alternate link / `Link` ヘッダ）の付加。
+  - 既存 CopyDropdown への「Markdown URL (.md)」項目追加。
+- **Out of scope（Phase 2 / 別スペック）**:
+  - sitemap.xml、JSON-LD、Open Graph、SEO 用 canonical メタ、llms.txt、robots.txt、およびこれら AI/検索エンジン向け公開機能の管理画面トグル。
+  - 子ページ一覧専用の Markdown エンドポイント（`/{pageId}/children.md` 等）は作らない。子が多い場合は footer から既存のページ一覧取得手段（ページ一覧 API）へ案内する。
+- **Adjacent expectations**:
+  - アクセス制御・本文（最新リビジョン）取得・親子関係／子ページ数・子ページ一覧は、既存のページ関連の仕組みに依存する（本機能は独自の認可を持たない）。
+  - 兄弟ページは既存に専用取得手段が無いため、対象ページの親を起点に導出する。
+- **Known limitation（要件ではなく前提）**:
+  - URL 貼り付け経由のクラウド AI はセッション情報を持たないため、実際に匿名で取得できるのは公開ページが中心となる。非公開のイントラページは PAT を持つ GROWI MCP が本来の解であり、本エンドポイントは認証付きツール経由でも等しく機能する。
+- **i18n**: UI 文言は英語ファーストとし、翻訳は後続タスクとする。
+
+## Requirements
+
+### Requirement 1: ページ Markdown の取得（URL 形態）
+**Objective:** As an AI エージェント（または認証付きツール）, I want ページの Markdown 表現を URL で取得したい, so that JavaScript を実行せずにページ本文を活用できる
+
+#### Acceptance Criteria
+1. When クライアントが `/{pageId}.md`（`pageId` は permalink 形式の有効なページ ID）を GET したとき, the Markdown エンドポイント shall 該当ページの本文 Markdown を `Content-Type: text/markdown; charset=utf-8` で返す。
+2. When クライアントが `{pagePath}.md` を GET し、そのパスの解決先ページが存在するとき, the Markdown エンドポイント shall 該当ページの本文 Markdown を `text/markdown` で返す。
+3. When クライアントが通常のページ URL を `Accept: text/markdown` ヘッダ付き、または `?format=md` 付きで GET したとき, the Markdown エンドポイント shall 要求されたページの本文 Markdown を `text/markdown` で返す。
+4. The Markdown エンドポイント shall 返す本文として、そのページの最新リビジョン本文をそのまま（別形式へ変換せず）用いる。
+5. If 解決先のページが存在しないとき, then the Markdown エンドポイント shall HTTP 404 を返す。
+
+### Requirement 2: `.md` サフィックスの衝突解決（後方互換）
+**Objective:** As a 既存 GROWI 利用者, I want パス末尾が `.md` の実在ページが従来どおり表示されること, so that 新機能によって既存ページの表示が壊れない
+
+#### Acceptance Criteria
+1. When リクエストパス R が `.md` で終わり、かつ R そのものに対応する実在ページがあるとき, the GROWI サーバー shall 従来どおりそのページの通常（HTML）表示を返し、`.md` をフォーマット指定として解釈しない。
+2. When リクエストパス R が `.md` で終わり、R に対応する実在ページが無く、末尾 `.md` を除いた base に対応する実在ページがあるとき, the Markdown エンドポイント shall base ページの Markdown を返す。
+3. If リクエストパス R が `.md` で終わり、R にも base にも対応するページが無いとき, then the GROWI サーバー shall HTTP 404 を返す。
+4. When クライアントが `Accept: text/markdown` または `?format=md` を明示したとき, the Markdown エンドポイント shall 末尾 `.md` の除去を行わず、要求されたパスそのものに対応するページの Markdown を返す。
+
+### Requirement 3: アクセス制御（既存のページ閲覧認可の踏襲）
+**Objective:** As a GROWI 管理者, I want Markdown 取得が通常のページ閲覧と同じ権限で保護されること, so that 非公開情報が新しい経路から漏れない
+
+#### Acceptance Criteria
+1. The Markdown エンドポイント shall 通常のページ閲覧と同一のアクセス制御（ページの grant と閲覧者の権限）に従って取得可否を判定する。
+2. If 閲覧者が対象ページを閲覧する権限を持たないとき, then the Markdown エンドポイント shall HTTP 403 を返す。
+3. While インスタンスがゲスト読み取りを許可し、かつ対象ページが公開であるとき, the Markdown エンドポイント shall 未認証（匿名）クライアントに対して Markdown を返す。
+4. While インスタンスがゲスト読み取りを許可していないとき, when 未認証クライアントが Markdown を要求したとき, the Markdown エンドポイント shall 通常のページ閲覧と同じ挙動（ログインへの誘導もしくは取得不可）に従う。
+5. When エンドポイントが 403 または 404 を返すとき, the Markdown エンドポイント shall 応答本文に、認証付き取得または GROWI MCP の利用を促す短い案内を Markdown で含める。
+
+### Requirement 4: 近傍ナビゲーション footer
+**Objective:** As an AI エージェント, I want 1 回の取得で親・子・兄弟ページと正規のページ URL を得たい, so that リンクを辿ってナレッジベースを探索できる
+
+#### Acceptance Criteria
+1. When the Markdown エンドポイントがページの Markdown を返すとき, the Markdown エンドポイント shall 本文の末尾に、対象ページの正規のページ URL（ホスト + パス形式）と permalink を含むナビゲーション footer を付加する。
+2. When 対象ページに親ページがあるとき, the Markdown エンドポイント shall footer に親ページへの `/{pageId}.md` 形式のリンクを含める。
+3. When 対象ページに子ページがあるとき, the Markdown エンドポイント shall footer に子ページへの `/{pageId}.md` 形式のリンクと直下子ページ総数を含め、あわせて子孫合計（descendantCount）を直下子数とは別に併記する。
+4. When 対象ページに兄弟ページがあるとき, the Markdown エンドポイント shall footer に兄弟ページへの `/{pageId}.md` 形式のリンクを含める。
+5. The Markdown エンドポイント shall footer に対象ページの最終更新日時と更新者を含める。
+6. The Markdown エンドポイント shall 子ページ数の多寡に関わらず、全件を取得できる既存のページ一覧取得手段（ページ一覧 API）への案内を footer に常に含める。
+7. If footer に列挙する子ページまたは兄弟ページの件数が上限を超えるとき, then the Markdown エンドポイント shall 総数と省略された残数を明記する（黙って切り詰めない）。
+8. Where 対象ページが階層のルートで親を持たない場合, the Markdown エンドポイント shall footer の親リンクを省略する。
+
+### Requirement 5: 空ページ（コンテナページ）の扱い
+**Objective:** As an AI エージェント, I want 本文を持たない中間ノードのページでもナビゲーションを得たい, so that 探索が中間ノードで止まらない
+
+#### Acceptance Criteria
+1. When 解決先が本文を持たない空ページ（コンテナ）であるとき, the Markdown エンドポイント shall エラーにせず、ページのパスと「本文が無い」旨、および近傍ナビゲーション footer を含む Markdown を返す。
+2. When 解決先が本文の内容が空（空文字）である通常ページのとき, the Markdown エンドポイント shall 空の本文と近傍ナビゲーション footer を返す。
+3. The Markdown エンドポイント shall 空ページに対しても Requirement 4 のナビゲーション footer の規則を適用する。
+
+### Requirement 6: 機械向けの発見性（alternate link / Link ヘッダ）
+**Objective:** As an AI エージェント／クローラ, I want 素のページ URL から Markdown 版の存在を知りたい, so that コピー操作を介さずとも機械可読版へ辿れる
+
+#### Acceptance Criteria
+1. When GROWI がページの HTML を返すとき, the GROWI サーバー shall `<head>` に、当該ページの Markdown 版を指す `<link rel="alternate" type="text/markdown" href="/{pageId}.md">` を含める。
+2. When GROWI がページの HTML を返すとき, the GROWI サーバー shall 同等の情報を HTTP `Link` レスポンスヘッダとしても提供する。
+3. While ページ本文が初期 HTML に含まれず後からクライアント側で取得される場合でも, the GROWI サーバー shall 上記の alternate 情報を初期 HTML（サーバー描画部分）に含める。
+
+### Requirement 7: 人間向けの発見性（CopyDropdown）
+**Objective:** As a GROWI 利用者, I want ページの「Markdown URL (.md)」を簡単にコピーしたい, so that AI エージェントにそのまま貼り付けられる
+
+#### Acceptance Criteria
+1. When 利用者が通常ページで CopyDropdown を開いたとき, the CopyDropdown shall 「Markdown URL (.md)」項目を表示する。
+2. When 利用者が「Markdown URL (.md)」項目を選択したとき, the CopyDropdown shall 当該ページのパス URL に `.md` を付与した URL（クエリまたはハッシュがある場合はその前に `.md` を挿入）をクリップボードにコピーする。
+3. When 対象ページのパス末尾が `.md` であるとき, the CopyDropdown shall 無条件に `.md` を付与し（例: `.../README.md.md`）、解決はサーバー側の規則（Requirement 2）に委ねる。
+4. Where 共有リンク表示モードのとき, the CopyDropdown shall 「Markdown URL (.md)」項目を対象外とする（本 Phase では通常ページのみ）。

--- a/.kiro/specs/page-markdown-endpoint/research.md
+++ b/.kiro/specs/page-markdown-endpoint/research.md
@@ -1,0 +1,142 @@
+# Gap Analysis: page-markdown-endpoint
+
+対象: `.kiro/specs/page-markdown-endpoint/requirements.md`（7 要件）
+種別: ブラウングフィールド（既存の GROWI ページ配信・認可・ページツリーを再利用）
+
+## 1. 現状調査サマリ
+
+- ページ配信は最終的に `apps/app/src/server/routes/index.js` の catch-all `app.get('/*', loginRequired, autoReconnectToSearch, next.delegateToNext)`（dev/8.0.x では `:403`、その 1 行手前 `:402` に trailing-slash 用 `/*/$`）が Next.js に委譲する。permalink `/{pageId}` 専用の Express ルートは無く、これも catch-all → Next の `[[...path]]` で解決される。※このモジュールは dev/8.0.x で ESM 化（`export const setup`、子ルーターは `import { setup as … }`）され、catch-all 手前に `/vault.git`(:82) が追加されている。
+- 認可はファインダに内包: `findByIdAndViewer` / `findByPathAndViewer`（`server/service/page/find-page-and-meta-data-by-viewer.ts:87,89`）が閲覧者の grant フィルタを適用。forbidden/not-found は「フィルタ無しで再カウントし count>0 なら forbidden」で区別（同 `:93-105`）。apiv3 は forbidden→403 / not-found→404（`apiv3/page/respond-with-single-page.ts:50-61`）。
+- 本文は `revision.body`。再利用できる「Markdown→Markdown」シリアライザは存在せず、raw の本文をそのまま出すのが既存流儀（bulk-export の md 出力も `revision.body` 逐語; `features/page-bulk-export/.../steps/export-pages-to-fs-async.ts:98-99`）。
+- ページツリー: 子は `pageListingService.findChildrenByParentPathOrIdAndViewer(parentPathOrId, user, ...)`（`server/service/page-listing/page-listing.ts:58-109`、viewer grant フィルタ込み）。`descendantCount` は永続フィールド（`models/page.ts:214`）。**兄弟の専用取得は無い** → 対象の `parent`（`models/page.ts:208-213`）を親として同メソッドを呼び、自分自身を除外して導出する。
+- `<head>` は SSR される（`pages/[[...path]]/index.page.tsx:160-162`、現状 `<title>` のみ。OG/description 等は未実装）。
+
+### 重要な発見（R2 の前提に直結）
+- **末尾 `.md` のページは元々作成禁止**: `packages/core/src/utils/page-path-utils/index.ts:110` の `restrictedPatternsToCreate` に `/.+\.md$/` があり、`isCreatablePage()`（同 `:119-121`）が `.md` 終わりパスを弾く。作成・リネームの経路で `/foo.md` は作れない。
+  - 帰結: R2 の「実在ページ優先(literal-wins)」で守るべき衝突（`/README.md` という**通常ページ**）は、通常操作では発生しない。literal-wins は「DB 直挿し・インポート・過去バージョンで作られた `.md` パス」向けの**安全網**として意味を持つ（廃止はしないが、実装上のホットパスではない）。
+  - 逆に「`.md` という名前空間が予約済みで空いている」ため、`{pagePath}.md` を Markdown フォーマット要求として解釈する設計は既存規約と整合的。
+
+## 2. 要件→資産マップ（ギャップタグ: 再利用可 / 新規 / 要調査）
+
+| 要件 | 使う既存資産 | ギャップ |
+|---|---|---|
+| R1 取得(URL 形態) | catch-all 手前への route/middleware 追加; `findByIdAndViewer`/`findByPathAndViewer`; `isPermalink`/`isValidObjectId`（`packages/core/.../objectid-utils.ts:3-16`, `page-path-utils/index.ts:21-24`） | **新規**: ルート本体・`Accept`/`?format=md` 判定 |
+| R2 `.md` 衝突解決 | `isCreatablePage`（`.md` 予約の裏付け）; パス実在チェック（ファインダ） | **新規**: literal-wins の分岐（安全網）。**要調査**: `.md` サフィックスと `Accept` 明示の優先順位 |
+| R3 認可 | `accessTokenParser([SCOPE.READ.FEATURES.PAGE], { acceptLegacy:true })` + `loginRequired`（ゲスト許可）の合成（例: `routes/index.js:200-205`, `routes/attachment/get-brand-logo.ts:21,28-29`） | **再利用可**（並行実装しない）。403/404 意味論もファインダ流用 |
+| R4 ナビ footer | `findChildrenByParentPathOrIdAndViewer`; `page.parent`; provenance（`page.updatedAt` `models/page.ts:262`, `page.lastUpdateUser.username` `:255`）; `serializeUserSecurely`（`@growi/core/dist/models/serializers`） | **新規**: footer 組立の純関数; 兄弟導出（親→子→自分除外）; ページ一覧 API 誘導文。**要調査**: 子/兄弟のインライン列挙上限値 |
+| R5 空ページ | ファインダの `isEmpty`/本文有無 | **新規**: 空ページ時の「本文なし＋ナビのみ」応答分岐 |
+| R6 発見性(機械) | `<head>`（`index.page.tsx:160-162`, SSR）; GSSP の `context.res` | **新規**: `<link rel=alternate>` 追加 + HTTP `Link` ヘッダ。**要調査**: HTML は Next 配信のため `Link` ヘッダをどこで付けるか（GSSP か手前 middleware か） |
+| R7 発見性(人間) | `CopyDropdown.tsx`（`:56-275`）; `useTranslation('commons')`; `encodeSpaces` | **新規（拡張）**: DropdownItem 1 個 + i18n キー `copy_to_clipboard.Markdown URL`（`public/static/locales/*/commons.json`, en は `en_US/commons.json:90-98`） |
+
+## 3. 実装アプローチ（コンポーネント別）
+
+### (a) Markdown 配信エンドポイント本体 — 推奨: Option B（新規）
+- catch-all（dev/8.0.x では `routes/index.js:402-403`）の**直前**に、Markdown 判定用のハンドラを 1 枚差し込む。責務が明確で既存の巨大ファイルを汚さない。ESM 化済みのため名前付き export ＋ `import` で組む（CJS `require` は使わない）。
+- 判定: パス末尾 `.md`（permalink `/{id}.md` / path `{path}.md`）**または** `Accept: text/markdown` / `?format=md`。該当しなければ `next()` で既存 Next 委譲へフォールスルー。
+- ルート構造は TS の factory パターン（`getBrandLogoRouterFactory(crowi): Router` `routes/attachment/get-brand-logo.ts:19` が手本）。Content-Type は `res`（`ogp.ts:119-122` のように明示設定）。
+- 認可は `accessTokenParser([SCOPE.READ.FEATURES.PAGE], { acceptLegacy:true })` + `loginRequired` を前段に合成（R3、並行実装しない）。
+- トレードオフ: ✅責務分離・単体テスト容易 / ❌ catch-all との**登録順序**が唯一の注意点（順序を誤ると通常ページ配信やアセットを飲み込む）。
+
+### (b) 本文＋footer の組立 — 推奨: Option B（新規・純関数）
+- `revision.body` に近傍ナビ footer 文字列を連結する**純関数**として切り出す（`page + revision + parent + children + siblings + counts → markdown` を受け取り出力）。coding-style の「フレームワーク境界から純ロジックを抽出」に合致し、テストが容易。
+- 兄弟は親 id で `findChildrenByParentPathOrIdAndViewer` を呼び自分を除外。provenance ユーザは `serializeUserSecurely` を通す。
+
+### (c) CopyDropdown 項目 — 推奨: Option A（既存拡張）
+- `CopyDropdown.tsx` に `DropdownItem` を 1 個追加、値は `${pagePathUrl}.md`（クエリ/ハッシュの前に `.md`）。共有リンクモードは対象外（R7.4）。i18n キーを 5 言語 `commons.json` に追加（英語ファースト、他言語は後続タスク可）。
+- `.md` URL を作る共有ヘルパは既存に無い（CopyDropdown は URL をインライン組立）。小さな純関数として `~/utils` 等に切り出すと CopyDropdown と `<link rel=alternate>` で共用でき、drift を防げる（要調査: 置き場所）。
+
+### (d) 発見性(head/Link) — 推奨: Option A（既存拡張）
+- `<link rel=alternate type=text/markdown href=/{pageId}.md>` を `[[...path]]/index.page.tsx` の `<Head>` に追加（SSR されるので CSR 時も初期 HTML に載る＝R6.3 を満たす）。
+- HTTP `Link` ヘッダは HTML が Next 配信のため、GSSP の `context.res.setHeader` か手前 middleware で付与（**要調査**）。
+
+## 4. 工数 / リスク
+
+| 項目 | 工数 | リスク | 一言 |
+|---|---|---|---|
+| (a) エンドポイント本体・解決・認可 | M | Low〜Medium | 既存パターン流用。唯一の勘所は catch-all との登録順序 |
+| (b) footer 組立・兄弟導出 | M | Low〜Medium | 兄弟でクエリ 1 本追加・自分除外。viewer フィルタは既存で担保 |
+| (c) CopyDropdown + i18n | S | Low | 項目 1 個 + キー追加 |
+| (d) alternate link + Link ヘッダ | S〜M | Low | head は容易。Link ヘッダ位置のみ要判断 |
+| R5 空ページ分岐 | S | Low | `isEmpty`/本文有無で分岐 |
+
+全体: **M / Low〜Medium**。新規アルゴリズムは無く、既存の配信・認可・ツリーの再利用が主。
+
+## 5. 設計フェーズへの申し送り
+
+### 推奨アプローチ
+- 本体は **Option B（catch-all 手前の新規ハンドラ）**、footer は **純関数として新規**、UI/head は **既存拡張（Option A）**。認可は完全再利用。
+- literal-wins（R2）は残すが、`.md` 作成禁止（`isCreatablePage`）の裏付けにより「安全網」と位置づけ、実装をシンプルに保つ。
+
+### 要調査（Research Needed）
+1. **interception の実装形態**: catch-all 手前の単一 middleware か、`.md` 用の正規表現ルート + `Accept` 用の別判定か。GET・ページ的パスのみに絞り性能影響を避ける方法。
+2. **`.md` サフィックスと `Accept`/`?format=md` の優先順位**（両方与えられた場合）。
+3. **HTTP `Link` ヘッダの付与位置**（Next 配信 HTML への付け方: GSSP か middleware か）。
+4. **子/兄弟のインライン列挙上限**（定数か config か）と、footer に載せるページ一覧 API 案内 URL の正確な形（`/_api/v3/page-listing/children?path=...`）。
+5. **`.md` URL 生成の共有ヘルパの置き場所**（server 応答内リンクと client CopyDropdown・`<link>` で共用し drift を防ぐ）。
+6. **provenance の公開範囲**（`serializeUserSecurely` を通し、username/name のみ露出）。
+7. 本文は `revision.body` 逐語で返す（lsx 等の動的展開・相対リンク解決は本 Phase の対象外）ことの明文化。
+8. キャッシュ方針（ETag / Cache-Control）は任意の NFR として design で検討。
+
+### テスト方針（既存作法）
+- サーバルートは supertest + `getInstance()`（`test/setup/crowi`）で bootstrap し、`accessTokenParser`/`login-required` を `vi.mock` する（手本: `apps/app/src/server/routes/apiv3/page/get-page-info.integ.ts:43-216`、plain ルートは `routes/comment.integ.ts`）。dev/8.0.x では `findPageAndMetaDataByViewer` が Prisma（bookmarks）に依存するため、bootstrap で Prisma が初期化されていること（手本 integ が dev/8.0.x で green か先に確認）。
+- footer 組立の純関数は fixture で単体テスト。
+
+---
+
+## 設計フェーズの統合結果（design synthesis）
+
+### Generalization
+- R1（3 つの URL 形態）・R2（解決）・R3（認可）・R4/R5（footer・空ページ）は「リクエスト → 閲覧者向けにページを解決 → Markdown 文書（本文＋footer）を生成」という単一パイプラインに集約。`PageMarkdownService.resolve` が唯一の入口で、`parseMarkdownRequest`（意図解釈）→ viewer ファインダ（解決＋認可）→ listing（親子兄弟）→ `buildPageMarkdown`（組立）と流す。
+- `.md` URL の形（`/{pageId}.md`）は `page-markdown-url` の純関数に一元化し、footer 内リンク・`<link rel=alternate>`・CopyDropdown・（将来 Phase 2 の）全消費者が同じ生成規則を参照する（drift 防止・単一情報源）。
+
+### Build vs Adopt
+- Adopt: HTTP 標準の内容ネゴシエーション（`Accept` / `Link` ヘッダ）、既存 viewer ファインダ（認可＋not-found/forbidden 意味論）、`pageListingService`（子・兄弟）、`revision.body` 逐語、`serializeUserSecurely`。
+- Build（最小限）: catch-all 手前の interception ルート、literal-wins の解決グルー、footer 組立の純関数、`.md` URL 生成の純関数、CopyDropdown 項目＋head link。
+- 理由: 認可・本文・ツリーは実績ある既存実装があり、再実装は drift とセキュリティリスクを生むため採用しない。
+
+### Simplification
+- children.md を作らない（決定済み）。footer から既存ページ一覧 API へ案内。
+- interception は「`.md` サフィックスと `Accept`/`?format=md` を 1 箇所で判定し、非該当は `next()`」の**単一ミドルウェア**に統一（複数正規表現ルートに分割しない）。
+- Phase 1 はキャッシュ層なし。footer のリンク上限は定数 `MARKDOWN_FOOTER_MAX_LINKS`（config 化は Phase 2）。
+- 結果型は discriminated union（`ok` / `forbidden` / `notFound` / `passthrough`）で表現し、`passthrough` により literal `.md` 実在ページを既存 HTML 配信へ委ねる。
+
+### 要調査（研究）項目の解決状況
+1. interception 形態 → catch-all 直前の単一ミドルウェアに決定。
+2. `.md` と `Accept` の優先順位 → 明示（`Accept`/`?format=md`）を最優先し末尾除去しない。`.md` サフィックスは糖衣で literal→base。
+3. `Link` ヘッダ位置 → `[[...path]]` の GSSP（`context.res`）で設定。
+4. 子/兄弟の列挙上限 → 定数 `MARKDOWN_FOOTER_MAX_LINKS`。案内 URL は `/_api/v3/page-listing/children`。
+5. `.md` URL ヘルパ位置 → `apps/app/src/utils/page-markdown-url.ts`（client 安全・共用）。
+6. provenance → `serializeUserSecurely` を通し username のみ露出。
+7. 本文は `revision.body` 逐語（lsx 展開・相対リンク解決は Non-Goal）。
+8. キャッシュ → Phase 1 では Non-Goal。
+
+---
+
+## validate-design（opus 敵対的レビュー）結果と反映
+
+opus サブエージェントが design を実コードと突き合わせて敵対的レビュー。骨格は健全と確認しつつ 3 件の要修正を検出。判定は条件付き NO-GO → 以下を design.md に反映して GO に転じた。
+
+1. **populate 抜け（correctness）**: `findPageAndMetaDataByViewer` は `revision`/`parent`/`lastUpdateUser` を populate しない（本体 page.ts:696-718・830-852 に populate 呼び出し無し）。既存の読み取り経路は route/データ層で `initLatestRevisionField`＋`populateDataToShowRevision` を別途呼ぶ（`respond-with-single-page.ts:78-81`, `page-data-props.ts:226-237`）。→ 慣習に合わせ populate は **route 層のレスポンスヘルパ `respond-with-page-markdown.ts`** の責務とし、`service/page-markdown/` を廃止。親は `page.parent` から追加クエリで解決すると明記。
+2. **空ページで pageId 不在（要件間矛盾）**: 空ページは GSSP が `data:null`+`isNotFound:true` を返す（`page-data-props.ts:206-223`）ため、client props に `_id` が無く `/{pageId}.md` の alternate/Link を作れない。→ `<link>`/`Link` を **path 形 `{path}.md` にフォールバック**可能にし、Link ヘッダは空ページ早期 return より前のスコープの `_id` で設定すると明記。R6.1 も pageId 無しは path 形を許すよう整合。
+3. **descendantCount ≠ 直下子数（correctness）**: `descendantCount`（page.ts:214）は子孫合計。→ 直下子総数は `findChildrenByParentPathOrIdAndViewer(id)` の結果長（viewer フィルタ済み）を使い、`descendantCount` は footer に**別個に併記**。ユーザ判断で専用 count メソッドは作らない（grant フィルタ二重実装＝drift 回避。将来性能問題時に page-listing service へ count 追加）。R4.3 を更新。
+
+副次対応: トップページ `/` の Accept/`?format=md` 非対応（既知の限界・permalink で代替）、`Accept` はメディアタイプ明示一致のみ（`req.accepts` の `*/*` 誤爆回避）、子・兄弟は id 指定で regex 非生成、root は親・兄弟省略ガード。すべて Implementation Notes / Open Questions に記載。
+
+### メモリ観点の追補（子・兄弟取得）
+ユーザ指摘により、直下子/兄弟が大量のページで全件ロードするとメモリを圧迫する点を是正。cursor は「先頭 N 件」用途では利点が無く不要と判断し、リンクは `limit(MARKDOWN_FOOTER_MAX_LINKS + 1)`、正確な総数は `addViewerCondition` を重ねた `countDocuments({ parent: id })`（既存 `countByIdAndViewer` `page.ts:722-729` と同流儀）で取得する方針に変更。`addViewerCondition` を find/count で共有するため grant ロジックの二重実装＝drift は起きない。`PageQueryBuilder` は `addConditionToPagenate(offset, limit, sortOpt)`（`page.ts:579-580`）で limit をサポート。page-listing サービスへ「limit 付き取得＋viewer-aware count」を追加し、既存の全件返し `findChildrenByParentPathOrIdAndViewer` は本用途に使わない。※上記 #3 の『専用 count メソッドは作らない』判断は、このメモリ観点で「viewer-aware count を足す（`addViewerCondition` 共有で drift 無し）」へ更新。既存ページツリーも全件ロードしている点は別課題（本エンドポイントのみ先行改善）。
+
+---
+
+## dev/8.0.x 再ベース（2026-07-11 実測）
+
+本 spec は master(現HEAD) 上で作成された。実装は `origin/dev/8.0.x`(cb655c3) をベースに行う。分岐点から dev は 1389 コミット先行しているため、設計が名指しした既存コードとの整合を実測で確認した。**要件・設計思想・タスク分割はそのまま通用する**。反映した差分は以下。
+
+### 実装前に効く差分（反映済み）
+1. **`server/routes/index.js` の ESM 化**: `module.exports = (crowi, app) =>` → `export const setup = (crowi, app) =>`。子ルーターは `require('./page')(crowi, app)` → `import { setup as setupPage } from './page'` ＋ `setupPage(crowi, app)`。新 page-markdown ルートも ESM の名前付き export（TS factory `getBrandLogoRouterFactory` と同型）で組み、`setup` 内で `app.use(...)` する。catch-all は master の `:401`/`:402` → dev では **`:402`/`:403`**。手前に新ルート `/vault.git`(:82) が追加（接頭辞違いで衝突なし）。
+2. **`findPageAndMetaDataByViewer` の Prisma 依存**: bookmark 集計が Mongoose→Prisma（`prisma.bookmarks.count` / `findByPageIdAndUserId`）に変更。**認可・not-found/forbidden の契約は master と同一**で設計ロジックに影響しない。ただしこの finder を通る `*.integ.ts` は bootstrap で Prisma 初期化が要る（dev/8.0.x の Mongoose+Prisma 二重書き込み構成由来）。
+
+### 据え置きで良い点（実測で確認）
+- literal-wins(R2) の前提 `packages/core/.../page-path-utils/index.ts` の `.md` 予約（`restrictedPatternsToCreate` の `/.+\.md$/`）と `isCreatablePage` は無変更（差分は import への `.js` 拡張子追加=ESM のみ）。
+- 認可ミドルウェア API `accessTokenParser([SCOPE.READ.FEATURES.PAGE], { acceptLegacy: true })` は dev にもそのままの形で残存。
+- `models/page.ts`・`service/page-listing/page-listing.ts`・`apiv3/page/respond-with-single-page.ts`・`pages/[[...path]]/page-data-props.ts`・`index.page.tsx`・`routes/attachment/get-brand-logo.ts` は master と**バイト一致**（引用した行番号アンカーも有効）。`initLatestRevisionField` は `obsolete-page.js` に健在。
+- 軽微: `en_US/commons.json`(+47 行) と `CopyDropdown.tsx`(2 行)・`ogp.ts`(16 行) は行番号がずれるのみで、キー追加・拡張作業自体は変わらない。

--- a/.kiro/specs/page-markdown-endpoint/spec.json
+++ b/.kiro/specs/page-markdown-endpoint/spec.json
@@ -1,0 +1,23 @@
+{
+  "feature_name": "page-markdown-endpoint",
+  "created_at": "2026-07-11T06:12:51Z",
+  "updated_at": "2026-07-11T18:19:46Z",
+  "language": "ja",
+  "base_branch": "origin/dev/8.0.x",
+  "phase": "tasks-generated",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/page-markdown-endpoint/tasks.md
+++ b/.kiro/specs/page-markdown-endpoint/tasks.md
@@ -28,7 +28,7 @@
   - _Boundary: buildPageMarkdown_
 
 - [ ] 2. Core: サーバ側データ取得とレスポンス組立
-- [ ] 2.1 (P) page-listing にメモリ非全件の子取得＋viewer-aware count を追加
+- [x] 2.1 (P) page-listing にメモリ非全件の子取得＋viewer-aware count を追加
   - `limit` を引数で受け取り最大 `limit` 件の viewer フィルタ済み直下子を返す取得と、`addViewerCondition` を共有した `countDocuments({ parent: id })` による正確な直下子総数を、統合テスト先行で追加する（既存の全件返しは本用途に使わない）。
   - Task 1 のユーティリティに依存しない（page-listing サービス境界のみ）ため foundation と並行実行可能。
   - Done: 統合テストで、返る子が `limit` 件に制限され、かつ総数が閲覧不可ページを除いた正確な件数になることを確認。

--- a/.kiro/specs/page-markdown-endpoint/tasks.md
+++ b/.kiro/specs/page-markdown-endpoint/tasks.md
@@ -59,7 +59,7 @@
   - _Requirements: 6.1, 6.2, 6.3_
   - _Boundary: Page Head, page-data-props_
 
-- [ ] 3.3 (P) CopyDropdown に「Markdown URL (.md)」項目＋英語ロケール
+- [x] 3.3 (P) CopyDropdown に「Markdown URL (.md)」項目＋英語ロケール
   - 既存 CopyDropdown に項目を追加し、値は `{path}.md`（無条件に `.md` を付与し解決はサーバに委ねる）。共有リンク表示モードでは非表示。`en_US` の `commons.json` に `copy_to_clipboard."Markdown URL"` を追加（他 4 言語の翻訳は英語ファースト方針により後続）。
   - Done: 通常ページで項目が表示され `{path}.md` をコピーでき、共有リンクモードでは非表示になることをコンポーネントテストで確認。
   - _Depends: 1.1_

--- a/.kiro/specs/page-markdown-endpoint/tasks.md
+++ b/.kiro/specs/page-markdown-endpoint/tasks.md
@@ -12,7 +12,7 @@
   - _Requirements: 6.1, 7.2, 7.3_
   - _Boundary: pageMarkdownUrl_
 
-- [ ] 1.2 (P) Markdown リクエストの意図解釈（純関数）
+- [x] 1.2 (P) Markdown リクエストの意図解釈（純関数）
   - リクエストを `none` / `permalink` / `path` に分類し、`explicit`（`Accept: text/markdown` または `?format=md`）か `.md` サフィックスかを表すフラグを返す純関数を、テスト先行で実装する。
   - permalink 判定は `isPermalink` / `isValidObjectId`。**元のパスは加工せず**そのまま返し、`explicit=false`（サフィックス）時の「literal→base」への落とし込みは 2.2 が担う（ここでは strip しない＝passthrough 用の元パスを失わない）。
   - Done: サフィックス／`Accept`／`?format=md`／permalink／`.md.md` を網羅するテーブルテストが green。

--- a/.kiro/specs/page-markdown-endpoint/tasks.md
+++ b/.kiro/specs/page-markdown-endpoint/tasks.md
@@ -5,7 +5,7 @@
 > ベース: 実装ブランチは `origin/dev/8.0.x` から切る（master ではない）。dev/8.0.x 固有の前提として、(1) `routes/index.js` は ESM 化済み（`export const setup`、子ルーターは `import { setup as … }`、catch-all は `:402`/`:403`、手前に `/vault.git`）→ 新ルートも名前付き export ＋ `import` で組む、(2) `findPageAndMetaDataByViewer` が bookmark 集計を Prisma で行う（認可契約は不変）→ この finder を通る結合テストは bootstrap で Prisma 初期化が要る。詳細は research.md「dev/8.0.x 再ベース」節。
 
 - [ ] 1. Foundation: 共有の純関数ユーティリティ（テスト先行）
-- [ ] 1.1 (P) `.md` URL 生成ユーティリティ
+- [x] 1.1 (P) `.md` URL 生成ユーティリティ
   - permalink 形（`/{pageId}.md`）とパス形（`{path}.md`）を生成する純関数を、先にユニットテストを書いてから実装する。
   - パス形はクエリ／ハッシュがある場合その**前**に `.md` を挿入する。
   - Done: `(pageId または path, origin)` を与えると期待どおりの `.md` URL を返し、クエリ/ハッシュ付きの端ケースもテストが green。

--- a/.kiro/specs/page-markdown-endpoint/tasks.md
+++ b/.kiro/specs/page-markdown-endpoint/tasks.md
@@ -45,7 +45,7 @@
   - _Boundary: respondWithPageMarkdown_
 
 - [ ] 3. Integration: HTTP ルート・発見リンク・UI
-- [ ] 3.1 page-markdown ルートを catch-all 直前に登録
+- [x] 3.1 page-markdown ルートを catch-all 直前に登録
   - GET のみ対象、`parseMarkdownRequest` が `none` なら即 `next()`。`accessTokenParser([SCOPE.READ.FEATURES.PAGE], { acceptLegacy: true })`＋`loginRequired`（ゲスト許可）を合成し `respondWithPageMarkdown` を呼ぶ。`text/markdown; charset=utf-8` で 200/403/404、`passthrough` は `next()`。`Accept` はメディアタイプ明示一致のみで判定（`req.accepts` の `*/*` 誤爆を避ける）。`routes/index.js`（ESM 化済み。名前付き export を `import` して `setup` 内で `app.use`）の `:402`/`:403` catch-all の直前に登録。
   - Done: `/{pageId}.md`・`{path}.md`・`Accept` 付き平文 URL が 200 Markdown、権限外 403、非存在 404、ゲスト許可時は匿名 200・不許可時はログイン挙動、literal `.md` は HTML passthrough、通常ページの HTML 配信が維持されることを supertest 統合テストで確認。
   - _Depends: 2.2_

--- a/.kiro/specs/page-markdown-endpoint/tasks.md
+++ b/.kiro/specs/page-markdown-endpoint/tasks.md
@@ -19,7 +19,7 @@
   - _Requirements: 1.1, 1.2, 1.3, 2.2, 2.4_
   - _Boundary: parseMarkdownRequest_
 
-- [ ] 1.3 Markdown 本文＋footer 組立（純関数）
+- [x] 1.3 Markdown 本文＋footer 組立（純関数）
   - 本文に近傍ナビゲーション footer（正規 URL・permalink・親・直下子リンク＋直下子総数・子孫合計 descendantCount・兄弟・更新日時／更新者）を連結する純関数と、403/404 用の案内 Markdown を返す関数を、テスト先行で実装する。footer の列挙上限定数 `MARKDOWN_FOOTER_MAX_LINKS` を定義する。
   - ページ一覧 API 案内を件数不問で常に含め、上限超過時は総数と残数を明記。ルートでは親・兄弟を省略。空ページは本文の代わりに「本文なし」の一文＋footer。
   - Done: footer 各要素と 4.6／4.7／4.8／5.1–5.3／3.5（エラー本文の案内）をユニットテストで検証。

--- a/.kiro/specs/page-markdown-endpoint/tasks.md
+++ b/.kiro/specs/page-markdown-endpoint/tasks.md
@@ -67,7 +67,7 @@
   - _Boundary: CopyDropdown_
 
 - [ ] 4. Validation: 結合と回帰
-- [ ] 4.1 エンドツーエンド結合と回帰検証
+- [x] 4.1 エンドツーエンド結合と回帰検証
   - 3 つの URL 形態、ゲスト／PAT 経路、空（コンテナ）ページのナビ中心 Markdown、populate 回帰（本文＋更新者名が含まれる）、footer の直下子総数と子孫合計 descendantCount の併記＋上限超過時の残数明記、メモリ非全件（子は最大 N 件ロード・総数は正確）、interception 登録順序による通常 HTML 配信への非干渉、を通しで検証する。
   - Done: 上記シナリオがすべて green。
   - _Depends: 3.1, 3.2, 3.3_

--- a/.kiro/specs/page-markdown-endpoint/tasks.md
+++ b/.kiro/specs/page-markdown-endpoint/tasks.md
@@ -35,7 +35,7 @@
   - _Requirements: 4.3, 4.7_
   - _Boundary: page-listing service_
 
-- [ ] 2.2 respond-with-page-markdown レスポンスヘルパ
+- [x] 2.2 respond-with-page-markdown レスポンスヘルパ
   - 意図（1.2）に従い解決する（permalink は id、path は literal→base の順に `findPageAndMetaDataByViewer` を使用。literal→base の判定はここが所有）。
   - finder は populate しないため `initLatestRevisionField()`＋`populateDataToShowRevision(false)` で本文・更新者を populate し、`page.parent` から親を追加クエリで解決。子・兄弟は 2.1 を `limit=MARKDOWN_FOOTER_MAX_LINKS` で呼び、兄弟は自分を除外。更新者は `serializeUserSecurely` を通す。
   - 結果を `ok` / `forbidden` / `notFound` / `passthrough`（literal `.md` 実在ページ）で返し、`buildPageMarkdown` で本文を組み立てる。
@@ -72,3 +72,8 @@
   - Done: 上記シナリオがすべて green。
   - _Depends: 3.1, 3.2, 3.3_
   - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 3.4, 3.5, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 5.1, 5.2, 5.3, 6.1, 6.2, 6.3, 7.1, 7.2, 7.3, 7.4_
+
+## Implementation Notes
+
+- 2.1: page-listing の新メソッドは `findLimitedChildrenByParentIdAndViewer(parentId: string, user, limit)` / `countChildrenByParentIdAndViewer(parentId: string, user)`（parentId は string、ObjectId は `.toString()` して渡す）。
+- 2.2: `respondWithPageMarkdown(crowi, input)` は finder を `basicOnly: true` で呼ぶ（認可・forbidden/notFound 判定は非 basicOnly と同一とレビューで実証済み。bookmark 集計をスキップするため、この経路は Prisma に到達しない）。input.user は `HydratedDocument<IUser> | undefined`（route は `req.user` をそのまま渡せる）。helper 単位の integ は respond-with-page-markdown.integ.ts（File Structure Plan への承認済み追加）。forbidden-literal passthrough と guest-forbidden の route 検証は 3.1 の supertest が所有。

--- a/.kiro/specs/page-markdown-endpoint/tasks.md
+++ b/.kiro/specs/page-markdown-endpoint/tasks.md
@@ -76,4 +76,5 @@
 ## Implementation Notes
 
 - 2.1: page-listing の新メソッドは `findLimitedChildrenByParentIdAndViewer(parentId: string, user, limit)` / `countChildrenByParentIdAndViewer(parentId: string, user)`（parentId は string、ObjectId は `.toString()` して渡す）。
+- 検証(4.1後): `src/server/routes/**` にはカスタム lint `route-top-level-guard` があり、トップレベルの呼び出し初期化（例: `[...].join('\n')`）を禁止する（ESM ブート順序対策）。route 配下へファイルを足すタスクは `pnpm run lint`（biome/tsgo だけでなく）まで回すこと。build-page-markdown.ts の ERROR_GUIDANCE を template literal に修正済み。
 - 2.2: `respondWithPageMarkdown(crowi, input)` は finder を `basicOnly: true` で呼ぶ（認可・forbidden/notFound 判定は非 basicOnly と同一とレビューで実証済み。bookmark 集計をスキップするため、この経路は Prisma に到達しない）。input.user は `HydratedDocument<IUser> | undefined`（route は `req.user` をそのまま渡せる）。helper 単位の integ は respond-with-page-markdown.integ.ts（File Structure Plan への承認済み追加）。forbidden-literal passthrough と guest-forbidden の route 検証は 3.1 の supertest が所有。

--- a/.kiro/specs/page-markdown-endpoint/tasks.md
+++ b/.kiro/specs/page-markdown-endpoint/tasks.md
@@ -1,0 +1,74 @@
+# Implementation Plan
+
+> 方針: 新規変更は TDD（テスト先行・red→green）。認可は既存 middleware / viewer ファインダを再利用（並行実装しない）。i18n は英語ファーストで他言語翻訳は後続。純関数（url/parse/build）を先に固め、route 層のレスポンスヘルパで組み立てる。
+>
+> ベース: 実装ブランチは `origin/dev/8.0.x` から切る（master ではない）。dev/8.0.x 固有の前提として、(1) `routes/index.js` は ESM 化済み（`export const setup`、子ルーターは `import { setup as … }`、catch-all は `:402`/`:403`、手前に `/vault.git`）→ 新ルートも名前付き export ＋ `import` で組む、(2) `findPageAndMetaDataByViewer` が bookmark 集計を Prisma で行う（認可契約は不変）→ この finder を通る結合テストは bootstrap で Prisma 初期化が要る。詳細は research.md「dev/8.0.x 再ベース」節。
+
+- [ ] 1. Foundation: 共有の純関数ユーティリティ（テスト先行）
+- [ ] 1.1 (P) `.md` URL 生成ユーティリティ
+  - permalink 形（`/{pageId}.md`）とパス形（`{path}.md`）を生成する純関数を、先にユニットテストを書いてから実装する。
+  - パス形はクエリ／ハッシュがある場合その**前**に `.md` を挿入する。
+  - Done: `(pageId または path, origin)` を与えると期待どおりの `.md` URL を返し、クエリ/ハッシュ付きの端ケースもテストが green。
+  - _Requirements: 6.1, 7.2, 7.3_
+  - _Boundary: pageMarkdownUrl_
+
+- [ ] 1.2 (P) Markdown リクエストの意図解釈（純関数）
+  - リクエストを `none` / `permalink` / `path` に分類し、`explicit`（`Accept: text/markdown` または `?format=md`）か `.md` サフィックスかを表すフラグを返す純関数を、テスト先行で実装する。
+  - permalink 判定は `isPermalink` / `isValidObjectId`。**元のパスは加工せず**そのまま返し、`explicit=false`（サフィックス）時の「literal→base」への落とし込みは 2.2 が担う（ここでは strip しない＝passthrough 用の元パスを失わない）。
+  - Done: サフィックス／`Accept`／`?format=md`／permalink／`.md.md` を網羅するテーブルテストが green。
+  - _Requirements: 1.1, 1.2, 1.3, 2.2, 2.4_
+  - _Boundary: parseMarkdownRequest_
+
+- [ ] 1.3 Markdown 本文＋footer 組立（純関数）
+  - 本文に近傍ナビゲーション footer（正規 URL・permalink・親・直下子リンク＋直下子総数・子孫合計 descendantCount・兄弟・更新日時／更新者）を連結する純関数と、403/404 用の案内 Markdown を返す関数を、テスト先行で実装する。footer の列挙上限定数 `MARKDOWN_FOOTER_MAX_LINKS` を定義する。
+  - ページ一覧 API 案内を件数不問で常に含め、上限超過時は総数と残数を明記。ルートでは親・兄弟を省略。空ページは本文の代わりに「本文なし」の一文＋footer。
+  - Done: footer 各要素と 4.6／4.7／4.8／5.1–5.3／3.5（エラー本文の案内）をユニットテストで検証。
+  - _Depends: 1.1_
+  - _Requirements: 3.5, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 5.1, 5.2, 5.3_
+  - _Boundary: buildPageMarkdown_
+
+- [ ] 2. Core: サーバ側データ取得とレスポンス組立
+- [ ] 2.1 (P) page-listing にメモリ非全件の子取得＋viewer-aware count を追加
+  - `limit` を引数で受け取り最大 `limit` 件の viewer フィルタ済み直下子を返す取得と、`addViewerCondition` を共有した `countDocuments({ parent: id })` による正確な直下子総数を、統合テスト先行で追加する（既存の全件返しは本用途に使わない）。
+  - Task 1 のユーティリティに依存しない（page-listing サービス境界のみ）ため foundation と並行実行可能。
+  - Done: 統合テストで、返る子が `limit` 件に制限され、かつ総数が閲覧不可ページを除いた正確な件数になることを確認。
+  - _Requirements: 4.3, 4.7_
+  - _Boundary: page-listing service_
+
+- [ ] 2.2 respond-with-page-markdown レスポンスヘルパ
+  - 意図（1.2）に従い解決する（permalink は id、path は literal→base の順に `findPageAndMetaDataByViewer` を使用。literal→base の判定はここが所有）。
+  - finder は populate しないため `initLatestRevisionField()`＋`populateDataToShowRevision(false)` で本文・更新者を populate し、`page.parent` から親を追加クエリで解決。子・兄弟は 2.1 を `limit=MARKDOWN_FOOTER_MAX_LINKS` で呼び、兄弟は自分を除外。更新者は `serializeUserSecurely` を通す。
+  - 結果を `ok` / `forbidden` / `notFound` / `passthrough`（literal `.md` 実在ページ）で返し、`buildPageMarkdown` で本文を組み立てる。
+  - Done: 公開ページで本文＋footer 付き `ok`、権限外は `forbidden`＋案内、非存在は `notFound`＋案内、literal `.md` は `passthrough` を返す（3.1 の統合テストで検証）。
+  - _Depends: 1.1, 1.2, 1.3, 2.1_
+  - _Requirements: 1.4, 2.1, 2.2, 2.3, 3.1, 3.2, 3.5, 4.1, 4.2, 4.3, 4.4, 4.5, 5.1, 5.2, 5.3_
+  - _Boundary: respondWithPageMarkdown_
+
+- [ ] 3. Integration: HTTP ルート・発見リンク・UI
+- [ ] 3.1 page-markdown ルートを catch-all 直前に登録
+  - GET のみ対象、`parseMarkdownRequest` が `none` なら即 `next()`。`accessTokenParser([SCOPE.READ.FEATURES.PAGE], { acceptLegacy: true })`＋`loginRequired`（ゲスト許可）を合成し `respondWithPageMarkdown` を呼ぶ。`text/markdown; charset=utf-8` で 200/403/404、`passthrough` は `next()`。`Accept` はメディアタイプ明示一致のみで判定（`req.accepts` の `*/*` 誤爆を避ける）。`routes/index.js`（ESM 化済み。名前付き export を `import` して `setup` 内で `app.use`）の `:402`/`:403` catch-all の直前に登録。
+  - Done: `/{pageId}.md`・`{path}.md`・`Accept` 付き平文 URL が 200 Markdown、権限外 403、非存在 404、ゲスト許可時は匿名 200・不許可時はログイン挙動、literal `.md` は HTML passthrough、通常ページの HTML 配信が維持されることを supertest 統合テストで確認。
+  - _Depends: 2.2_
+  - _Requirements: 1.1, 1.2, 1.3, 1.5, 2.1, 2.3, 2.4, 3.1, 3.2, 3.3, 3.4, 3.5_
+  - _Boundary: PageMarkdownRoute, routes/index.js_
+
+- [ ] 3.2 (P) 機械向け発見リンク（alternate link ＋ Link ヘッダ）
+  - `[[...path]]` の `<Head>` に `<link rel="alternate" type="text/markdown">` を追加。`pageId` があれば permalink 形、無ければ（空ページ等で props に `_id` が無い）`currentPathname` から path 形にフォールバック。`Link` ヘッダは GSSP で、空ページの早期 return より前のスコープの `_id` を使って設定。
+  - Done: ページ HTML の `<head>` に Markdown 版 alternate が出力され、空ページでは path 形になり、`Link` ヘッダも（本文 CSR ページ含め）付与される。
+  - _Depends: 1.1_
+  - _Requirements: 6.1, 6.2, 6.3_
+  - _Boundary: Page Head, page-data-props_
+
+- [ ] 3.3 (P) CopyDropdown に「Markdown URL (.md)」項目＋英語ロケール
+  - 既存 CopyDropdown に項目を追加し、値は `{path}.md`（無条件に `.md` を付与し解決はサーバに委ねる）。共有リンク表示モードでは非表示。`en_US` の `commons.json` に `copy_to_clipboard."Markdown URL"` を追加（他 4 言語の翻訳は英語ファースト方針により後続）。
+  - Done: 通常ページで項目が表示され `{path}.md` をコピーでき、共有リンクモードでは非表示になることをコンポーネントテストで確認。
+  - _Depends: 1.1_
+  - _Requirements: 7.1, 7.2, 7.3, 7.4_
+  - _Boundary: CopyDropdown_
+
+- [ ] 4. Validation: 結合と回帰
+- [ ] 4.1 エンドツーエンド結合と回帰検証
+  - 3 つの URL 形態、ゲスト／PAT 経路、空（コンテナ）ページのナビ中心 Markdown、populate 回帰（本文＋更新者名が含まれる）、footer の直下子総数と子孫合計 descendantCount の併記＋上限超過時の残数明記、メモリ非全件（子は最大 N 件ロード・総数は正確）、interception 登録順序による通常 HTML 配信への非干渉、を通しで検証する。
+  - Done: 上記シナリオがすべて green。
+  - _Depends: 3.1, 3.2, 3.3_
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 3.4, 3.5, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 5.1, 5.2, 5.3, 6.1, 6.2, 6.3, 7.1, 7.2, 7.3, 7.4_

--- a/.kiro/specs/page-markdown-endpoint/tasks.md
+++ b/.kiro/specs/page-markdown-endpoint/tasks.md
@@ -52,7 +52,7 @@
   - _Requirements: 1.1, 1.2, 1.3, 1.5, 2.1, 2.3, 2.4, 3.1, 3.2, 3.3, 3.4, 3.5_
   - _Boundary: PageMarkdownRoute, routes/index.js_
 
-- [ ] 3.2 (P) 機械向け発見リンク（alternate link ＋ Link ヘッダ）
+- [x] 3.2 (P) 機械向け発見リンク（alternate link ＋ Link ヘッダ）
   - `[[...path]]` の `<Head>` に `<link rel="alternate" type="text/markdown">` を追加。`pageId` があれば permalink 形、無ければ（空ページ等で props に `_id` が無い）`currentPathname` から path 形にフォールバック。`Link` ヘッダは GSSP で、空ページの早期 return より前のスコープの `_id` を使って設定。
   - Done: ページ HTML の `<head>` に Markdown 版 alternate が出力され、空ページでは path 形になり、`Link` ヘッダも（本文 CSR ページ含め）付与される。
   - _Depends: 1.1_

--- a/apps/app/public/static/locales/en_US/commons.json
+++ b/apps/app/public/static/locales/en_US/commons.json
@@ -91,6 +91,7 @@
     "Copy to clipboard": "Copy to clipboard",
     "Page path": "Page path",
     "Page URL": "Page URL",
+    "Markdown URL": "Markdown URL (.md)",
     "Permanent link": "Permanent link",
     "Page path and permanent link": "Page path and permanent link",
     "Markdown link": "Markdown link",

--- a/apps/app/src/client/components/Common/CopyDropdown/CopyDropdown.spec.tsx
+++ b/apps/app/src/client/components/Common/CopyDropdown/CopyDropdown.spec.tsx
@@ -1,0 +1,130 @@
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { CopyDropdown } from './CopyDropdown';
+
+/**
+ * Requirements covered: 7.1, 7.2, 7.3, 7.4 (page-markdown-endpoint spec).
+ *
+ * next-i18next: reduce t() to identity so the assertion targets the i18n key
+ * itself (matches the convention used elsewhere in this app, e.g. GrantSelector.spec.tsx).
+ */
+vi.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+/**
+ * react-copy-to-clipboard wraps its child and copies the `text` prop on click.
+ * We surface `text` as a DOM attribute so tests can assert the exact payload
+ * that would be copied without invoking the real browser clipboard API.
+ */
+vi.mock('react-copy-to-clipboard', () => ({
+  CopyToClipboard: ({
+    text,
+    children,
+  }: {
+    text: string;
+    onCopy?: () => void;
+    children: ReactNode;
+  }) => <div data-copy-text={text}>{children}</div>,
+}));
+
+/**
+ * reactstrap's real Dropdown/DropdownMenu compose react-popper for positioning,
+ * which is irrelevant to this component's contract (which items it renders,
+ * and with what content) and adds open/close-state noise unrelated to
+ * Requirements 7.1-7.4. Reduce to pass-through elements.
+ */
+vi.mock('reactstrap', () => ({
+  Dropdown: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownToggle: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+  DropdownMenu: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownItem: ({
+    children,
+    header,
+    divider,
+  }: {
+    children?: ReactNode;
+    header?: boolean;
+    divider?: boolean;
+  }) => {
+    if (divider) {
+      return null;
+    }
+    return <div>{children}</div>;
+  },
+  Tooltip: () => null,
+}));
+
+const MARKDOWN_URL_LABEL = 'copy_to_clipboard.Markdown URL';
+
+describe('CopyDropdown', () => {
+  describe('Requirement 7.1 - normal page shows the "Markdown URL" item', () => {
+    it('renders the "Markdown URL" item', () => {
+      render(
+        <CopyDropdown dropdownToggleId="test-toggle" pagePath="/foo/bar">
+          toggle
+        </CopyDropdown>,
+      );
+
+      expect(screen.getByText(MARKDOWN_URL_LABEL)).toBeInTheDocument();
+    });
+  });
+
+  describe('Requirement 7.2 - selecting the item copies "{path}.md"', () => {
+    it('copies the page path URL with ".md" appended', () => {
+      render(
+        <CopyDropdown dropdownToggleId="test-toggle" pagePath="/foo/bar">
+          toggle
+        </CopyDropdown>,
+      );
+
+      const label = screen.getByText(MARKDOWN_URL_LABEL);
+      const copyWrapper = label.closest('[data-copy-text]');
+
+      expect(copyWrapper).not.toBeNull();
+      expect(copyWrapper).toHaveAttribute(
+        'data-copy-text',
+        `${window.location.origin}/foo/bar.md`,
+      );
+    });
+  });
+
+  describe('Requirement 7.3 - a path already ending in ".md" gets ".md" appended unconditionally', () => {
+    it('produces "{path}.md.md" rather than deduplicating the suffix', () => {
+      render(
+        <CopyDropdown dropdownToggleId="test-toggle" pagePath="/README.md">
+          toggle
+        </CopyDropdown>,
+      );
+
+      const label = screen.getByText(MARKDOWN_URL_LABEL);
+      const copyWrapper = label.closest('[data-copy-text]');
+
+      expect(copyWrapper).toHaveAttribute(
+        'data-copy-text',
+        `${window.location.origin}/README.md.md`,
+      );
+    });
+  });
+
+  describe('Requirement 7.4 - share-link display mode hides the item', () => {
+    it('does not render the "Markdown URL" item', () => {
+      render(
+        <CopyDropdown
+          dropdownToggleId="test-toggle"
+          pagePath="/foo/bar"
+          isShareLinkMode
+        >
+          toggle
+        </CopyDropdown>,
+      );
+
+      expect(screen.queryByText(MARKDOWN_URL_LABEL)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/app/src/client/components/Common/CopyDropdown/CopyDropdown.tsx
+++ b/apps/app/src/client/components/Common/CopyDropdown/CopyDropdown.tsx
@@ -16,6 +16,8 @@ import {
   Tooltip,
 } from 'reactstrap';
 
+import { toPathMdUrl } from '~/utils/page-markdown-url';
+
 import styles from './CopyDropdown.module.scss';
 
 const { encodeSpaces } = pagePathUtils;
@@ -82,6 +84,14 @@ export const CopyDropdown: React.FC<CopyDropdownProps> = (props) => {
     const { origin } = window.location;
     return `${origin}${encodeSpaces(pagePathWithParams)}`;
   }, [pagePathWithParams]);
+
+  // ".md" is appended unconditionally, even when pagePathUrl already ends
+  // with ".md" (e.g. "/README.md" -> ".../README.md.md"); resolving that
+  // collision against real pages is the server's responsibility
+  // (Requirement 2 / 7.3).
+  const markdownUrl = useMemo(() => {
+    return toPathMdUrl(pagePathUrl);
+  }, [pagePathUrl]);
 
   const permalink = useMemo(() => {
     const { origin } = window.location;
@@ -207,6 +217,21 @@ export const CopyDropdown: React.FC<CopyDropdownProps> = (props) => {
               />
             </DropdownItem>
           </CopyToClipboard>
+          <DropdownItem divider className="my-0"></DropdownItem>
+
+          {/* Markdown URL (.md) */}
+          {!isShareLinkMode && (
+            <CopyToClipboard text={markdownUrl} onCopy={showToolTip}>
+              <DropdownItem className="px-3">
+                <DropdownItemContents
+                  title={t('copy_to_clipboard.Markdown URL')}
+                  contents={markdownUrl}
+                  className="text-truncate d-block"
+                />
+              </DropdownItem>
+            </CopyToClipboard>
+          )}
+
           <DropdownItem divider className="my-0"></DropdownItem>
 
           {/* Permanent Link */}

--- a/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.integ.ts
+++ b/apps/app/src/features/growi-plugin/server/services/growi-plugin/growi-plugin.integ.ts
@@ -5,85 +5,101 @@ import { PLUGIN_STORING_PATH } from '../../consts';
 import { GrowiPlugin } from '../../models';
 import { growiPluginService } from './growi-plugin';
 
+// install() downloads and unzips a real GitHub archive over the network;
+// the default 5000ms test timeout is too tight for that round trip under CI network conditions.
+const NETWORK_INSTALL_TEST_TIMEOUT = 30_000;
+
 describe('Installing a GROWI template plugin', () => {
-  it('install() should success', async () => {
-    // when
-    const result = await growiPluginService.install({
-      url: 'https://github.com/growilabs/growi-plugin-templates-for-office',
-    });
-    const count = await GrowiPlugin.count({
-      'meta.name': 'growi-plugin-templates-for-office',
-    });
+  it(
+    'install() should success',
+    async () => {
+      // when
+      const result = await growiPluginService.install({
+        url: 'https://github.com/growilabs/growi-plugin-templates-for-office',
+      });
+      const count = await GrowiPlugin.count({
+        'meta.name': 'growi-plugin-templates-for-office',
+      });
 
-    // expect
-    expect(result).toEqual('growi-plugin-templates-for-office');
-    expect(count).toBe(1);
-    expect(
-      fs.existsSync(
-        path.join(
-          PLUGIN_STORING_PATH,
-          'growilabs',
-          'growi-plugin-templates-for-office',
+      // expect
+      expect(result).toEqual('growi-plugin-templates-for-office');
+      expect(count).toBe(1);
+      expect(
+        fs.existsSync(
+          path.join(
+            PLUGIN_STORING_PATH,
+            'growilabs',
+            'growi-plugin-templates-for-office',
+          ),
         ),
-      ),
-    ).toBeTruthy();
-  });
+      ).toBeTruthy();
+    },
+    NETWORK_INSTALL_TEST_TIMEOUT,
+  );
 
-  it('install() should success (re-install)', async () => {
-    // confirm
-    const count1 = await GrowiPlugin.count({
-      'meta.name': 'growi-plugin-templates-for-office',
-    });
-    expect(count1).toBe(1);
+  it(
+    'install() should success (re-install)',
+    async () => {
+      // confirm
+      const count1 = await GrowiPlugin.count({
+        'meta.name': 'growi-plugin-templates-for-office',
+      });
+      expect(count1).toBe(1);
 
-    // setup
-    const dummyFilePath = path.join(
-      PLUGIN_STORING_PATH,
-      'growilabs',
-      'growi-plugin-templates-for-office',
-      'dummy.txt',
-    );
-    fs.appendFileSync(dummyFilePath, '');
-    expect(fs.existsSync(dummyFilePath)).toBeTruthy();
+      // setup
+      const dummyFilePath = path.join(
+        PLUGIN_STORING_PATH,
+        'growilabs',
+        'growi-plugin-templates-for-office',
+        'dummy.txt',
+      );
+      fs.appendFileSync(dummyFilePath, '');
+      expect(fs.existsSync(dummyFilePath)).toBeTruthy();
 
-    // when
-    const result = await growiPluginService.install({
-      url: 'https://github.com/growilabs/growi-plugin-templates-for-office',
-    });
-    const count2 = await GrowiPlugin.count({
-      'meta.name': 'growi-plugin-templates-for-office',
-    });
+      // when
+      const result = await growiPluginService.install({
+        url: 'https://github.com/growilabs/growi-plugin-templates-for-office',
+      });
+      const count2 = await GrowiPlugin.count({
+        'meta.name': 'growi-plugin-templates-for-office',
+      });
 
-    // expect
-    expect(result).toEqual('growi-plugin-templates-for-office');
-    expect(count2).toBe(1);
-    expect(fs.existsSync(dummyFilePath)).toBeFalsy(); // the dummy file should be removed
-  });
+      // expect
+      expect(result).toEqual('growi-plugin-templates-for-office');
+      expect(count2).toBe(1);
+      expect(fs.existsSync(dummyFilePath)).toBeFalsy(); // the dummy file should be removed
+    },
+    NETWORK_INSTALL_TEST_TIMEOUT,
+  );
 });
 
 describe('Installing a GROWI theme plugin', () => {
-  it('install() should success', async () => {
-    // when
-    const result = await growiPluginService.install({
-      url: 'https://github.com/growilabs/growi-plugin-theme-vivid-internet',
-    });
-    const count = await GrowiPlugin.count({
-      'meta.name': 'growi-plugin-theme-vivid-internet',
-    });
+  it(
+    'install() should success',
+    async () => {
+      // when
+      const result = await growiPluginService.install({
+        url: 'https://github.com/growilabs/growi-plugin-theme-vivid-internet',
+      });
+      const count = await GrowiPlugin.count({
+        'meta.name': 'growi-plugin-theme-vivid-internet',
+      });
 
-    // expect
-    expect(result).toEqual('growi-plugin-theme-vivid-internet');
-    expect(count).toBe(1);
-    expect(
-      fs.existsSync(
-        path.join(
-          PLUGIN_STORING_PATH,
-          'growilabs',
-          'growi-plugin-theme-vivid-internet',
+      // expect
+      expect(result).toEqual('growi-plugin-theme-vivid-internet');
+      expect(count).toBe(1);
+      expect(
+        fs.existsSync(
+          path.join(
+            PLUGIN_STORING_PATH,
+            'growilabs',
+            'growi-plugin-theme-vivid-internet',
+          ),
         ),
-      ),
-    ).toBeTruthy();
-  });
+      ).toBeTruthy();
+    },
+    NETWORK_INSTALL_TEST_TIMEOUT,
+  );
 
   it('findThemePlugin() should return data with metadata and manifest', async () => {
     // confirm

--- a/apps/app/src/pages/[[...path]]/index.page.tsx
+++ b/apps/app/src/pages/[[...path]]/index.page.tsx
@@ -29,6 +29,7 @@ import {
 } from '~/states/socket-io';
 import { useSetEditingMarkdown } from '~/states/ui/editor';
 import { useSWRxPageInfo } from '~/stores/page';
+import { selectAlternateMdUrl } from '~/utils/page-markdown-alternate';
 
 import type { NextPageWithLayout } from '../_app.page';
 import { useHydrateBasicLayoutConfigurationAtoms } from '../basic-layout-page/hydrate';
@@ -155,10 +156,19 @@ const Page: NextPageWithLayout<Props> = (props: Props) => {
 
   const title = useCustomTitleForPage(pagePath);
 
+  // Machine-facing discovery of the Markdown alternate (Requirement 6.1/6.3):
+  // rendered unconditionally in the server-rendered <head> so it is present
+  // even when the body is fetched client-side (skipSSR). Prefers the permalink
+  // form; empty (container) pages without an entity _id fall back to path form.
+  const mdAlternateUrl = selectAlternateMdUrl(currentPage?._id, pagePath);
+
   return (
     <>
       <Head>
         <title>{title}</title>
+        {mdAlternateUrl != null && (
+          <link rel="alternate" type="text/markdown" href={mdAlternateUrl} />
+        )}
       </Head>
       <div className="dynamic-layout-root justify-content-between">
         <GrowiContextualSubNavigation currentPage={currentPage} />

--- a/apps/app/src/pages/[[...path]]/page-data-props.ts
+++ b/apps/app/src/pages/[[...path]]/page-data-props.ts
@@ -24,6 +24,8 @@ import type {
   PageRedirectModel,
 } from '~/server/models/page-redirect';
 import { findPageAndMetaDataByViewer } from '~/server/service/page/find-page-and-meta-data-by-viewer';
+import { toMarkdownAlternateLinkHeader } from '~/utils/page-markdown-alternate';
+import { toPermalinkMdUrl } from '~/utils/page-markdown-url';
 
 import type { CommonEachProps } from '../common-props';
 import type {
@@ -202,6 +204,27 @@ export async function getPageDataForInitial(
 
     // type assertion
     assert(isIPageInfo(meta), 'meta should be IPageInfo when data is not null');
+
+    // Requirement 6.2/6.3: advertise the Markdown alternate via the `Link`
+    // response header. Set it here, before the empty-page early return below,
+    // using the still-in-scope entity `_id`, so empty (container) pages,
+    // CSR-fallback pages (skipSSR), and normal pages all carry the pageId-form
+    // Link header. Append rather than overwrite to preserve any existing header.
+    const mdLinkHeader = toMarkdownAlternateLinkHeader(
+      toPermalinkMdUrl(page._id.toString()),
+    );
+    const existingLink = context.res.getHeader('Link');
+    context.res.setHeader(
+      'Link',
+      existingLink == null
+        ? mdLinkHeader
+        : [
+            ...(Array.isArray(existingLink)
+              ? existingLink
+              : [String(existingLink)]),
+            mdLinkHeader,
+          ],
+    );
 
     // Handle empty pages - return as not found to avoid serialization issues
     if (page.isEmpty) {

--- a/apps/app/src/server/routes/index.js
+++ b/apps/app/src/server/routes/index.js
@@ -37,6 +37,7 @@ import { setup as setupLoginPassport } from './login-passport';
 import nextFactory from './next';
 import { setup as setupOgp } from './ogp';
 import { setup as setupPage } from './page';
+import { pageMarkdownRouteFactory } from './page-markdown';
 import { setup as setupSearch } from './search';
 import { setup as setupTag } from './tag';
 import * as userActivation from './user-activation';
@@ -398,6 +399,11 @@ export const setup = (crowi, app) => {
         ogp.renderOgp,
       ),
   );
+
+  // Page Markdown endpoint (.md suffix / Accept: text/markdown / ?format=md).
+  // Must be registered immediately before the catch-all so it can intercept
+  // markdown requests; non-markdown requests fall through to the HTML delegate.
+  app.use(pageMarkdownRouteFactory(crowi));
 
   app.get('/*/$', loginRequired, next.delegateToNext);
   app.get('/*', loginRequired, autoReconnectToSearch, next.delegateToNext);

--- a/apps/app/src/server/routes/page-markdown/build-page-markdown.spec.ts
+++ b/apps/app/src/server/routes/page-markdown/build-page-markdown.spec.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildErrorMarkdown,
+  buildPageMarkdown,
+  type FooterLink,
+  type PageMarkdownInput,
+} from './build-page-markdown';
+import { MARKDOWN_FOOTER_MAX_LINKS } from './constants';
+
+const PARENT_LINK: FooterLink = {
+  title: 'foo',
+  mdUrl: '/507f1f77bcf86cd799439001.md',
+};
+
+const SIBLING_LINK: FooterLink = {
+  title: 'sibling-a',
+  mdUrl: '/507f1f77bcf86cd799439004.md',
+};
+
+const CHILD_LINKS: FooterLink[] = [
+  { title: 'child-a', mdUrl: '/507f1f77bcf86cd799439002.md' },
+  { title: 'child-b', mdUrl: '/507f1f77bcf86cd799439003.md' },
+];
+
+const baseInput: PageMarkdownInput = {
+  path: '/foo/bar',
+  origin: 'https://example.com',
+  permalinkUrl: 'https://example.com/507f1f77bcf86cd799439011',
+  canonicalUrl: 'https://example.com/foo/bar',
+  body: 'Hello **world**',
+  isEmpty: false,
+  parent: PARENT_LINK,
+  children: CHILD_LINKS,
+  childrenTotal: 2,
+  descendantCount: 5,
+  siblings: [SIBLING_LINK],
+  siblingsTotal: 1,
+  pageListApiHint: 'GET /_api/v3/pages/list?path=/foo/bar',
+  updatedAt: '2026-07-01T00:00:00.000Z',
+  updatedByUsername: 'alice',
+};
+
+describe('buildPageMarkdown', () => {
+  it('renders the body verbatim, followed by the footer (4.1)', () => {
+    const result = buildPageMarkdown(baseInput);
+
+    expect(result.startsWith(baseInput.body)).toBe(true);
+    const bodyIndex = result.indexOf(baseInput.body);
+    const footerIndex = result.indexOf('Page Navigation');
+    expect(footerIndex).toBeGreaterThan(bodyIndex);
+  });
+
+  it('never transforms the body content itself, even when it contains its own Markdown', () => {
+    const bodyWithMarkdown =
+      '# Title\n\n- item1\n- item2\n\n```js\nconst x = 1;\n```';
+    const result = buildPageMarkdown({ ...baseInput, body: bodyWithMarkdown });
+
+    expect(result).toContain(bodyWithMarkdown);
+  });
+
+  it('includes both the canonical URL and the permalink URL (4.1)', () => {
+    const result = buildPageMarkdown(baseInput);
+
+    expect(result).toContain(baseInput.canonicalUrl);
+    expect(result).toContain(baseInput.permalinkUrl);
+  });
+
+  it('renders the parent link when a parent is present (4.2)', () => {
+    const result = buildPageMarkdown(baseInput);
+
+    expect(result).toContain(`[${PARENT_LINK.title}](${PARENT_LINK.mdUrl})`);
+  });
+
+  it('omits the parent line, and the entire siblings section, when parent is null (root, 4.8)', () => {
+    const rootInput: PageMarkdownInput = { ...baseInput, parent: null };
+    const result = buildPageMarkdown(rootInput);
+
+    expect(result).not.toContain('Parent:');
+    expect(result).not.toContain('Siblings');
+    expect(result).not.toContain(SIBLING_LINK.mdUrl);
+  });
+
+  it('still renders children at the root (root only omits parent/siblings, not children)', () => {
+    const rootInput: PageMarkdownInput = { ...baseInput, parent: null };
+    const result = buildPageMarkdown(rootInput);
+
+    for (const child of CHILD_LINKS) {
+      expect(result).toContain(`[${child.title}](${child.mdUrl})`);
+    }
+  });
+
+  it('renders child links and states the exact childrenTotal (4.3)', () => {
+    const result = buildPageMarkdown(baseInput);
+
+    for (const child of CHILD_LINKS) {
+      expect(result).toContain(`[${child.title}](${child.mdUrl})`);
+    }
+    expect(result).toContain(`${baseInput.childrenTotal} total`);
+  });
+
+  it('states descendantCount as a number separate and distinguishable from childrenTotal (4.3)', () => {
+    const result = buildPageMarkdown(baseInput);
+
+    expect(result).toContain(`Total descendants: ${baseInput.descendantCount}`);
+    expect(result).toContain(`${baseInput.childrenTotal} total`);
+    // The two figures must both be present and must not collapse into one number.
+    expect(baseInput.childrenTotal).not.toBe(baseInput.descendantCount);
+  });
+
+  it('renders sibling links when present (4.4)', () => {
+    const result = buildPageMarkdown(baseInput);
+
+    expect(result).toContain(`[${SIBLING_LINK.title}](${SIBLING_LINK.mdUrl})`);
+  });
+
+  it('always includes the last-updated datetime and updater username (4.5)', () => {
+    const result = buildPageMarkdown(baseInput);
+
+    expect(result).toContain(baseInput.updatedAt);
+    expect(result).toContain(baseInput.updatedByUsername);
+  });
+
+  it('always includes the page-list API hint, even when there are zero children (4.6)', () => {
+    const noChildrenInput: PageMarkdownInput = {
+      ...baseInput,
+      children: [],
+      childrenTotal: 0,
+      descendantCount: 0,
+    };
+    const result = buildPageMarkdown(noChildrenInput);
+
+    expect(result).toContain(baseInput.pageListApiHint);
+  });
+
+  it('always includes the page-list API hint alongside a full (non-truncated) children list', () => {
+    const result = buildPageMarkdown(baseInput);
+
+    expect(result).toContain(baseInput.pageListApiHint);
+  });
+
+  it('states the total and the omitted remainder when children exceed the footer limit, instead of silently truncating (4.7)', () => {
+    const shown: FooterLink[] = Array.from(
+      { length: MARKDOWN_FOOTER_MAX_LINKS },
+      (_, i) => ({ title: `child-${i}`, mdUrl: `/child-${i}.md` }),
+    );
+    const total = MARKDOWN_FOOTER_MAX_LINKS + 7;
+    const result = buildPageMarkdown({
+      ...baseInput,
+      children: shown,
+      childrenTotal: total,
+    });
+
+    expect(result).toContain(`${total}`);
+    expect(result).toContain('7 more');
+  });
+
+  it('states the total and the omitted remainder when siblings exceed the footer limit, instead of silently truncating (4.7)', () => {
+    const shown: FooterLink[] = Array.from(
+      { length: MARKDOWN_FOOTER_MAX_LINKS },
+      (_, i) => ({ title: `sibling-${i}`, mdUrl: `/sibling-${i}.md` }),
+    );
+    const total = MARKDOWN_FOOTER_MAX_LINKS + 3;
+    const result = buildPageMarkdown({
+      ...baseInput,
+      siblings: shown,
+      siblingsTotal: total,
+    });
+
+    expect(result).toContain(`${total}`);
+    expect(result).toContain('3 more');
+  });
+
+  it('does not state a remainder when the shown count exactly matches the total (no false truncation notice)', () => {
+    const result = buildPageMarkdown(baseInput);
+
+    expect(result).not.toContain('more not shown');
+  });
+
+  it('shows the page path and a one-sentence "no content" notice instead of the body, plus the full footer, for an empty container page (5.1, 5.3)', () => {
+    const emptyInput: PageMarkdownInput = {
+      ...baseInput,
+      isEmpty: true,
+      body: '',
+    };
+    const result = buildPageMarkdown(emptyInput);
+
+    expect(result).toContain(baseInput.path);
+    expect(result.toLowerCase()).toMatch(/no content/);
+    // footer elements must still be present
+    expect(result).toContain(baseInput.canonicalUrl);
+    expect(result).toContain(baseInput.permalinkUrl);
+    expect(result).toContain(`[${PARENT_LINK.title}](${PARENT_LINK.mdUrl})`);
+    expect(result).toContain(baseInput.pageListApiHint);
+  });
+
+  it('renders an empty body verbatim (no "no content" notice) plus the footer, for a non-empty page whose revision body is the empty string (5.2)', () => {
+    const emptyBodyInput: PageMarkdownInput = {
+      ...baseInput,
+      isEmpty: false,
+      body: '',
+    };
+    const result = buildPageMarkdown(emptyBodyInput);
+
+    expect(result.toLowerCase()).not.toMatch(/no content/);
+    expect(result).toContain(baseInput.canonicalUrl);
+    expect(result).toContain(baseInput.permalinkUrl);
+  });
+});
+
+describe('buildErrorMarkdown', () => {
+  it('returns Markdown guidance suggesting authenticated access or the GROWI MCP for a forbidden (403) response, without leaking page content (3.5)', () => {
+    const result = buildErrorMarkdown('forbidden');
+
+    expect(result).toMatch(/authenticat/i);
+    expect(result).toMatch(/MCP/);
+    expect(result).not.toContain(baseInput.body);
+    expect(result).not.toContain(baseInput.path);
+  });
+
+  it('returns Markdown guidance suggesting authenticated access or the GROWI MCP for a not-found (404) response, without leaking page content (3.5)', () => {
+    const result = buildErrorMarkdown('notFound');
+
+    expect(result).toMatch(/authenticat/i);
+    expect(result).toMatch(/MCP/);
+    expect(result).not.toContain(baseInput.body);
+    expect(result).not.toContain(baseInput.path);
+  });
+
+  it('produces distinguishable bodies for forbidden vs notFound, without asserting existence in the notFound case (3.5)', () => {
+    const forbidden = buildErrorMarkdown('forbidden');
+    const notFound = buildErrorMarkdown('notFound');
+
+    expect(forbidden).not.toBe(notFound);
+    expect(forbidden.toLowerCase()).toContain('permission');
+    expect(notFound.toLowerCase()).toMatch(/not exist|not found/);
+  });
+});
+
+describe('MARKDOWN_FOOTER_MAX_LINKS', () => {
+  it('is exported with the documented Phase 1 default of 50', () => {
+    expect(MARKDOWN_FOOTER_MAX_LINKS).toBe(50);
+  });
+});

--- a/apps/app/src/server/routes/page-markdown/build-page-markdown.ts
+++ b/apps/app/src/server/routes/page-markdown/build-page-markdown.ts
@@ -1,0 +1,174 @@
+/**
+ * A single navigation link rendered in the Markdown footer (parent, a
+ * child, or a sibling): a human-readable title paired with the page's
+ * ".md" URL (see ~/utils/page-markdown-url).
+ */
+export interface FooterLink {
+  title: string;
+  mdUrl: string;
+}
+
+/**
+ * Input to buildPageMarkdown. All fields are pre-resolved by the caller
+ * (respondWithPageMarkdown) -- this module performs no I/O and knows
+ * nothing about Page/Revision models, viewers, or Express.
+ */
+export interface PageMarkdownInput {
+  /** The page's path, e.g. "/foo/bar". Used for the empty-page notice. */
+  path: string;
+  /** Origin (protocol + host), reserved for callers; not rendered directly. */
+  origin: string;
+  /** host + "/{pageId}" -- the permalink form (Requirement 4.1). */
+  permalinkUrl: string;
+  /** host + path -- the "can also be opened via host+path" hint (Requirement 4.1). */
+  canonicalUrl: string;
+  /** revision.body, verbatim. Empty string for empty pages. */
+  body: string;
+  /** True when the page has no body content (container page, Requirement 5.1). */
+  isEmpty: boolean;
+  /** The parent page's footer link, or null at the hierarchy root (Requirement 4.8). */
+  parent: FooterLink | null;
+  /** Child links, already limited by the caller to at most MARKDOWN_FOOTER_MAX_LINKS. */
+  children: FooterLink[];
+  /** The exact total number of direct children (may exceed children.length). */
+  childrenTotal: number;
+  /** The total descendant count -- distinct from childrenTotal (Requirement 4.3). */
+  descendantCount: number;
+  /** Sibling links (self excluded), already limited by the caller. */
+  siblings: FooterLink[];
+  /** The exact total number of siblings (may exceed siblings.length). */
+  siblingsTotal: number;
+  /** Guidance pointing to the existing page-list API for the full listing (Requirement 4.6). */
+  pageListApiHint: string;
+  /** Last revision update datetime, ISO-8601 or otherwise pre-formatted by the caller. */
+  updatedAt: string;
+  /** Last updater's username, already passed through serializeUserSecurely by the caller. */
+  updatedByUsername: string;
+}
+
+const EMPTY_PAGE_NOTICE = 'This page has no content yet.';
+
+const ERROR_GUIDANCE = [
+  'If you believe this page exists and you have access to it, retry with an',
+  'authenticated request (a logged-in session or a Personal Access Token),',
+  'or use the GROWI MCP server, which can fetch this page on your behalf',
+  'using your own credentials.',
+].join('\n');
+
+function renderLinkListItem(link: FooterLink): string {
+  return `  - [${link.title}](${link.mdUrl})`;
+}
+
+/**
+ * Render a count summary line ("N total" or, when the shown list is
+ * shorter than the true total, "shown of total (remainder more not
+ * shown; ...)") so overflow is always stated explicitly rather than
+ * silently truncated (Requirement 4.7).
+ */
+function renderCountSummary(
+  label: string,
+  shown: number,
+  total: number,
+): string {
+  if (shown >= total) {
+    return `- ${label}: ${total} total`;
+  }
+  const remaining = total - shown;
+  return `- ${label}: ${shown} of ${total} total (${remaining} more not shown; see the page list API below for the full listing)`;
+}
+
+function renderChildrenSection(input: PageMarkdownInput): string[] {
+  const lines: string[] = [
+    renderCountSummary('Children', input.children.length, input.childrenTotal),
+  ];
+  if (input.children.length > 0) {
+    lines.push(...input.children.map(renderLinkListItem));
+  }
+  lines.push(`- Total descendants: ${input.descendantCount}`);
+  return lines;
+}
+
+function renderSiblingsSection(input: PageMarkdownInput): string[] {
+  const lines: string[] = [
+    renderCountSummary('Siblings', input.siblings.length, input.siblingsTotal),
+  ];
+  if (input.siblings.length > 0) {
+    lines.push(...input.siblings.map(renderLinkListItem));
+  }
+  return lines;
+}
+
+function buildFooter(input: PageMarkdownInput): string {
+  const lines: string[] = ['## Page Navigation', ''];
+
+  lines.push(`- Canonical URL: ${input.canonicalUrl}`);
+  lines.push(`- Permalink: ${input.permalinkUrl}`);
+
+  if (input.parent != null) {
+    lines.push(`- Parent: [${input.parent.title}](${input.parent.mdUrl})`);
+  }
+
+  lines.push(...renderChildrenSection(input));
+
+  // Root pages have no parent and, by design, omit the siblings section too
+  // (siblings are derived from the parent; a root has none to derive from).
+  if (input.parent != null) {
+    lines.push(...renderSiblingsSection(input));
+  }
+
+  lines.push(
+    `- Last updated: ${input.updatedAt} by ${input.updatedByUsername}`,
+  );
+  lines.push(
+    `- Full page listing (all children regardless of count): ${input.pageListApiHint}`,
+  );
+
+  return lines.join('\n');
+}
+
+/**
+ * Build the full Markdown document for a page response: the body verbatim
+ * (never transformed), followed by a navigation footer with the canonical
+ * URL, permalink, parent/children/siblings links, update info, and a
+ * page-list API pointer (Requirements 3.5, 4.1-4.8, 5.1-5.3).
+ */
+export function buildPageMarkdown(input: PageMarkdownInput): string {
+  const bodySection = input.isEmpty
+    ? `# ${input.path}\n\n${EMPTY_PAGE_NOTICE}`
+    : input.body;
+
+  const footer = buildFooter(input);
+
+  return `${bodySection}\n\n---\n\n${footer}\n`;
+}
+
+/**
+ * Build the short Markdown guidance body returned for 403/404 responses.
+ * Never includes any page content (title, path, or body) -- only generic
+ * guidance toward authenticated access or the GROWI MCP (Requirement 3.5).
+ *
+ * The two kinds are deliberately worded differently:
+ * - 'forbidden': the page exists but the viewer lacks permission.
+ * - 'notFound': the page may not exist, or may exist without permission --
+ *   this must NOT assert existence, to avoid leaking that a private page
+ *   is present at this path (see design.md "Error Categories").
+ */
+export function buildErrorMarkdown(kind: 'forbidden' | 'notFound'): string {
+  if (kind === 'forbidden') {
+    return [
+      '# 403 Forbidden',
+      '',
+      'You do not have permission to view this page.',
+      '',
+      ERROR_GUIDANCE,
+    ].join('\n');
+  }
+
+  return [
+    '# 404 Not Found',
+    '',
+    'This page does not exist, or it exists and you do not have permission to view it.',
+    '',
+    ERROR_GUIDANCE,
+  ].join('\n');
+}

--- a/apps/app/src/server/routes/page-markdown/build-page-markdown.ts
+++ b/apps/app/src/server/routes/page-markdown/build-page-markdown.ts
@@ -48,12 +48,12 @@ export interface PageMarkdownInput {
 
 const EMPTY_PAGE_NOTICE = 'This page has no content yet.';
 
-const ERROR_GUIDANCE = [
-  'If you believe this page exists and you have access to it, retry with an',
-  'authenticated request (a logged-in session or a Personal Access Token),',
-  'or use the GROWI MCP server, which can fetch this page on your behalf',
-  'using your own credentials.',
-].join('\n');
+// Template literal (not .join) so the initializer stays on the
+// route-top-level-guard allowlist (no top-level call expressions).
+const ERROR_GUIDANCE = `If you believe this page exists and you have access to it, retry with an
+authenticated request (a logged-in session or a Personal Access Token),
+or use the GROWI MCP server, which can fetch this page on your behalf
+using your own credentials.`;
 
 function renderLinkListItem(link: FooterLink): string {
   return `  - [${link.title}](${link.mdUrl})`;

--- a/apps/app/src/server/routes/page-markdown/constants.ts
+++ b/apps/app/src/server/routes/page-markdown/constants.ts
@@ -1,0 +1,11 @@
+/**
+ * Maximum number of child/sibling links enumerated in the navigation footer
+ * of a Markdown page response.
+ *
+ * This is the documented Phase 1 default (see design.md "Open Questions").
+ * The caller (respondWithPageMarkdown) is responsible for loading at most
+ * this many links and passing the accurate totals separately -- this module
+ * only declares the shared limit value; enforcement happens where the
+ * links are loaded, not in the pure Markdown builder.
+ */
+export const MARKDOWN_FOOTER_MAX_LINKS = 50;

--- a/apps/app/src/server/routes/page-markdown/index.ts
+++ b/apps/app/src/server/routes/page-markdown/index.ts
@@ -1,0 +1,125 @@
+import { SCOPE } from '@growi/core/dist/interfaces';
+import type { NextFunction, Response, Router } from 'express';
+import express from 'express';
+
+import type { CrowiRequest } from '~/interfaces/crowi-request';
+import { accessTokenParser } from '~/server/middlewares/access-token-parser';
+import loginRequiredFactory from '~/server/middlewares/login-required';
+import { configManager } from '~/server/service/config-manager';
+import loggerFactory from '~/utils/logger';
+
+import type Crowi from '../../crowi';
+import { parseMarkdownRequest } from './parse-markdown-request';
+import { respondWithPageMarkdown } from './respond-with-page-markdown';
+
+const logger = loggerFactory('growi:routes:page-markdown');
+
+const MARKDOWN_CONTENT_TYPE = 'text/markdown; charset=utf-8';
+
+/**
+ * Normalize the raw `format` query value. Express types it loosely
+ * (string | string[] | ParsedQs | ...); the parser only cares about a plain
+ * string, so take the first entry of a repeated param and drop anything else.
+ */
+function normalizeFormatQuery(format: unknown): string | undefined {
+  if (typeof format === 'string') {
+    return format;
+  }
+  if (Array.isArray(format)) {
+    const first = format[0];
+    return typeof first === 'string' ? first : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the origin (protocol + host) used to build the absolute URLs in the
+ * navigation footer. Prefer the configured canonical Site URL; fall back to
+ * the request's own scheme + host when it is not set or not a valid URL.
+ */
+function resolveOrigin(req: CrowiRequest): string {
+  const siteUrl = configManager.getConfig('app:siteUrl');
+  if (siteUrl != null) {
+    try {
+      return new URL(siteUrl).origin;
+    } catch {
+      // Configured value is not a valid URL -> fall back to the request origin.
+    }
+  }
+  return `${req.protocol}://${req.get('host') ?? ''}`;
+}
+
+/**
+ * Express route that intercepts Markdown requests for a page and serves the
+ * page's Markdown representation, falling through to the existing HTML flow
+ * for everything else.
+ *
+ * Registered immediately before the catch-all in routes/index.js. It handles
+ * GET only (mounted via router.get). The cheap, pure `parseMarkdownRequest`
+ * runs for every GET; only when it detects a Markdown request are the
+ * authorization middlewares invoked -- non-Markdown traffic skips authz
+ * entirely via `next('route')`, which exits this router and lets the request
+ * reach the catch-all with zero added auth overhead.
+ */
+export const pageMarkdownRouteFactory = (crowi: Crowi): Router => {
+  const parseAccessToken = accessTokenParser([SCOPE.READ.FEATURES.PAGE], {
+    acceptLegacy: true,
+  });
+  // Guest-allowed variant: mirrors the catch-all's own `loginRequired`, so the
+  // anonymous-access decision (Requirement 3.3 / 3.4) matches HTML delivery.
+  const loginRequired = loginRequiredFactory(crowi, true);
+
+  const router = express.Router();
+
+  router.get(
+    '/*',
+    // Gate: classify the request. Non-Markdown GETs skip the remaining
+    // handlers (authz + responder) via next('route') and fall through to the
+    // catch-all -- authorization is composed only for Markdown requests.
+    (req: CrowiRequest, _res: Response, next: NextFunction) => {
+      const intent = parseMarkdownRequest(
+        req.path,
+        req.headers.accept,
+        normalizeFormatQuery(req.query.format),
+      );
+      if (intent.kind === 'none') {
+        return next('route');
+      }
+      return next();
+    },
+    parseAccessToken,
+    loginRequired,
+    async (req: CrowiRequest, res: Response, next: NextFunction) => {
+      try {
+        const resolution = await respondWithPageMarkdown(crowi, {
+          reqPath: req.path,
+          accept: req.headers.accept,
+          formatQuery: normalizeFormatQuery(req.query.format),
+          user: req.user,
+          origin: resolveOrigin(req),
+        });
+
+        switch (resolution.type) {
+          case 'passthrough':
+            // A literal `.md` page exists (Requirement 2.1): defer to the
+            // existing HTML delivery by falling through to the catch-all.
+            return next();
+          case 'ok':
+            res.type(MARKDOWN_CONTENT_TYPE);
+            return res.status(200).send(resolution.markdown);
+          case 'forbidden':
+            res.type(MARKDOWN_CONTENT_TYPE);
+            return res.status(403).send(resolution.markdown);
+          case 'notFound':
+            res.type(MARKDOWN_CONTENT_TYPE);
+            return res.status(404).send(resolution.markdown);
+        }
+      } catch (err) {
+        logger.error('Failed to respond with page markdown', err);
+        return next(err);
+      }
+    },
+  );
+
+  return router;
+};

--- a/apps/app/src/server/routes/page-markdown/page-markdown.integ.ts
+++ b/apps/app/src/server/routes/page-markdown/page-markdown.integ.ts
@@ -1,4 +1,5 @@
 import type { IUser } from '@growi/core';
+import { SCOPE } from '@growi/core/dist/interfaces';
 import express from 'express';
 import mongoose, { type HydratedDocument, type Model } from 'mongoose';
 import request from 'supertest';
@@ -7,9 +8,11 @@ import { getInstance } from '^/test/setup/crowi';
 
 import type { CrowiRequest } from '~/interfaces/crowi-request';
 import type Crowi from '~/server/crowi';
+import { AccessToken } from '~/server/models/access-token';
 import type { PageDocument, PageModel } from '~/server/models/page';
 
 import { pageMarkdownRouteFactory } from '.';
+import { MARKDOWN_FOOTER_MAX_LINKS } from './constants';
 
 // Route-level integration test for the page-markdown interception route.
 //
@@ -54,12 +57,40 @@ describe('pageMarkdownRouteFactory (route integration)', () => {
 
   let docId: string; // public page at `${BASE}/doc`
   let secretId: string; // GRANT_OWNER page owned by otherUser (forbidden to testUser)
+  let bigId: string; // public root-like page with more than the footer link cap of children
+
+  // Real Personal Access Tokens for testUser: one with the page-read scope the
+  // route requires, one deliberately scoped elsewhere (used to prove the scope
+  // gate actually rejects). These flow through the genuine accessTokenParser
+  // mounted by the factory — nothing in the token path is mocked.
+  let patToken: string;
+  let patWrongScopeToken: string;
 
   const bodyDoc = 'DOC-BODY-CONTENT-VERBATIM';
   const bodySecret = 'SECRET-BODY-DO-NOT-LEAK';
   const bodyLiteral = 'LITERAL-MD-PAGE-BODY';
+  const bodyBig = 'BIG-PARENT-BODY';
 
-  const seededPaths = [`${BASE}/doc`, `${BASE}/secret`, `${BASE}/literal.md`];
+  // Over-limit fixture: seed MORE direct children than the footer cap so the
+  // response must truncate the link list, state the exact total and remainder
+  // (Requirement 4.7), and load at most the cap into memory (Requirement 4.3).
+  const OVER_LIMIT_CHILD_COUNT = MARKDOWN_FOOTER_MAX_LINKS + 5;
+  // Distinct from the direct-child count so the footer's separate descendant
+  // total can be proven to not be conflated with it (Requirement 4.3).
+  const BIG_DESCENDANT_COUNT = MARKDOWN_FOOTER_MAX_LINKS + 10;
+  const bigParentPath = `${BASE}/big`;
+  const bigChildPaths = Array.from(
+    { length: OVER_LIMIT_CHILD_COUNT },
+    (_, i) => `${bigParentPath}/c${String(i).padStart(2, '0')}`,
+  );
+
+  const seededPaths = [
+    `${BASE}/doc`,
+    `${BASE}/secret`,
+    `${BASE}/literal.md`,
+    bigParentPath,
+    ...bigChildPaths,
+  ];
 
   beforeAll(async () => {
     crowi = await getInstance();
@@ -110,6 +141,26 @@ describe('pageMarkdownRouteFactory (route integration)', () => {
       lastUpdateUser: testUser._id,
       descendantCount: 0,
     });
+    // Root-like public hub with more direct children than the footer link cap.
+    // Its descendantCount is deliberately larger still, so the footer's
+    // direct-child total and descendant total are visibly different numbers.
+    const big = await Page.create({
+      path: bigParentPath,
+      grant: Page.GRANT_PUBLIC,
+      creator: testUser._id,
+      lastUpdateUser: testUser._id,
+      descendantCount: BIG_DESCENDANT_COUNT,
+    });
+    await Page.insertMany(
+      bigChildPaths.map((path) => ({
+        path,
+        parent: big._id,
+        grant: Page.GRANT_PUBLIC,
+        creator: testUser._id,
+        lastUpdateUser: testUser._id,
+        descendantCount: 0,
+      })),
+    );
 
     const revisions = await Revision.insertMany([
       {
@@ -130,16 +181,40 @@ describe('pageMarkdownRouteFactory (route integration)', () => {
         format: 'markdown',
         author: testUser._id,
       },
+      {
+        pageId: big._id,
+        body: bodyBig,
+        format: 'markdown',
+        author: testUser._id,
+      },
     ]);
     doc.revision = revisions[0]._id;
     secret.revision = revisions[1]._id;
     literal.revision = revisions[2]._id;
+    big.revision = revisions[3]._id;
     await doc.save();
     await secret.save();
     await literal.save();
+    await big.save();
 
     docId = String(doc._id);
     secretId = String(secret._id);
+    bigId = String(big._id);
+
+    // Seed real access tokens. generateToken + the route's accessTokenParser
+    // both normalize scopes identically, so the required-scope token satisfies
+    // the route's [READ.FEATURES.PAGE] check while the other one does not.
+    const oneDayLater = new Date(Date.now() + 1000 * 60 * 60 * 24);
+    patToken = (
+      await AccessToken.generateToken(testUser._id, oneDayLater, [
+        SCOPE.READ.FEATURES.PAGE,
+      ])
+    ).token;
+    patWrongScopeToken = (
+      await AccessToken.generateToken(testUser._id, oneDayLater, [
+        SCOPE.READ.USER_SETTINGS.INFO,
+      ])
+    ).token;
 
     // Build the app once: express.json ensures req.body is defined (production
     // mounts body parsers upstream of the catch-all); the injector emulates
@@ -161,6 +236,11 @@ describe('pageMarkdownRouteFactory (route integration)', () => {
   afterAll(async () => {
     try {
       await Page.deleteMany({ path: { $in: seededPaths } });
+    } catch {
+      // ignore
+    }
+    try {
+      await AccessToken.deleteAllTokensByUserId(testUser?._id);
     } catch {
       // ignore
     }
@@ -305,6 +385,72 @@ describe('pageMarkdownRouteFactory (route integration)', () => {
 
       const res = await request(app).get(`/${docId}.md`).redirects(0);
 
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toBe('/login');
+    });
+  });
+
+  describe('over-limit footer (Requirement 4.3, 4.7)', () => {
+    it('caps child links at MARKDOWN_FOOTER_MAX_LINKS while stating the exact total, the omitted remainder, and a separate descendant total', async () => {
+      currentUser = testUser;
+
+      const res = await request(app).get(`/${bigId}.md`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('text/markdown');
+
+      // Overflow is stated explicitly, never silently truncated: the exact
+      // direct-child total and the omitted remainder both appear (4.7).
+      expect(res.text).toContain(
+        `Children: ${MARKDOWN_FOOTER_MAX_LINKS} of ${OVER_LIMIT_CHILD_COUNT} total`,
+      );
+      const remainder = OVER_LIMIT_CHILD_COUNT - MARKDOWN_FOOTER_MAX_LINKS;
+      expect(res.text).toContain(`${remainder} more not shown`);
+
+      // descendantCount is reported separately from the direct-child count and
+      // the two seeded values differ, proving they are not conflated (4.3).
+      expect(res.text).toContain(`Total descendants: ${BIG_DESCENDANT_COUNT}`);
+
+      // Memory-bounded rendering: at most MARKDOWN_FOOTER_MAX_LINKS child links
+      // are emitted even though more children exist. For this root-like page
+      // there are no parent/sibling sections, so the indented list items are
+      // exactly the child links — counting them is unambiguous.
+      const childLinkLines = res.text
+        .split('\n')
+        .filter((line) => /^ {2}- \[/.test(line));
+      expect(childLinkLines).toHaveLength(MARKDOWN_FOOTER_MAX_LINKS);
+    });
+  });
+
+  describe('PAT (Personal Access Token) authentication (Requirement 3.1)', () => {
+    it('authenticates a markdown request via a real Bearer token through the genuine accessTokenParser, even when guest read is disallowed', async () => {
+      currentUser = undefined; // no session; the token is the ONLY credential
+      vi.spyOn(crowi.aclService, 'isGuestAllowedToRead').mockReturnValue(false);
+
+      const res = await request(app)
+        .get(`/${docId}.md`)
+        .set('Authorization', `Bearer ${patToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('text/markdown');
+      // populate regression across the full route round-trip: the finder does
+      // not populate, so both the verbatim body and the updater username must be
+      // reconstituted by the helper and present in the HTTP response (1.4, 4.5).
+      expect(res.text).toContain(bodyDoc);
+      expect(res.text).toContain(testUser.username);
+    });
+
+    it('does not authenticate a token lacking the required page-read scope, deferring to loginRequired (redirect to /login)', async () => {
+      currentUser = undefined;
+      vi.spyOn(crowi.aclService, 'isGuestAllowedToRead').mockReturnValue(false);
+
+      const res = await request(app)
+        .get(`/${docId}.md`)
+        .set('Authorization', `Bearer ${patWrongScopeToken}`)
+        .redirects(0);
+
+      // The token is valid but out of scope, so no user is resolved and the
+      // request follows the same guest-disallowed path as a tokenless one.
       expect(res.status).toBe(302);
       expect(res.headers.location).toBe('/login');
     });

--- a/apps/app/src/server/routes/page-markdown/page-markdown.integ.ts
+++ b/apps/app/src/server/routes/page-markdown/page-markdown.integ.ts
@@ -1,0 +1,332 @@
+import type { IUser } from '@growi/core';
+import express from 'express';
+import mongoose, { type HydratedDocument, type Model } from 'mongoose';
+import request from 'supertest';
+
+import { getInstance } from '^/test/setup/crowi';
+
+import type { CrowiRequest } from '~/interfaces/crowi-request';
+import type Crowi from '~/server/crowi';
+import type { PageDocument, PageModel } from '~/server/models/page';
+
+import { pageMarkdownRouteFactory } from '.';
+
+// Route-level integration test for the page-markdown interception route.
+//
+// Approach: real MongoDB + real Page / Revision / User models, the real
+// grant-aware finder, and the REAL authorization middlewares composed by the
+// factory (accessTokenParser + loginRequired). Nothing in the auth path is
+// mocked; instead an upstream middleware optionally injects `req.user` (the
+// job normally done by session/PAT resolution) so authenticated scenarios can
+// be exercised, and guest scenarios run through the genuine loginRequired
+// middleware whose ACL answer is controlled per-test via a spy.
+//
+// A sentinel fallback handler is mounted AFTER the factory to observe
+// next()/passthrough: any request the factory lets through lands on the
+// sentinel, mirroring how the production catch-all delegates to the HTML flow.
+//
+// Bootstrap mirrors respond-with-page-markdown.integ.ts (real Page/Revision seeding).
+
+// Per-worker prefix isolates fixtures when Vitest runs workers in parallel.
+const WORKER_ID = process.env.VITEST_WORKER_ID ?? '1';
+const BASE = `/mdroute-${WORKER_ID}`;
+const SENTINEL = 'HTML_FALLBACK_SENTINEL';
+
+type RevisionDoc = {
+  pageId: mongoose.Types.ObjectId;
+  body: string;
+  format: string;
+  author: mongoose.Types.ObjectId;
+};
+
+describe('pageMarkdownRouteFactory (route integration)', () => {
+  let crowi: Crowi;
+  let app: express.Application;
+  let Page: PageModel;
+  let User: Model<IUser>;
+  let Revision: Model<RevisionDoc>;
+
+  let testUser: HydratedDocument<IUser>;
+  let otherUser: HydratedDocument<IUser>;
+
+  // The user injected upstream for the current request (undefined => anonymous).
+  let currentUser: HydratedDocument<IUser> | undefined;
+
+  let docId: string; // public page at `${BASE}/doc`
+  let secretId: string; // GRANT_OWNER page owned by otherUser (forbidden to testUser)
+
+  const bodyDoc = 'DOC-BODY-CONTENT-VERBATIM';
+  const bodySecret = 'SECRET-BODY-DO-NOT-LEAK';
+  const bodyLiteral = 'LITERAL-MD-PAGE-BODY';
+
+  const seededPaths = [`${BASE}/doc`, `${BASE}/secret`, `${BASE}/literal.md`];
+
+  beforeAll(async () => {
+    crowi = await getInstance();
+
+    Page = mongoose.model<PageDocument, PageModel>('Page');
+    User = mongoose.model<IUser>('User');
+    Revision = mongoose.model<RevisionDoc>('Revision');
+
+    const testUserName = `mdroute-user-${WORKER_ID}`;
+    const otherUserName = `mdroute-other-${WORKER_ID}`;
+    await User.deleteMany({ username: { $in: [testUserName, otherUserName] } });
+    testUser = await User.create({
+      name: testUserName,
+      username: testUserName,
+      email: `${testUserName}@example.com`,
+    });
+    otherUser = await User.create({
+      name: otherUserName,
+      username: otherUserName,
+      email: `${otherUserName}@example.com`,
+    });
+
+    // Idempotency: wipe any leftover fixtures from a prior aborted run.
+    await Page.deleteMany({ path: { $in: seededPaths } });
+
+    const doc = await Page.create({
+      path: `${BASE}/doc`,
+      grant: Page.GRANT_PUBLIC,
+      creator: testUser._id,
+      lastUpdateUser: testUser._id,
+      descendantCount: 0,
+    });
+    const secret = await Page.create({
+      path: `${BASE}/secret`,
+      grant: Page.GRANT_OWNER,
+      grantedUsers: [otherUser._id],
+      creator: otherUser._id,
+      lastUpdateUser: otherUser._id,
+      descendantCount: 0,
+    });
+    // A page whose path literally ends with `.md`. isCreatablePage forbids
+    // this via normal flows, so it is seeded directly (backward-compat safety
+    // net for imported/legacy data) to exercise literal-wins (Requirement 2.1).
+    const literal = await Page.create({
+      path: `${BASE}/literal.md`,
+      grant: Page.GRANT_PUBLIC,
+      creator: testUser._id,
+      lastUpdateUser: testUser._id,
+      descendantCount: 0,
+    });
+
+    const revisions = await Revision.insertMany([
+      {
+        pageId: doc._id,
+        body: bodyDoc,
+        format: 'markdown',
+        author: testUser._id,
+      },
+      {
+        pageId: secret._id,
+        body: bodySecret,
+        format: 'markdown',
+        author: otherUser._id,
+      },
+      {
+        pageId: literal._id,
+        body: bodyLiteral,
+        format: 'markdown',
+        author: testUser._id,
+      },
+    ]);
+    doc.revision = revisions[0]._id;
+    secret.revision = revisions[1]._id;
+    literal.revision = revisions[2]._id;
+    await doc.save();
+    await secret.save();
+    await literal.save();
+
+    docId = String(doc._id);
+    secretId = String(secret._id);
+
+    // Build the app once: express.json ensures req.body is defined (production
+    // mounts body parsers upstream of the catch-all); the injector emulates
+    // session/PAT user resolution; the sentinel observes fall-through.
+    app = express();
+    app.use(express.json());
+    app.use((req: CrowiRequest, _res, next) => {
+      if (currentUser != null) {
+        req.user = currentUser;
+      }
+      next();
+    });
+    app.use(pageMarkdownRouteFactory(crowi));
+    app.use((_req, res) => {
+      res.status(200).type('text/html').send(SENTINEL);
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    try {
+      await Page.deleteMany({ path: { $in: seededPaths } });
+    } catch {
+      // ignore
+    }
+    try {
+      await User.deleteMany({ _id: { $in: [testUser?._id, otherUser?._id] } });
+    } catch {
+      // ignore
+    }
+  }, 30_000);
+
+  beforeEach(() => {
+    currentUser = undefined;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('markdown retrieval (Requirement 1.1, 1.2, 1.3)', () => {
+    it('serves permalink /{pageId}.md as text/markdown with the verbatim body and footer', async () => {
+      currentUser = testUser;
+
+      const res = await request(app).get(`/${docId}.md`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('text/markdown');
+      expect(res.headers['content-type']).toContain('charset=utf-8');
+      expect(res.text).toContain(bodyDoc);
+      // navigation footer is present (page-list API hint is always included, 4.6)
+      expect(res.text).toContain(`/_api/v3/page-listing/children?id=${docId}`);
+    });
+
+    it('serves {path}.md for a base page that exists', async () => {
+      currentUser = testUser;
+
+      const res = await request(app).get(`${BASE}/doc.md`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('text/markdown');
+      expect(res.text).toContain(bodyDoc);
+    });
+
+    it('serves a plain page URL with Accept: text/markdown', async () => {
+      currentUser = testUser;
+
+      const res = await request(app)
+        .get(`${BASE}/doc`)
+        .set('Accept', 'text/markdown');
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('text/markdown');
+      expect(res.text).toContain(bodyDoc);
+    });
+
+    it('serves a plain page URL with ?format=md', async () => {
+      currentUser = testUser;
+
+      const res = await request(app).get(`${BASE}/doc`).query({ format: 'md' });
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('text/markdown');
+      expect(res.text).toContain(bodyDoc);
+    });
+  });
+
+  describe('content negotiation guard', () => {
+    it('does NOT hijack a plain URL sent with the curl-default Accept: */*', async () => {
+      currentUser = testUser;
+
+      const res = await request(app).get(`${BASE}/doc`).set('Accept', '*/*');
+
+      // */* must not count as an explicit text/markdown request, so the request
+      // falls through to the HTML sentinel rather than being served as markdown.
+      expect(res.status).toBe(200);
+      expect(res.text).toBe(SENTINEL);
+    });
+  });
+
+  describe('not found (Requirement 1.5, 2.3, 3.5)', () => {
+    it('returns 404 text/markdown guidance when neither the path nor its base exists', async () => {
+      currentUser = testUser;
+
+      const res = await request(app).get(`${BASE}/no-such-page-xyz.md`);
+
+      expect(res.status).toBe(404);
+      expect(res.headers['content-type']).toContain('text/markdown');
+      expect(res.text).toContain('404');
+    });
+  });
+
+  describe('forbidden (Requirement 3.1, 3.2, 3.5)', () => {
+    it('returns 403 text/markdown guidance without leaking the protected body', async () => {
+      currentUser = testUser; // not the owner of the GRANT_OWNER page
+
+      const res = await request(app).get(`/${secretId}.md`);
+
+      expect(res.status).toBe(403);
+      expect(res.headers['content-type']).toContain('text/markdown');
+      expect(res.text).toContain('403');
+      expect(res.text).not.toContain(bodySecret);
+    });
+  });
+
+  describe('literal .md collision (Requirement 2.1, 2.4)', () => {
+    it('passes a literal .md page through to the HTML sentinel (backward compat)', async () => {
+      currentUser = testUser;
+
+      const res = await request(app).get(`${BASE}/literal.md`);
+
+      expect(res.status).toBe(200);
+      expect(res.text).toBe(SENTINEL);
+    });
+
+    it('serves the literal .md page own markdown when Accept is explicit (no stripping)', async () => {
+      currentUser = testUser;
+
+      const res = await request(app)
+        .get(`${BASE}/literal.md`)
+        .set('Accept', 'text/markdown');
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('text/markdown');
+      expect(res.text).toContain(bodyLiteral);
+    });
+  });
+
+  describe('guest access (Requirement 3.3, 3.4)', () => {
+    it('serves a public page anonymously when guest read is allowed', async () => {
+      currentUser = undefined; // anonymous
+      vi.spyOn(crowi.aclService, 'isGuestAllowedToRead').mockReturnValue(true);
+
+      const res = await request(app).get(`/${docId}.md`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('text/markdown');
+      expect(res.text).toContain(bodyDoc);
+    });
+
+    it('follows loginRequired (redirect to /login) for an anonymous request when guest read is disallowed', async () => {
+      currentUser = undefined; // anonymous
+      vi.spyOn(crowi.aclService, 'isGuestAllowedToRead').mockReturnValue(false);
+
+      const res = await request(app).get(`/${docId}.md`).redirects(0);
+
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toBe('/login');
+    });
+  });
+
+  describe('GET-only + HTML delivery preserved', () => {
+    it('does not intercept non-GET requests (POST falls through to the sentinel)', async () => {
+      currentUser = testUser;
+
+      const res = await request(app).post(`/${docId}.md`);
+
+      expect(res.status).toBe(200);
+      expect(res.text).toBe(SENTINEL);
+    });
+
+    it('does not intercept a plain page GET without Accept/format (normal HTML delivery preserved)', async () => {
+      currentUser = testUser;
+
+      const res = await request(app).get(`${BASE}/doc`);
+
+      expect(res.status).toBe(200);
+      expect(res.text).toBe(SENTINEL);
+    });
+  });
+});

--- a/apps/app/src/server/routes/page-markdown/parse-markdown-request.spec.ts
+++ b/apps/app/src/server/routes/page-markdown/parse-markdown-request.spec.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type MarkdownRequestIntent,
+  parseMarkdownRequest,
+} from './parse-markdown-request';
+
+// A syntactically valid 24-hex ObjectId, reused across permalink-related cases.
+const VALID_OBJECT_ID = '507f1f77bcf86cd799439011';
+
+type Case = {
+  name: string;
+  reqPath: string;
+  accept: string | undefined;
+  formatQuery: string | undefined;
+  expected: MarkdownRequestIntent;
+};
+
+describe('parseMarkdownRequest', () => {
+  describe('not a markdown request -> none', () => {
+    const cases: Case[] = [
+      {
+        name: 'plain path without .md suffix, no Accept, no ?format',
+        reqPath: '/foo/bar',
+        accept: undefined,
+        formatQuery: undefined,
+        expected: { kind: 'none' },
+      },
+      {
+        name: 'bare permalink path without .md suffix or explicit intent is a normal page view',
+        reqPath: `/${VALID_OBJECT_ID}`,
+        accept: undefined,
+        formatQuery: undefined,
+        expected: { kind: 'none' },
+      },
+      {
+        name: '.mdx suffix is not treated as a markdown request',
+        reqPath: '/foo/file.mdx',
+        accept: undefined,
+        formatQuery: undefined,
+        expected: { kind: 'none' },
+      },
+      {
+        name: 'Accept: */* (wildcard) must not be treated as an explicit markdown request',
+        reqPath: '/foo/bar',
+        accept: '*/*',
+        formatQuery: undefined,
+        expected: { kind: 'none' },
+      },
+      {
+        name: 'Accept: text/* (wildcard subtype) must not be treated as an explicit markdown request',
+        reqPath: '/foo/bar',
+        accept: 'text/*',
+        formatQuery: undefined,
+        expected: { kind: 'none' },
+      },
+      {
+        name: '?format=html (not "md") does not trigger a markdown request',
+        reqPath: '/foo/bar',
+        accept: undefined,
+        formatQuery: 'html',
+        expected: { kind: 'none' },
+      },
+      {
+        name: 'empty Accept header behaves like no Accept header',
+        reqPath: '/foo/bar',
+        accept: '',
+        formatQuery: undefined,
+        expected: { kind: 'none' },
+      },
+    ];
+
+    it.each(cases)('$name', ({ reqPath, accept, formatQuery, expected }) => {
+      expect(parseMarkdownRequest(reqPath, accept, formatQuery)).toStrictEqual(
+        expected,
+      );
+    });
+  });
+
+  describe('.md suffix (sugar, explicit=false) -> path or permalink, original path preserved', () => {
+    const cases: Case[] = [
+      {
+        name: '.md suffix on an ordinary path yields kind=path with the ORIGINAL (unstripped) path',
+        reqPath: '/foo/README.md',
+        accept: undefined,
+        formatQuery: undefined,
+        expected: { kind: 'path', path: '/foo/README.md', explicit: false },
+      },
+      {
+        name: '.md.md (double suffix) yields kind=path with the path fully unchanged',
+        reqPath: '/foo/README.md.md',
+        accept: undefined,
+        formatQuery: undefined,
+        expected: {
+          kind: 'path',
+          path: '/foo/README.md.md',
+          explicit: false,
+        },
+      },
+      {
+        name: '.md suffix on a permalink (/{24hex}.md) yields kind=permalink with the extracted pageId',
+        reqPath: `/${VALID_OBJECT_ID}.md`,
+        accept: undefined,
+        formatQuery: undefined,
+        expected: {
+          kind: 'permalink',
+          pageId: VALID_OBJECT_ID,
+          explicit: false,
+        },
+      },
+    ];
+
+    it.each(cases)('$name', ({ reqPath, accept, formatQuery, expected }) => {
+      expect(parseMarkdownRequest(reqPath, accept, formatQuery)).toStrictEqual(
+        expected,
+      );
+    });
+  });
+
+  describe('explicit intent (Accept: text/markdown or ?format=md) -> never strips trailing .md', () => {
+    const cases: Case[] = [
+      {
+        name: 'Accept: text/markdown (exact) marks the request explicit',
+        reqPath: '/foo/bar',
+        accept: 'text/markdown',
+        formatQuery: undefined,
+        expected: { kind: 'path', path: '/foo/bar', explicit: true },
+      },
+      {
+        name: 'Accept header with quality parameter (;q=0.9) still matches explicitly',
+        reqPath: '/foo/bar',
+        accept: 'text/markdown;q=0.9',
+        formatQuery: undefined,
+        expected: { kind: 'path', path: '/foo/bar', explicit: true },
+      },
+      {
+        name: 'comma-separated Accept list containing text/markdown matches explicitly',
+        reqPath: '/foo/bar',
+        accept: 'text/html, text/markdown',
+        formatQuery: undefined,
+        expected: { kind: 'path', path: '/foo/bar', explicit: true },
+      },
+      {
+        name: 'messy comma-separated Accept list with extra whitespace and quality params still matches',
+        reqPath: '/foo/bar',
+        accept: 'text/html , text/markdown ; q=0.5 , application/json',
+        formatQuery: undefined,
+        expected: { kind: 'path', path: '/foo/bar', explicit: true },
+      },
+      {
+        name: 'Accept media type comparison is case-insensitive',
+        reqPath: '/foo/bar',
+        accept: 'Text/Markdown',
+        formatQuery: undefined,
+        expected: { kind: 'path', path: '/foo/bar', explicit: true },
+      },
+      {
+        name: '?format=md marks the request explicit',
+        reqPath: '/foo/bar',
+        accept: undefined,
+        formatQuery: 'md',
+        expected: { kind: 'path', path: '/foo/bar', explicit: true },
+      },
+      {
+        name: 'explicit intent on a bare permalink path yields kind=permalink',
+        reqPath: `/${VALID_OBJECT_ID}`,
+        accept: 'text/markdown',
+        formatQuery: undefined,
+        expected: {
+          kind: 'permalink',
+          pageId: VALID_OBJECT_ID,
+          explicit: true,
+        },
+      },
+      {
+        name: 'explicit intent does NOT strip a trailing .md suffix from an ordinary path (req 2.4)',
+        reqPath: '/foo/README.md',
+        accept: 'text/markdown',
+        formatQuery: undefined,
+        expected: { kind: 'path', path: '/foo/README.md', explicit: true },
+      },
+    ];
+
+    it.each(cases)('$name', ({ reqPath, accept, formatQuery, expected }) => {
+      expect(parseMarkdownRequest(reqPath, accept, formatQuery)).toStrictEqual(
+        expected,
+      );
+    });
+  });
+});

--- a/apps/app/src/server/routes/page-markdown/parse-markdown-request.ts
+++ b/apps/app/src/server/routes/page-markdown/parse-markdown-request.ts
@@ -1,0 +1,91 @@
+import { isPermalink } from '@growi/core/dist/utils/page-path-utils';
+
+/**
+ * The caller's interpretation of a request as a markdown-format request.
+ *
+ * - 'none': not a markdown request at all -- the caller should call next().
+ * - 'permalink': the requested path is a permalink (/{24-hex ObjectId}[.md]).
+ * - 'path': the requested path is an ordinary page path (possibly ending with .md).
+ *
+ * `explicit` distinguishes the two ways a markdown request can be signaled:
+ * - true:  Accept: text/markdown (explicit media type) or ?format=md
+ * - false: bare `.md` suffix (sugar)
+ *
+ * When explicit=false and kind='path', `path` is returned UNMODIFIED (still
+ * carrying its trailing `.md`, if any) -- literal-vs-base resolution is owned
+ * by the caller (respondWithPageMarkdown), not by this pure classifier.
+ */
+export type MarkdownRequestIntent =
+  | { kind: 'none' }
+  | { kind: 'permalink'; pageId: string; explicit: boolean }
+  | { kind: 'path'; path: string; explicit: boolean };
+
+const MARKDOWN_MEDIA_TYPE = 'text/markdown';
+const MARKDOWN_SUFFIX = '.md';
+
+/**
+ * Whether the Accept header explicitly lists text/markdown as a media type.
+ *
+ * Deliberately NOT equivalent to Express's `req.accepts()`, which treats a
+ * wildcard such as "any type" (curl's default Accept) as a match for
+ * anything. Here, only an exact `text/markdown` entry (ignoring `;q=...`
+ * parameters and surrounding whitespace, case-insensitively) counts.
+ */
+function hasExplicitMarkdownAccept(accept: string | undefined): boolean {
+  if (accept == null || accept.length === 0) {
+    return false;
+  }
+
+  return accept
+    .split(',')
+    .map((entry) => entry.split(';')[0].trim().toLowerCase())
+    .includes(MARKDOWN_MEDIA_TYPE);
+}
+
+/**
+ * Classify a path (with no further suffix stripping) as permalink or ordinary path.
+ */
+function classifyPath(path: string, explicit: boolean): MarkdownRequestIntent {
+  if (isPermalink(path)) {
+    // isPermalink already validated that path.substring(1) is a valid ObjectId.
+    return { kind: 'permalink', pageId: path.substring(1), explicit };
+  }
+  return { kind: 'path', path, explicit };
+}
+
+/**
+ * Interpret an incoming request as a markdown-format request, without
+ * touching Express types or performing any I/O.
+ *
+ * Judgment order (see design.md System Flows):
+ * 1. Explicit intent (Accept: text/markdown or ?format=md) takes top
+ *    priority and never strips a trailing `.md` from the path.
+ * 2. Otherwise, a `.md` suffix (exact, case-sensitive -- `.mdx` does not
+ *    count) is treated as sugar; literal-vs-base resolution is deferred to
+ *    the caller.
+ * 3. Otherwise, this is not a markdown request at all.
+ */
+export function parseMarkdownRequest(
+  reqPath: string,
+  accept: string | undefined,
+  formatQuery: string | undefined,
+): MarkdownRequestIntent {
+  const explicit = hasExplicitMarkdownAccept(accept) || formatQuery === 'md';
+
+  if (explicit) {
+    return classifyPath(reqPath, true);
+  }
+
+  if (!reqPath.endsWith(MARKDOWN_SUFFIX)) {
+    return { kind: 'none' };
+  }
+
+  const base = reqPath.slice(0, -MARKDOWN_SUFFIX.length);
+  if (isPermalink(base)) {
+    return { kind: 'permalink', pageId: base.substring(1), explicit: false };
+  }
+
+  // Not a permalink: keep the ORIGINAL (still `.md`-suffixed) path. The
+  // caller owns literal-vs-base resolution (task 2.2).
+  return { kind: 'path', path: reqPath, explicit: false };
+}

--- a/apps/app/src/server/routes/page-markdown/respond-with-page-markdown.integ.ts
+++ b/apps/app/src/server/routes/page-markdown/respond-with-page-markdown.integ.ts
@@ -1,0 +1,375 @@
+import type { IUser } from '@growi/core';
+import mongoose, { type HydratedDocument, type Model } from 'mongoose';
+
+import { getInstance } from '^/test/setup/crowi';
+
+import type Crowi from '~/server/crowi';
+import type { PageDocument, PageModel } from '~/server/models/page';
+
+import {
+  type MarkdownResolution,
+  respondWithPageMarkdown,
+} from './respond-with-page-markdown';
+
+// Helper-level integration test for respondWithPageMarkdown.
+//
+// Approach: real MongoDB + real Page / Revision / User models and the real
+// grant-aware finder (`findPageAndMetaDataByViewer`) + pageListingService. No
+// supertest / Express — the route factory (task 3.1) is out of scope here.
+// Authorization is exercised for real (never mocked) so the resolution reflects
+// the genuine viewer contract.
+//
+// Bootstrap mirrors get-page-content-tool.integ.ts (real Page/Revision seeding).
+
+// Per-worker prefix isolates fixtures when Vitest runs workers in parallel.
+const WORKER_ID = process.env.VITEST_WORKER_ID ?? '1';
+const BASE = `/mdtest-${WORKER_ID}`;
+const ORIGIN = 'https://md.example.test';
+
+type RevisionDoc = {
+  pageId: mongoose.Types.ObjectId;
+  body: string;
+  format: string;
+  author: mongoose.Types.ObjectId;
+};
+
+// Narrow a resolution to its markdown body, failing loudly on passthrough.
+function markdownOf(res: MarkdownResolution): string {
+  if (res.type === 'passthrough') {
+    throw new Error(
+      'expected a markdown-bearing resolution but got passthrough',
+    );
+  }
+  return res.markdown;
+}
+
+describe('respondWithPageMarkdown (integration)', () => {
+  let crowi: Crowi;
+  let Page: PageModel;
+  let User: Model<IUser>;
+  let Revision: Model<RevisionDoc>;
+
+  let testUser: HydratedDocument<IUser>;
+  let otherUser: HydratedDocument<IUser>;
+
+  // Seeded pages (ids captured for permalink resolution + link assertions).
+  let hubId: string; // parent==null (root-like), has children aaa/bbb
+  let aaaId: string; // child of hub, sibling of bbb
+  let bbbId: string; // child of hub, sibling of aaa
+  let secretId: string; // GRANT_OWNER owned by otherUser
+  let emptyId: string; // empty container page (no revision)
+
+  const bodyAaa = 'AAA-BODY-CONTENT-VERBATIM';
+  const bodyBbb = 'BBB-BODY';
+  const bodyHub = 'HUB-BODY-CONTENT';
+  const bodySecret = 'SECRET-BODY-DO-NOT-LEAK';
+  const bodyLiteral = 'LITERAL-MD-PAGE-BODY';
+  const bodyDoc = 'BASE-DOC-BODY';
+
+  const HUB_DESCENDANT_COUNT = 5;
+
+  beforeAll(async () => {
+    crowi = await getInstance();
+
+    Page = mongoose.model<PageDocument, PageModel>('Page');
+    User = mongoose.model<IUser>('User');
+    Revision = mongoose.model<RevisionDoc>('Revision');
+
+    const testUserName = `mdtest-user-${WORKER_ID}`;
+    const otherUserName = `mdtest-other-${WORKER_ID}`;
+    await User.deleteMany({ username: { $in: [testUserName, otherUserName] } });
+    testUser = await User.create({
+      name: testUserName,
+      username: testUserName,
+      email: `${testUserName}@example.com`,
+    });
+    otherUser = await User.create({
+      name: otherUserName,
+      username: otherUserName,
+      email: `${otherUserName}@example.com`,
+    });
+
+    // Idempotency: wipe any leftover fixtures from a prior aborted run.
+    const seededPaths = [
+      `${BASE}/hub`,
+      `${BASE}/hub/aaa`,
+      `${BASE}/hub/bbb`,
+      `${BASE}/secret`,
+      `${BASE}/literal.md`,
+      `${BASE}/doc`,
+      `${BASE}/empty`,
+    ];
+    await Page.deleteMany({ path: { $in: seededPaths } });
+
+    // Root-like hub: parent omitted (null) so the footer must omit parent AND
+    // siblings (Requirement 4.8). descendantCount is distinct from the direct
+    // child count (Requirement 4.3).
+    const hub = await Page.create({
+      path: `${BASE}/hub`,
+      grant: Page.GRANT_PUBLIC,
+      creator: testUser._id,
+      lastUpdateUser: testUser._id,
+      descendantCount: HUB_DESCENDANT_COUNT,
+    });
+    const aaa = await Page.create({
+      path: `${BASE}/hub/aaa`,
+      grant: Page.GRANT_PUBLIC,
+      creator: testUser._id,
+      lastUpdateUser: testUser._id,
+      parent: hub._id,
+      descendantCount: 0,
+    });
+    const bbb = await Page.create({
+      path: `${BASE}/hub/bbb`,
+      grant: Page.GRANT_PUBLIC,
+      creator: testUser._id,
+      lastUpdateUser: testUser._id,
+      parent: hub._id,
+      descendantCount: 0,
+    });
+    const secret = await Page.create({
+      path: `${BASE}/secret`,
+      grant: Page.GRANT_OWNER,
+      grantedUsers: [otherUser._id],
+      creator: otherUser._id,
+      lastUpdateUser: otherUser._id,
+      descendantCount: 0,
+    });
+    const literal = await Page.create({
+      path: `${BASE}/literal.md`,
+      grant: Page.GRANT_PUBLIC,
+      creator: testUser._id,
+      lastUpdateUser: testUser._id,
+      descendantCount: 0,
+    });
+    const doc = await Page.create({
+      path: `${BASE}/doc`,
+      grant: Page.GRANT_PUBLIC,
+      creator: testUser._id,
+      lastUpdateUser: testUser._id,
+      descendantCount: 0,
+    });
+    // Empty container page: no revision, no lastUpdateUser (mirrors the empty
+    // container in page-listing.integ.ts). The footer must still render.
+    const empty = await Page.create({
+      path: `${BASE}/empty`,
+      grant: Page.GRANT_PUBLIC,
+      creator: testUser._id,
+      isEmpty: true,
+      descendantCount: 1,
+    });
+
+    const revisions = await Revision.insertMany([
+      {
+        pageId: hub._id,
+        body: bodyHub,
+        format: 'markdown',
+        author: testUser._id,
+      },
+      {
+        pageId: aaa._id,
+        body: bodyAaa,
+        format: 'markdown',
+        author: testUser._id,
+      },
+      {
+        pageId: bbb._id,
+        body: bodyBbb,
+        format: 'markdown',
+        author: testUser._id,
+      },
+      {
+        pageId: secret._id,
+        body: bodySecret,
+        format: 'markdown',
+        author: otherUser._id,
+      },
+      {
+        pageId: literal._id,
+        body: bodyLiteral,
+        format: 'markdown',
+        author: testUser._id,
+      },
+      {
+        pageId: doc._id,
+        body: bodyDoc,
+        format: 'markdown',
+        author: testUser._id,
+      },
+    ]);
+
+    hub.revision = revisions[0]._id;
+    aaa.revision = revisions[1]._id;
+    bbb.revision = revisions[2]._id;
+    secret.revision = revisions[3]._id;
+    literal.revision = revisions[4]._id;
+    doc.revision = revisions[5]._id;
+    await hub.save();
+    await aaa.save();
+    await bbb.save();
+    await secret.save();
+    await literal.save();
+    await doc.save();
+
+    hubId = String(hub._id);
+    aaaId = String(aaa._id);
+    bbbId = String(bbb._id);
+    secretId = String(secret._id);
+    emptyId = String(empty._id);
+  }, 60_000);
+
+  afterAll(async () => {
+    try {
+      await Page.deleteMany({
+        path: {
+          $in: [
+            `${BASE}/hub`,
+            `${BASE}/hub/aaa`,
+            `${BASE}/hub/bbb`,
+            `${BASE}/secret`,
+            `${BASE}/literal.md`,
+            `${BASE}/doc`,
+            `${BASE}/empty`,
+          ],
+        },
+      });
+    } catch {
+      // ignore
+    }
+    try {
+      await User.deleteMany({ _id: { $in: [testUser?._id, otherUser?._id] } });
+    } catch {
+      // ignore
+    }
+  }, 30_000);
+
+  const call = (
+    reqPath: string,
+    user: HydratedDocument<IUser> | undefined,
+    opts: { accept?: string; formatQuery?: string } = {},
+  ): Promise<MarkdownResolution> =>
+    respondWithPageMarkdown(crowi, {
+      reqPath,
+      accept: opts.accept,
+      formatQuery: opts.formatQuery,
+      user,
+      origin: ORIGIN,
+    });
+
+  describe('ok resolution: body + footer', () => {
+    it('resolves a public page by permalink and returns the revision body verbatim plus canonical URL, permalink, and updater username', async () => {
+      const res = await call(`/${aaaId}.md`, testUser);
+
+      expect(res.type).toBe('ok');
+      const md = markdownOf(res);
+      // body is passed through verbatim (populate regression guard, 1.4/4.5)
+      expect(md).toContain(bodyAaa);
+      // footer provenance (4.1, 4.5)
+      expect(md).toContain(`${ORIGIN}${BASE}/hub/aaa`); // canonical URL
+      expect(md).toContain(`${ORIGIN}/${aaaId}`); // permalink
+      expect(md).toContain(testUser.username); // serialized updater
+      // page-list API hint is always present (4.6)
+      expect(md).toContain(`/_api/v3/page-listing/children?id=${aaaId}`);
+    });
+
+    it('resolves a public page anonymously (guest) when the page is public', async () => {
+      const res = await call(`/${aaaId}.md`, undefined);
+
+      expect(res.type).toBe('ok');
+      expect(markdownOf(res)).toContain(bodyAaa);
+    });
+  });
+
+  describe('footer: children counts + descendantCount, root omits parent/siblings', () => {
+    it('lists direct children as permalink .md links with the exact direct-child total and a separate descendant total, and omits parent/siblings for a root-like page', async () => {
+      const res = await call(`/${hubId}.md`, testUser);
+
+      expect(res.type).toBe('ok');
+      const md = markdownOf(res);
+      expect(md).toContain(bodyHub);
+      // child links in permalink .md form (4.2-4.4)
+      expect(md).toContain(`(/${aaaId}.md)`);
+      expect(md).toContain(`(/${bbbId}.md)`);
+      // exact direct-child total (2 seeded), distinct from descendantCount (4.3)
+      expect(md).toContain('Children: 2 total');
+      expect(md).toContain(`Total descendants: ${HUB_DESCENDANT_COUNT}`);
+      // root-like (parent == null): no parent or sibling lines (4.8)
+      expect(md).not.toContain('Parent:');
+      expect(md).not.toContain('Siblings:');
+    });
+  });
+
+  describe('footer: parent link + siblings excluding self', () => {
+    it('includes the parent link and sibling links, excluding the page itself', async () => {
+      const res = await call(`/${aaaId}.md`, testUser);
+
+      expect(res.type).toBe('ok');
+      const md = markdownOf(res);
+      // parent link to hub
+      expect(md).toContain(`- Parent: [hub](/${hubId}.md)`);
+      // sibling bbb present, self (aaa) excluded from the sibling list.
+      expect(md).toContain('Siblings: 1 total');
+      expect(md).toContain(`(/${bbbId}.md)`);
+      // The self permalink `.md` link never appears (permalinkUrl/hint use the
+      // bare id without a `.md` suffix, so this uniquely proves self-exclusion).
+      expect(md).not.toContain(`/${aaaId}.md`);
+    });
+  });
+
+  describe('forbidden resolution', () => {
+    it('returns forbidden with guidance and no page content when the viewer lacks permission', async () => {
+      const res = await call(`/${secretId}.md`, testUser);
+
+      expect(res.type).toBe('forbidden');
+      const md = markdownOf(res);
+      expect(md).toContain('403');
+      // never leak the protected body
+      expect(md).not.toContain(bodySecret);
+    });
+  });
+
+  describe('notFound resolution', () => {
+    it('returns notFound with guidance when neither the path nor its base exists', async () => {
+      const res = await call(`${BASE}/no-such-page-xyz.md`, testUser);
+
+      expect(res.type).toBe('notFound');
+      expect(markdownOf(res)).toContain('404');
+    });
+  });
+
+  describe('literal-wins (.md suffix) resolution', () => {
+    it('passes through when a real page literally exists at the .md path (backward compat)', async () => {
+      const res = await call(`${BASE}/literal.md`, testUser);
+
+      expect(res.type).toBe('passthrough');
+    });
+
+    it('returns the literal .md page own markdown when the request is explicit (Accept), without stripping', async () => {
+      const res = await call(`${BASE}/literal.md`, testUser, {
+        accept: 'text/markdown',
+      });
+
+      expect(res.type).toBe('ok');
+      expect(markdownOf(res)).toContain(bodyLiteral);
+    });
+
+    it('strips the trailing .md and returns the base page markdown when no literal page exists', async () => {
+      const res = await call(`${BASE}/doc.md`, testUser);
+
+      expect(res.type).toBe('ok');
+      expect(markdownOf(res)).toContain(bodyDoc);
+    });
+  });
+
+  describe('empty (container) page', () => {
+    it('returns ok with a no-body notice plus footer, without crashing', async () => {
+      const res = await call(`/${emptyId}.md`, testUser);
+
+      expect(res.type).toBe('ok');
+      const md = markdownOf(res);
+      expect(md).toContain('This page has no content yet.');
+      // footer still rendered for empty pages (5.1-5.3)
+      expect(md).toContain(`${ORIGIN}${BASE}/empty`);
+    });
+  });
+});

--- a/apps/app/src/server/routes/page-markdown/respond-with-page-markdown.ts
+++ b/apps/app/src/server/routes/page-markdown/respond-with-page-markdown.ts
@@ -1,0 +1,321 @@
+import nodePath from 'node:path';
+import type { IUser } from '@growi/core';
+import { serializeUserSecurely } from '@growi/core/dist/models/serializers';
+import { pagePathUtils } from '@growi/core/dist/utils';
+import type { HydratedDocument } from 'mongoose';
+import mongoose from 'mongoose';
+
+import type { IPageForTreeItem } from '~/interfaces/page';
+import type Crowi from '~/server/crowi';
+import type { PageDocument, PageModel } from '~/server/models/page';
+import { findPageAndMetaDataByViewer } from '~/server/service/page/find-page-and-meta-data-by-viewer';
+import { pageListingService } from '~/server/service/page-listing';
+import loggerFactory from '~/utils/logger';
+import { toPermalinkMdUrl } from '~/utils/page-markdown-url';
+
+import {
+  buildErrorMarkdown,
+  buildPageMarkdown,
+  type FooterLink,
+} from './build-page-markdown';
+import { MARKDOWN_FOOTER_MAX_LINKS } from './constants';
+import { parseMarkdownRequest } from './parse-markdown-request';
+
+const { encodeSpaces } = pagePathUtils;
+
+const logger = loggerFactory(
+  'growi:routes:page-markdown:respond-with-page-markdown',
+);
+
+const MARKDOWN_SUFFIX = '.md';
+
+/**
+ * The outcome of resolving a markdown request into a response.
+ *
+ * - 'ok':          the page was resolved and is viewable; `markdown` is the body+footer document.
+ * - 'forbidden':   the page exists but the viewer lacks permission; `markdown` is guidance only.
+ * - 'notFound':    neither the requested path nor its base resolves; `markdown` is guidance only.
+ * - 'passthrough': a literal `.md` page exists at the requested path -> let the existing HTML flow serve it.
+ */
+export type MarkdownResolution =
+  | { type: 'ok'; markdown: string }
+  | { type: 'forbidden'; markdown: string }
+  | { type: 'notFound'; markdown: string }
+  | { type: 'passthrough' };
+
+export interface RespondWithPageMarkdownInput {
+  reqPath: string;
+  accept: string | undefined;
+  formatQuery: string | undefined;
+  // NOTE: design.md spells this `IUserHasId | undefined`, but the mandated
+  // dependency `findPageAndMetaDataByViewer` requires `opts.user:
+  // HydratedDocument<IUser>` and the coding rules forbid type assertions. The
+  // route (task 3.1) passes `req.user`, which is exactly this type, so this is
+  // the honest, cast-free, route-compatible shape (also assignable to IUserHasId).
+  user: HydratedDocument<IUser> | undefined;
+  origin: string;
+}
+
+type PageDoc = HydratedDocument<PageDocument>;
+
+// Result of the viewer-aware finder used in basicOnly mode. The markdown
+// endpoint only needs the page document plus the viewable/forbidden/not-found
+// distinction; it does NOT need bookmark counts, deletability, subscription, or
+// like status. `basicOnly: true` returns exactly that via the identical
+// authorization contract while skipping the extra (Prisma) work -- desirable for
+// a crawler-facing read endpoint.
+type FinderResult = Awaited<ReturnType<typeof resolvePage>>;
+
+function resolvePage(
+  crowi: Crowi,
+  target: { pageId: string | null; path: string | null },
+  user: HydratedDocument<IUser> | undefined,
+) {
+  return findPageAndMetaDataByViewer(
+    crowi.pageService,
+    crowi.pageGrantService,
+    {
+      pageId: target.pageId,
+      path: target.path,
+      user,
+      basicOnly: true,
+    },
+  );
+}
+
+/**
+ * Whether a page exists at the resolved target for THIS viewer's existence
+ * check: viewable (data present) OR present-but-forbidden. This mirrors the
+ * finder's own re-count semantics and is what literal-wins needs (Requirement
+ * 2.1: existence wins over viewability).
+ */
+function pageExists(result: FinderResult): boolean {
+  if (result.data != null) {
+    return true;
+  }
+  // data == null -> meta is IPageNotFoundInfo, which carries isForbidden.
+  return result.meta.isForbidden;
+}
+
+// Derive a footer link title from a page path: the last path segment, falling
+// back to the path itself for the root ('/').
+function titleFromPath(path: string): string {
+  return nodePath.basename(path) || path;
+}
+
+function toFooterLink(
+  item: Pick<IPageForTreeItem, '_id' | 'path'>,
+): FooterLink {
+  return {
+    title: titleFromPath(item.path),
+    mdUrl: toPermalinkMdUrl(String(item._id)),
+  };
+}
+
+/**
+ * Resolve the parent page's footer link from the child's `parent` ObjectId.
+ * The finder does not populate `parent`, so an additional query is required.
+ * The parent path is a prefix of the child's path, so resolving it by id
+ * exposes nothing new -- a plain findById (no viewer filter) is sufficient.
+ */
+async function resolveParentLink(
+  parent: PageDocument['parent'],
+): Promise<FooterLink | null> {
+  if (parent == null) {
+    return null;
+  }
+  const Page = mongoose.model<PageDoc, PageModel>('Page');
+  const parentPage = await Page.findById(parent).select('_id path').lean();
+  if (parentPage == null) {
+    return null;
+  }
+  return {
+    title: titleFromPath(parentPage.path),
+    mdUrl: toPermalinkMdUrl(String(parentPage._id)),
+  };
+}
+
+/**
+ * Assemble the successful (200) markdown document for a resolved, viewable page.
+ *
+ * The finder returns the page WITHOUT populated revision / lastUpdateUser /
+ * parent (all ObjectIds), so this route helper performs the populate itself --
+ * the GROWI convention for read endpoints (see respond-with-single-page.ts).
+ */
+async function buildOkResolution(
+  page: PageDoc,
+  user: HydratedDocument<IUser> | undefined,
+  origin: string,
+): Promise<MarkdownResolution> {
+  // Populate body + updater. Empty container pages have no revision; populate
+  // leaves it null rather than throwing, so this is safe for empty pages too.
+  page.initLatestRevisionField();
+  const populated = await page.populateDataToShowRevision(false);
+
+  const pageId = String(populated._id);
+  const isEmpty = populated.isEmpty === true;
+  const body = isEmpty ? '' : (populated.revision?.body ?? '');
+
+  const updater = populated.lastUpdateUser;
+  const updatedByUsername =
+    updater != null ? (serializeUserSecurely(updater).username ?? '') : '';
+  const updatedAt =
+    populated.updatedAt != null
+      ? new Date(populated.updatedAt).toISOString()
+      : '';
+
+  const parent = await resolveParentLink(populated.parent);
+
+  // Children: at most MARKDOWN_FOOTER_MAX_LINKS links loaded, plus the exact
+  // viewer-aware direct-child total (the two share addViewerCondition in the
+  // service, so grant logic is not duplicated). descendantCount is separate.
+  const children = (
+    await pageListingService.findLimitedChildrenByParentIdAndViewer(
+      pageId,
+      user,
+      MARKDOWN_FOOTER_MAX_LINKS,
+    )
+  ).map(toFooterLink);
+  const childrenTotal =
+    await pageListingService.countChildrenByParentIdAndViewer(pageId, user);
+
+  // Siblings: only when the page has a parent (root pages have none). Derived
+  // from the parent id via the same methods; the page itself is excluded from
+  // the list and subtracted from the count so the remainder message stays
+  // truthful (Requirement 4.4 / 4.8).
+  let siblings: FooterLink[] = [];
+  let siblingsTotal = 0;
+  if (populated.parent != null) {
+    const parentId = String(populated.parent);
+    const rawSiblings =
+      await pageListingService.findLimitedChildrenByParentIdAndViewer(
+        parentId,
+        user,
+        MARKDOWN_FOOTER_MAX_LINKS,
+      );
+    siblings = rawSiblings
+      .filter((sibling) => String(sibling._id) !== pageId)
+      .map(toFooterLink);
+    const siblingCountIncludingSelf =
+      await pageListingService.countChildrenByParentIdAndViewer(parentId, user);
+    siblingsTotal = Math.max(0, siblingCountIncludingSelf - 1);
+  }
+
+  const markdown = buildPageMarkdown({
+    path: populated.path,
+    origin,
+    permalinkUrl: `${origin}/${pageId}`,
+    canonicalUrl: `${origin}${encodeSpaces(populated.path) ?? populated.path}`,
+    body,
+    isEmpty,
+    parent,
+    children,
+    childrenTotal,
+    descendantCount: populated.descendantCount ?? 0,
+    siblings,
+    siblingsTotal,
+    pageListApiHint: `${origin}/_api/v3/page-listing/children?id=${pageId}`,
+    updatedAt,
+    updatedByUsername,
+  });
+
+  logger.debug({ pageId }, 'markdown resolution: ok');
+  return { type: 'ok', markdown };
+}
+
+/**
+ * Map a finder result into a markdown resolution: viewable -> ok, present but
+ * not viewable -> forbidden, otherwise notFound. Authorization decisions come
+ * ONLY from the viewer-aware finder (never hand-rolled here).
+ */
+async function buildFromResult(
+  result: FinderResult,
+  user: HydratedDocument<IUser> | undefined,
+  origin: string,
+): Promise<MarkdownResolution> {
+  if (result.data != null) {
+    return await buildOkResolution(result.data, user, origin);
+  }
+  if (result.meta.isForbidden) {
+    logger.debug('markdown resolution: forbidden');
+    return { type: 'forbidden', markdown: buildErrorMarkdown('forbidden') };
+  }
+  logger.debug('markdown resolution: notFound');
+  return { type: 'notFound', markdown: buildErrorMarkdown('notFound') };
+}
+
+/**
+ * Resolve an incoming request for a page's Markdown representation.
+ *
+ * Preconditions: the authorization middleware has already run, so `user` is a
+ * session/PAT/guest-resolved viewer (or undefined for anonymous). The page
+ * returned by the finder is not yet populated.
+ * Postconditions: `ok` / `forbidden` / `notFound` carry a `text/markdown` body;
+ * `passthrough` carries none and the route factory falls through via next().
+ * Invariant: `revision.body` is passed through verbatim.
+ */
+export async function respondWithPageMarkdown(
+  crowi: Crowi,
+  input: RespondWithPageMarkdownInput,
+): Promise<MarkdownResolution> {
+  const { reqPath, accept, formatQuery, user, origin } = input;
+  const intent = parseMarkdownRequest(reqPath, accept, formatQuery);
+
+  // Defensive: the route factory calls next() for 'none' before invoking this
+  // helper, so this branch is not reached in practice. Return passthrough so
+  // the caller falls through to the existing HTML delegate rather than emitting
+  // a bogus markdown response.
+  if (intent.kind === 'none') {
+    return { type: 'passthrough' };
+  }
+
+  if (intent.kind === 'permalink') {
+    return buildFromResult(
+      await resolvePage(crowi, { pageId: intent.pageId, path: null }, user),
+      user,
+      origin,
+    );
+  }
+
+  // intent.kind === 'path'
+  if (intent.explicit) {
+    // Explicit (Accept / ?format=md): resolve the requested path AS-IS -- never
+    // strip a trailing `.md` (Requirement 2.4).
+    return buildFromResult(
+      await resolvePage(crowi, { pageId: null, path: intent.path }, user),
+      user,
+      origin,
+    );
+  }
+
+  // `.md` suffix sugar (literal-wins, owned here). First resolve the ORIGINAL
+  // path R; if a real page exists there -- viewable OR forbidden -- hand off to
+  // the existing HTML flow (Requirement 2.1). Otherwise strip the trailing `.md`
+  // and resolve the base path (Requirement 2.2 / 2.3).
+  const literal = await resolvePage(
+    crowi,
+    { pageId: null, path: intent.path },
+    user,
+  );
+  if (pageExists(literal)) {
+    logger.debug(
+      { reqPath },
+      'markdown resolution: passthrough (literal .md page exists)',
+    );
+    return { type: 'passthrough' };
+  }
+
+  const base = intent.path.endsWith(MARKDOWN_SUFFIX)
+    ? intent.path.slice(0, -MARKDOWN_SUFFIX.length)
+    : intent.path;
+  if (base.length === 0) {
+    // Path was exactly the suffix -> nothing to resolve.
+    logger.debug({ reqPath }, 'markdown resolution: notFound (empty base)');
+    return { type: 'notFound', markdown: buildErrorMarkdown('notFound') };
+  }
+  return buildFromResult(
+    await resolvePage(crowi, { pageId: null, path: base }, user),
+    user,
+    origin,
+  );
+}

--- a/apps/app/src/server/service/page-listing/page-listing.integ.ts
+++ b/apps/app/src/server/service/page-listing/page-listing.integ.ts
@@ -429,4 +429,207 @@ describe('page-listing store integration tests', () => {
       });
     });
   });
+
+  describe('viewer-aware limited children for markdown footer', () => {
+    const GRANT_PUBLIC = 1;
+    const GRANT_OWNER = 4;
+
+    let parentPage: HydratedDocument<IPage>;
+    let otherUser: HydratedDocument<IUser>;
+
+    // 5 public children (visible to everyone), lexicographically first
+    const publicChildPaths = [
+      '/parent/aaa-01',
+      '/parent/aaa-02',
+      '/parent/aaa-03',
+      '/parent/aaa-04',
+      '/parent/aaa-05',
+    ];
+    // empty container page (public) — footer navigation must not stop at containers
+    const containerChildPath = '/parent/container';
+    // owner-restricted page visible to testUser only (invisible to guest)
+    const ownedByTestUserPath = '/parent/mmm-own-testuser';
+    // owner-restricted pages owned by another user — invisible to testUser AND guest
+    const ownedByOtherUserPaths = [
+      '/parent/zzz-secret-01',
+      '/parent/zzz-secret-02',
+    ];
+
+    // Visible direct-child totals derived from the seed above:
+    //   testUser: 5 public + 1 container + 1 owned-by-testUser = 7
+    //   guest:    5 public + 1 container                       = 6
+    //   invisible to both: 2 owned-by-otherUser
+    //   total docs under /parent: 9
+    const VISIBLE_TO_TESTUSER = 7;
+    const VISIBLE_TO_GUEST = 6;
+
+    beforeEach(async () => {
+      otherUser = await User.create({
+        name: 'Other User',
+        username: 'otheruser',
+        email: 'other@example.com',
+        lang: 'en_US',
+      });
+
+      parentPage = await Page.create({
+        path: '/parent',
+        revision: new mongoose.Types.ObjectId(),
+        creator: testUser._id,
+        lastUpdateUser: testUser._id,
+        grant: GRANT_PUBLIC,
+        isEmpty: false,
+        descendantCount: 9,
+        parent: rootPage._id,
+      });
+
+      await Page.insertMany(
+        publicChildPaths.map((path) => ({
+          path,
+          revision: new mongoose.Types.ObjectId(),
+          creator: testUser._id,
+          lastUpdateUser: testUser._id,
+          grant: GRANT_PUBLIC,
+          isEmpty: false,
+          descendantCount: 0,
+          parent: parentPage._id,
+        })),
+      );
+
+      // empty container child: no revision, isEmpty true
+      await Page.create({
+        path: containerChildPath,
+        creator: testUser._id,
+        grant: GRANT_PUBLIC,
+        isEmpty: true,
+        descendantCount: 1,
+        parent: parentPage._id,
+      });
+
+      await Page.create({
+        path: ownedByTestUserPath,
+        revision: new mongoose.Types.ObjectId(),
+        creator: testUser._id,
+        lastUpdateUser: testUser._id,
+        grant: GRANT_OWNER,
+        grantedUsers: [testUser._id],
+        isEmpty: false,
+        descendantCount: 0,
+        parent: parentPage._id,
+      });
+
+      await Page.insertMany(
+        ownedByOtherUserPaths.map((path) => ({
+          path,
+          revision: new mongoose.Types.ObjectId(),
+          creator: otherUser._id,
+          lastUpdateUser: otherUser._id,
+          grant: GRANT_OWNER,
+          grantedUsers: [otherUser._id],
+          isEmpty: false,
+          descendantCount: 0,
+          parent: parentPage._id,
+        })),
+      );
+    });
+
+    describe('findLimitedChildrenByParentIdAndViewer', () => {
+      test('should return at most `limit` viewer-visible direct children (invisible ones excluded)', async () => {
+        const limit = 3;
+        const children =
+          await pageListingService.findLimitedChildrenByParentIdAndViewer(
+            parentPage._id.toString(),
+            testUser,
+            limit,
+          );
+
+        // limited to `limit` even though 7 are visible
+        expect(children).toHaveLength(limit);
+
+        const paths = children.map((c) => c.path);
+        // none of the invisible (owner-restricted to otherUser) pages leak
+        ownedByOtherUserPaths.forEach((secret) => {
+          expect(paths).not.toContain(secret);
+        });
+        // deterministic ascending-path order → the lexicographically-first 3
+        expect(paths).toEqual([
+          '/parent/aaa-01',
+          '/parent/aaa-02',
+          '/parent/aaa-03',
+        ]);
+      });
+
+      test('should include empty container children and stay consistent with the count', async () => {
+        // fetch with a generous limit to retrieve every visible child
+        const children =
+          await pageListingService.findLimitedChildrenByParentIdAndViewer(
+            parentPage._id.toString(),
+            testUser,
+            100,
+          );
+        const count = await pageListingService.countChildrenByParentIdAndViewer(
+          parentPage._id.toString(),
+          testUser,
+        );
+
+        expect(children).toHaveLength(VISIBLE_TO_TESTUSER);
+        expect(children).toHaveLength(count);
+
+        const paths = children.map((c) => c.path);
+        // the empty container is a direct child and must be present
+        expect(paths).toContain(containerChildPath);
+
+        children.forEach((child) => {
+          validatePageForTreeItem(child);
+        });
+      });
+
+      test('guest (no user) sees only publicly visible children', async () => {
+        const guestChildren =
+          await pageListingService.findLimitedChildrenByParentIdAndViewer(
+            parentPage._id.toString(),
+            undefined,
+            100,
+          );
+
+        const guestPaths = guestChildren.map((c) => c.path);
+        expect(guestChildren).toHaveLength(VISIBLE_TO_GUEST);
+        // owner-restricted pages (incl. the one owned by testUser) are hidden from guests
+        expect(guestPaths).not.toContain(ownedByTestUserPath);
+        ownedByOtherUserPaths.forEach((secret) => {
+          expect(guestPaths).not.toContain(secret);
+        });
+        // the public container is still visible to guests
+        expect(guestPaths).toContain(containerChildPath);
+      });
+    });
+
+    describe('countChildrenByParentIdAndViewer', () => {
+      test('should return the exact number of viewer-visible direct children, excluding invisible pages and ignoring the link limit', async () => {
+        const count = await pageListingService.countChildrenByParentIdAndViewer(
+          parentPage._id.toString(),
+          testUser,
+        );
+
+        // 7 = 9 total direct children minus the 2 restricted to otherUser.
+        // It is NOT capped by any link limit and NOT the full 9.
+        expect(count).toBe(VISIBLE_TO_TESTUSER);
+      });
+
+      test('should be viewer-aware: a guest counts fewer children than a member', async () => {
+        const memberCount =
+          await pageListingService.countChildrenByParentIdAndViewer(
+            parentPage._id.toString(),
+            testUser,
+          );
+        const guestCount =
+          await pageListingService.countChildrenByParentIdAndViewer(
+            parentPage._id.toString(),
+          );
+
+        expect(memberCount).toBe(VISIBLE_TO_TESTUSER);
+        expect(guestCount).toBe(VISIBLE_TO_GUEST);
+        expect(guestCount).toBeLessThan(memberCount);
+      });
+    });
+  });
 });

--- a/apps/app/src/server/service/page-listing/page-listing.ts
+++ b/apps/app/src/server/service/page-listing/page-listing.ts
@@ -27,6 +27,15 @@ export interface IPageListingService {
     showPagesRestrictedByOwner?: boolean,
     showPagesRestrictedByGroup?: boolean,
   ): Promise<IPageForTreeItem[]>;
+  findLimitedChildrenByParentIdAndViewer(
+    parentId: string,
+    user: IUser | undefined,
+    limit: number,
+  ): Promise<IPageForTreeItem[]>;
+  countChildrenByParentIdAndViewer(
+    parentId: string,
+    user?: IUser,
+  ): Promise<number>;
 }
 
 let pageOperationService: IPageOperationService;
@@ -106,6 +115,76 @@ class PageListingService implements IPageListingService {
     return injectedPages.map((page) =>
       Object.assign(page, { _id: page._id.toString() }),
     );
+  }
+
+  /**
+   * Return at most `limit` viewer-visible direct children of the given parent page id,
+   * limited at the query level (never by slicing an all-loaded array) so memory stays
+   * bounded even when a page has many children. Mirrors the semantics of
+   * findChildrenByParentPathOrIdAndViewer (viewer grant filter, empty container pages
+   * included, ascending path order) but resolves strictly by parent id — no path regex.
+   * Intended for the page-markdown footer, where only the first N children are linked.
+   */
+  async findLimitedChildrenByParentIdAndViewer(
+    parentId: string,
+    user: IUser | undefined,
+    limit: number,
+  ): Promise<IPageForTreeItem[]> {
+    const Page = mongoose.model<HydratedDocument<PageDocument>, PageModel>(
+      'Page',
+    );
+
+    // Use $eq for user-controlled sources. see: https://codeql.github.com/codeql-query-help/javascript/js-sql-injection/#recommendation
+    const queryBuilder = new PageQueryBuilder(
+      Page.find({ parent: { $eq: parentId } }),
+      true,
+    );
+    // Share the exact viewer condition with countChildrenByParentIdAndViewer so the
+    // grant logic is not re-implemented and the two can never drift apart.
+    await queryBuilder.addViewerCondition(user);
+
+    const pages: HydratedDocument<Omit<IPageForTreeItem, 'processData'>>[] =
+      await queryBuilder
+        .addConditionToPagenate(0, limit, 'path')
+        .query.select(
+          '_id path parent revision descendantCount grant isEmpty wip',
+        )
+        .lean()
+        .exec();
+
+    const injectedPages = await this.injectProcessDataIntoPagesByActionTypes(
+      pages,
+      [PageActionType.Rename],
+    );
+
+    // Type-safe conversion to IPageForTreeItem
+    return injectedPages.map((page) =>
+      Object.assign(page, { _id: page._id.toString() }),
+    );
+  }
+
+  /**
+   * Return the exact number of viewer-visible direct children of the given parent page id.
+   * Uses countDocuments({ parent: id }) with the same addViewerCondition applied to the
+   * limited fetch above, so the total reflects the identical grant filter (no double
+   * implementation) and is not affected by the footer link limit.
+   */
+  async countChildrenByParentIdAndViewer(
+    parentId: string,
+    user?: IUser,
+  ): Promise<number> {
+    const Page = mongoose.model<HydratedDocument<PageDocument>, PageModel>(
+      'Page',
+    );
+
+    // Use $eq for user-controlled sources. see: https://codeql.github.com/codeql-query-help/javascript/js-sql-injection/#recommendation
+    const queryBuilder = new PageQueryBuilder(
+      Page.countDocuments({ parent: { $eq: parentId } }),
+      true,
+    );
+    await queryBuilder.addViewerCondition(user);
+
+    return queryBuilder.query.exec();
   }
 
   /**

--- a/apps/app/src/utils/page-markdown-alternate.spec.ts
+++ b/apps/app/src/utils/page-markdown-alternate.spec.ts
@@ -1,0 +1,51 @@
+import {
+  selectAlternateMdUrl,
+  toMarkdownAlternateLinkHeader,
+} from './page-markdown-alternate';
+import { toPermalinkMdUrl } from './page-markdown-url';
+
+describe('selectAlternateMdUrl', () => {
+  test('returns the permalink-form ".md" URL when a pageId is given', () => {
+    const result = selectAlternateMdUrl('507f1f77bcf86cd799439011', '/foo/bar');
+    expect(result).toBe('/507f1f77bcf86cd799439011.md');
+  });
+
+  test('prefers the pageId over the pathname when both are given', () => {
+    const result = selectAlternateMdUrl('507f1f77bcf86cd799439011', '/foo/bar');
+    expect(result).toBe('/507f1f77bcf86cd799439011.md');
+  });
+
+  test('falls back to the path-form ".md" URL when no pageId is given (empty/container page)', () => {
+    const result = selectAlternateMdUrl(undefined, '/foo/bar');
+    expect(result).toBe('/foo/bar.md');
+  });
+
+  test('returns null when neither a pageId nor a pathname is available', () => {
+    expect(selectAlternateMdUrl(undefined, undefined)).toBeNull();
+    expect(selectAlternateMdUrl(null, null)).toBeNull();
+  });
+
+  test('returns null for an empty-string pathname (avoids a broken "/.md" href)', () => {
+    expect(selectAlternateMdUrl(undefined, '')).toBeNull();
+  });
+});
+
+describe('toMarkdownAlternateLinkHeader', () => {
+  test('wraps the URL in the RFC 8288 alternate Link header value', () => {
+    const result = toMarkdownAlternateLinkHeader(
+      '/507f1f77bcf86cd799439011.md',
+    );
+    expect(result).toBe(
+      '</507f1f77bcf86cd799439011.md>; rel="alternate"; type="text/markdown"',
+    );
+  });
+
+  test('produces the permalink-form Link header value from a pageId (Requirement 6.2)', () => {
+    const result = toMarkdownAlternateLinkHeader(
+      toPermalinkMdUrl('507f1f77bcf86cd799439011'),
+    );
+    expect(result).toBe(
+      '</507f1f77bcf86cd799439011.md>; rel="alternate"; type="text/markdown"',
+    );
+  });
+});

--- a/apps/app/src/utils/page-markdown-alternate.ts
+++ b/apps/app/src/utils/page-markdown-alternate.ts
@@ -1,0 +1,35 @@
+import { toPathMdUrl, toPermalinkMdUrl } from './page-markdown-url';
+
+/**
+ * Select the ".md" alternate URL for a page's machine-facing discovery link
+ * (the HTML <head> `<link rel="alternate">`).
+ *
+ * Prefers the permalink form (`/{pageId}.md`) when the page id is known;
+ * otherwise falls back to the path form (`{path}.md`) — the case of empty
+ * (container) pages whose props carry no entity `_id` (Requirement 6.1).
+ * Returns null when neither is available (rendered without page context), so
+ * callers can omit the link rather than emit a broken href.
+ *
+ * URLs are relative (no origin), matching Requirement 6.1's `href="/{pageId}.md"`.
+ */
+export const selectAlternateMdUrl = (
+  pageId: string | null | undefined,
+  pathname: string | null | undefined,
+): string | null => {
+  if (pageId != null) {
+    return toPermalinkMdUrl(pageId);
+  }
+  if (pathname != null && pathname.length > 0) {
+    return toPathMdUrl(pathname);
+  }
+  return null;
+};
+
+/**
+ * Format an RFC 8288 "Link" response header value pointing at the page's
+ * Markdown alternate: `<{mdUrl}>; rel="alternate"; type="text/markdown"`
+ * (Requirement 6.2).
+ */
+export const toMarkdownAlternateLinkHeader = (mdUrl: string): string => {
+  return `<${mdUrl}>; rel="alternate"; type="text/markdown"`;
+};

--- a/apps/app/src/utils/page-markdown-url.spec.ts
+++ b/apps/app/src/utils/page-markdown-url.spec.ts
@@ -1,0 +1,58 @@
+import { toPathMdUrl, toPermalinkMdUrl } from './page-markdown-url';
+
+describe('toPermalinkMdUrl', () => {
+  test('returns a relative "/{pageId}.md" URL when no origin is given', () => {
+    const result = toPermalinkMdUrl('507f1f77bcf86cd799439011');
+    expect(result).toBe('/507f1f77bcf86cd799439011.md');
+  });
+
+  test('prefixes the origin when given', () => {
+    const result = toPermalinkMdUrl(
+      '507f1f77bcf86cd799439011',
+      'https://example.com',
+    );
+    expect(result).toBe('https://example.com/507f1f77bcf86cd799439011.md');
+  });
+});
+
+describe('toPathMdUrl', () => {
+  test('appends ".md" to a plain path with no origin', () => {
+    const result = toPathMdUrl('/foo/bar');
+    expect(result).toBe('/foo/bar.md');
+  });
+
+  test('prefixes the origin when given', () => {
+    const result = toPathMdUrl('/foo/bar', 'https://example.com');
+    expect(result).toBe('https://example.com/foo/bar.md');
+  });
+
+  test('inserts ".md" before a query string', () => {
+    const result = toPathMdUrl('/foo/bar?rev=1');
+    expect(result).toBe('/foo/bar.md?rev=1');
+  });
+
+  test('inserts ".md" before a hash fragment', () => {
+    const result = toPathMdUrl('/foo#sec');
+    expect(result).toBe('/foo.md#sec');
+  });
+
+  test('inserts ".md" before both a query string and a trailing hash fragment', () => {
+    const result = toPathMdUrl('/foo/bar?rev=1#sec');
+    expect(result).toBe('/foo/bar.md?rev=1#sec');
+  });
+
+  test('appends ".md" unconditionally even when the path already ends with ".md" (Requirement 7.3)', () => {
+    const result = toPathMdUrl('/README.md');
+    expect(result).toBe('/README.md.md');
+  });
+
+  test('appends ".md" unconditionally before a query string when the path already ends with ".md"', () => {
+    const result = toPathMdUrl('/README.md?rev=1');
+    expect(result).toBe('/README.md.md?rev=1');
+  });
+
+  test('encodes spaces in the path portion without touching the query/hash', () => {
+    const result = toPathMdUrl('/foo bar?q=a b#sec tion');
+    expect(result).toBe('/foo%20bar.md?q=a b#sec tion');
+  });
+});

--- a/apps/app/src/utils/page-markdown-url.ts
+++ b/apps/app/src/utils/page-markdown-url.ts
@@ -1,0 +1,43 @@
+import { pagePathUtils } from '@growi/core/dist/utils';
+
+const { encodeSpaces } = pagePathUtils;
+
+/**
+ * Build the permalink-style ".md" URL for a page: "/{pageId}.md".
+ *
+ * This is the single source of truth for the permalink-form ".md" URL shape,
+ * shared by the CopyDropdown UI, the page Head alternate link, and the
+ * server-side navigation footer.
+ *
+ * @param pageId - the page's permalink ID
+ * @param origin - optional origin (protocol + host) to produce an absolute URL;
+ *   omit to produce a relative URL
+ */
+export const toPermalinkMdUrl = (pageId: string, origin?: string): string => {
+  return `${origin ?? ''}/${pageId}.md`;
+};
+
+/**
+ * Build the path-style ".md" URL for a page.
+ *
+ * ".md" is inserted immediately before the query string and/or hash fragment,
+ * if present, so the suffix lands on the path rather than the query/hash
+ * (e.g. "/foo/bar?rev=1" -> "/foo/bar.md?rev=1", "/foo#sec" -> "/foo.md#sec").
+ * ".md" is appended unconditionally, even when the path already ends with
+ * ".md" (e.g. "/README.md" -> "/README.md.md"); resolving that collision
+ * against real pages is the server's responsibility (Requirement 2 / 7.3).
+ *
+ * @param pagePathUrl - the page path, optionally including an origin and/or
+ *   a query string/hash fragment
+ * @param origin - optional origin (protocol + host) to prefix; omit if
+ *   pagePathUrl already includes one, or to produce a relative URL
+ */
+export const toPathMdUrl = (pagePathUrl: string, origin?: string): string => {
+  const separatorIndex = pagePathUrl.search(/[?#]/);
+  const path =
+    separatorIndex === -1 ? pagePathUrl : pagePathUrl.slice(0, separatorIndex);
+  const queryAndHash =
+    separatorIndex === -1 ? '' : pagePathUrl.slice(separatorIndex);
+
+  return `${origin ?? ''}${encodeSpaces(path) ?? path}.md${queryAndHash}`;
+};


### PR DESCRIPTION
## 概要

GROWI の各ページに対して **Markdown 表現を返す HTTP エンドポイント**を追加します。URL を渡された対話型 AI エージェント（および認証付きツール）が、JavaScript を実行せずに 1 回の GET でページ本文と近傍ナビゲーション（親・子・兄弟・正規 URL）を取得できるようにするものです。

Spec: `.kiro/specs/page-markdown-endpoint/`（requirements / design / research / tasks を同梱）

## 主な変更

### サーバ
- **`GET /{pageId}.md`・`GET {pagePath}.md`・`Accept: text/markdown`・`?format=md`** で最新リビジョン本文を `text/markdown; charset=utf-8` で返す interception ルートを `routes/index.js` の catch-all 直前に登録（非対象トラフィックは `next('route')` で素通し）
- 認可は既存の `accessTokenParser([SCOPE.READ.FEATURES.PAGE], { acceptLegacy: true })`＋ゲスト許可 `loginRequired`＋viewer 付きファインダを再利用（独自認可なし）。権限外 403・非存在 404 のエラー本文には認証付き取得 / GROWI MCP への案内を Markdown で同梱
- `.md` サフィックスと実在ページの衝突は **literal-wins**（実在すれば従来の HTML 配信へ passthrough、`Accept`/`?format=md` 明示時はサフィックス除去なし）
- 本文末尾に近傍ナビゲーション footer を付加: 正規 URL・permalink・親・直下子（リンク＋正確な総数）・子孫合計 `descendantCount`・兄弟・更新日時／更新者・ページ一覧 API への案内。列挙は `MARKDOWN_FOOTER_MAX_LINKS`(=50) 件で頭打ちし、超過時は総数と残数を明記
- page-listing サービスに **メモリ非全件の子取得**（クエリレベル limit）と **viewer-aware な直下子カウント**（`addViewerCondition` を find/count で共有）を追加
- 空（コンテナ）ページはエラーにせず「本文なし」の一文＋footer を返却

### 発見導線
- ページ HTML の `<head>` に `<link rel="alternate" type="text/markdown">`、HTTP レスポンスに `Link` ヘッダを付与（空ページ・本文 CSR ページ含む）
- CopyDropdown に「Markdown URL (.md)」項目を追加（共有リンクモードでは非表示。i18n は英語ファースト、他言語翻訳は後続）

## 検証

- 全タスクをテスト先行（RED→GREEN）で実装。ユニット＋統合（supertest / 実 DB）で 100 件超のテストを追加
- `turbo run test --filter @growi/app` → 370 files / 4150 tests green、`turbo run lint build --filter @growi/app` → green
- dev サーバでの実測 smoke: 3 つの URL 形態 200、404 案内、通常 HTML 配信の非干渉（`Accept: */*` は素通し）、`Link` ヘッダ／head alternate の出力、PAT 認証 200 を確認

## 既知の限界（設計で許容済み）

- トップページ `/` への `Accept`/`?format=md` は既存 `/` ルートが先に解決するため非対応（`/{pageId}.md` permalink 形で代替可能）
- lsx 等の動的展開・相対リンク絶対化は行わず `revision.body` を逐語返却（Non-Goal）

🤖 Generated with [Claude Code](https://claude.com/claude-code)