### PR TITLE
fix(editor): Disable bracketMatching to prevent IME composition rendering corruption (Reverts #10900)

### DIFF
--- a/packages/editor/src/client/services/use-codemirror-editor/use-codemirror-editor.ts
+++ b/packages/editor/src/client/services/use-codemirror-editor/use-codemirror-editor.ts
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { bracketMatching } from '@codemirror/language';
 import type { EditorState } from '@codemirror/state';
 import type { EditorView } from '@codemirror/view';
 import { type UseCodeMirror, useCodeMirror } from '@uiw/react-codemirror';
@@ -61,15 +60,7 @@ export const useCodeMirrorEditor = (
             dropCursor: false,
             highlightActiveLine: false,
             highlightActiveLineGutter: false,
-            // Disable default bracketMatching and re-add with afterCursor: false
-            // to prevent a rendering bug where text visually disappears after IME
-            // composition inside brackets on non-Safari browsers (e.g. Chrome).
-            // When afterCursor is true (default), bracketMatching decorates brackets
-            // ahead of the cursor immediately after composition ends, which corrupts
-            // CodeMirror's DOM reconciliation.
-            bracketMatching: false,
           },
-          extensions: [bracketMatching({ afterCursor: false })],
           // ------- End -------
         },
         props ?? {},


### PR DESCRIPTION
Reverts growilabs/growi#10900

## Task
https://redmine.weseek.co.jp/issues/187189