### PR TITLE
fix(plantuml): Stop leaking PlantUML theme YAML front matter into diagram source

### DIFF
--- a/apps/app/src/features/plantuml/services/plantuml.spec.ts
+++ b/apps/app/src/features/plantuml/services/plantuml.spec.ts
@@ -1,4 +1,6 @@
-import type { Code, Root } from 'mdast';
+import remarkParse from 'remark-parse';
+import { unified } from 'unified';
+import { visit } from 'unist-util-visit';
 import { describe, expect, it, vi } from 'vitest';
 
 import { remarkPlugin } from './plantuml';
@@ -16,23 +18,25 @@ describe('remarkPlugin', () => {
     ['dark', true],
   ])('does not prepend theme metadata to the plantuml source in %s mode', (_modeLabel, isDarkMode) => {
     const userDiagram = 'A -> B: hello';
-    const codeNode: Code = {
-      type: 'code',
-      lang: 'plantuml',
-      value: userDiagram,
-    };
-    const tree: Root = { type: 'root', children: [codeNode] };
+    const markdown = ['```plantuml', userDiagram, '```', ''].join('\n');
 
-    const transformer = remarkPlugin({
+    const processor = unified().use(remarkParse).use(remarkPlugin, {
       plantumlUri: 'https://plantuml.example.com',
       isDarkMode,
     });
-    transformer(tree, { data: {} } as Parameters<typeof transformer>[1]);
+
+    const tree = processor.parse(markdown);
+    processor.runSync(tree);
+
+    let codeValue: string | undefined;
+    visit(tree, 'code', (node) => {
+      codeValue = node.value;
+    });
 
     // The theme is still prepended, but must never carry a YAML front matter
     // block into the source sent to the PlantUML server.
-    expect(codeNode.value).not.toMatch(/^\s*---/);
-    expect(codeNode.value).not.toContain('---\n');
-    expect(codeNode.value).toContain(userDiagram);
+    expect(codeValue).not.toMatch(/^\s*---/);
+    expect(codeValue).not.toContain('---\n');
+    expect(codeValue).toContain(userDiagram);
   });
 });

--- a/apps/app/src/features/plantuml/services/plantuml.spec.ts
+++ b/apps/app/src/features/plantuml/services/plantuml.spec.ts
@@ -1,0 +1,38 @@
+import type { Code, Root } from 'mdast';
+import { describe, expect, it, vi } from 'vitest';
+
+import { remarkPlugin } from './plantuml';
+
+vi.mock('@akebifiky/remark-simple-plantuml', () => ({
+  // The real plugin would convert the 'code' node into an 'image' node.
+  // Stubbed as a no-op so the test can inspect the 'code' node value
+  // exactly as it is handed off for PlantUML rendering.
+  default: vi.fn(() => vi.fn()),
+}));
+
+describe('remarkPlugin', () => {
+  it.each([
+    ['light', false],
+    ['dark', true],
+  ])('does not prepend theme metadata to the plantuml source in %s mode', (_modeLabel, isDarkMode) => {
+    const userDiagram = 'A -> B: hello';
+    const codeNode: Code = {
+      type: 'code',
+      lang: 'plantuml',
+      value: userDiagram,
+    };
+    const tree: Root = { type: 'root', children: [codeNode] };
+
+    const transformer = remarkPlugin({
+      plantumlUri: 'https://plantuml.example.com',
+      isDarkMode,
+    });
+    transformer(tree, { data: {} } as Parameters<typeof transformer>[1]);
+
+    // The theme is still prepended, but must never carry a YAML front matter
+    // block into the source sent to the PlantUML server.
+    expect(codeNode.value).not.toMatch(/^\s*---/);
+    expect(codeNode.value).not.toContain('---\n');
+    expect(codeNode.value).toContain(userDiagram);
+  });
+});

--- a/apps/app/src/features/plantuml/themes/carbon-gray-dark.puml.ts
+++ b/apps/app/src/features/plantuml/themes/carbon-gray-dark.puml.ts
@@ -1,18 +1,19 @@
 import commonStyles from './carbon-gray-common.puml';
 
+/**
+ * ---
+ * name: growi-carbon-gray-dark
+ * display_name: GROWI Carbon Gray
+ * description: A gray theme using the IBM Carbon Design Gray palette for GROWI dark themes
+ * author: Yuki Takei
+ * release:
+ * license:
+ * version:
+ * source:
+ * inspiration: https://carbondesignsystem.com/elements/color/overview/
+ * ---
+ */
 const style = `
----
-name: growi-carbon-gray-dark
-display_name: GROWI Carbon Gray
-description: A gray theme using the IBM Carbon Design Gray palette for GROWI dark themes
-author: Yuki Takei
-release:
-license:
-version:
-source:
-inspiration: https://carbondesignsystem.com/elements/color/overview/
----
-
 !$THEME = "growi-carbon-gray-dark"
 
 '!$BGCOLOR = "#f5f5f5"

--- a/apps/app/src/features/plantuml/themes/carbon-gray-light.puml.ts
+++ b/apps/app/src/features/plantuml/themes/carbon-gray-light.puml.ts
@@ -1,18 +1,19 @@
 import commonStyles from './carbon-gray-common.puml';
 
+/**
+ * ---
+ * name: growi-carbon-gray-light
+ * display_name: GROWI Carbon Gray
+ * description: A gray theme using the IBM Carbon Design Gray palette for GROWI light themes
+ * author: Yuki Takei
+ * release:
+ * license:
+ * version:
+ * source:
+ * inspiration: https://carbondesignsystem.com/elements/color/overview/
+ * ---
+ */
 const style = `
----
-name: growi-carbon-gray-light
-display_name: GROWI Carbon Gray
-description: A gray theme using the IBM Carbon Design Gray palette for GROWI light themes
-author: Yuki Takei
-release:
-license:
-version:
-source:
-inspiration: https://carbondesignsystem.com/elements/color/overview/
----
-
 !$THEME = "growi-carbon-gray-light"
 
 '!$BGCOLOR = "#f5f5f5"


### PR DESCRIPTION
## Summary

When `PLANTUML_URI` is configured, GROWI prepends a built-in Carbon Gray theme to every user-authored PlantUML diagram before sending it to the PlantUML server (`remarkPlugin` in `apps/app/src/features/plantuml/services/plantuml.ts`). The `growi-carbon-gray-light` and `growi-carbon-gray-dark` theme source files kept their YAML front matter (`name`, `display_name`, `description`, ...) directly inside the template literal that becomes the actual PlantUML source, so that metadata block was sent to the PlantUML server as part of the diagram. PCRE2 (used by the PlantUML server) doesn't understand YAML front matter, so it returned `Syntax Error?` and the diagram failed to render.

## Root Cause

- `apps/app/src/features/plantuml/services/plantuml.ts:26-29` prepends the theme string directly to the user's diagram with no stripping.
- `apps/app/src/features/plantuml/themes/carbon-gray-light.puml.ts` and `carbon-gray-dark.puml.ts` had the front matter inside the backtick template literal, so it leaked into the real PlantUML source.
- By contrast, `apps/app/src/features/plantuml/themes/carbon-gray-common.puml.ts` already wraps the same kind of front matter in a JS `/** ... */` comment, keeping it out of the template literal — the light/dark theme files were inconsistent with this pattern.
- No code in the repository reads these front matter fields, so moving them into a comment removes the bug with no functional loss.

## Changes

- `apps/app/src/features/plantuml/themes/carbon-gray-light.puml.ts`: move the front matter into a JS comment above the template literal.
- `apps/app/src/features/plantuml/themes/carbon-gray-dark.puml.ts`: same change.
- `apps/app/src/features/plantuml/services/plantuml.spec.ts`: add a regression test asserting `remarkPlugin` never prepends a YAML front matter block (`---`) to the PlantUML source handed to the renderer, for both light and dark themes. Verified this test fails against the pre-fix theme files and passes after the fix.

## Test Plan

- [x] `pnpm vitest run plantuml.spec` — new regression test passes
- [x] `pnpm vitest run PlantUmlViewer.spec` — existing PlantUML component tests still pass
- [x] `npx biome check apps/app/src/features/plantuml/` — no new lint errors (pre-existing `noDefaultExport` warnings on the theme files are unrelated to this change)

Closes #11438


---
_Generated by [Claude Code](https://claude.ai/code/session_011FeGvdkyYfsmUqT6oHVP15)_