### PR TITLE
imprv(mastra): reword AI chat accuracy notice from sources to referenced pages

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -547,7 +547,7 @@
   "ai_sidebar": {
     "new_chat": "New Chat",
     "recent_threads": "Recent Items",
-    "accuracy_notice": "Check the sources to verify the information.",
+    "accuracy_notice": "Check the referenced pages to verify the information.",
     "sources": "{{count}} pages referenced",
     "sources_one": "{{count}} page referenced",
     "sources_other": "{{count}} pages referenced",

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -543,7 +543,7 @@
   "ai_sidebar": {
     "new_chat": "Nouvelle discussion",
     "recent_threads": "Éléments récents",
-    "accuracy_notice": "Vérifiez les sources pour vous assurer de l'exactitude des informations.",
+    "accuracy_notice": "Vérifiez les pages référencées pour vous assurer de l'exactitude des informations.",
     "sources": "{{count}} pages référencées",
     "sources_one": "{{count}} page référencée",
     "sources_other": "{{count}} pages référencées",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -581,7 +581,7 @@
   "ai_sidebar": {
     "new_chat": "新規チャット",
     "recent_threads": "最近の項目",
-    "accuracy_notice": "情報が正しいか出典を確認しましょう。",
+    "accuracy_notice": "情報が正しいか参照ページを確認しましょう。",
     "sources": "参照したページ {{count}} 件",
     "error": {
       "title": "エラーが発生しました",

--- a/apps/app/public/static/locales/ko_KR/translation.json
+++ b/apps/app/public/static/locales/ko_KR/translation.json
@@ -518,7 +518,7 @@
   "ai_sidebar": {
     "new_chat": "새 채팅",
     "recent_threads": "최근 항목",
-    "accuracy_notice": "정보가 정확한지 출처를 확인하세요.",
+    "accuracy_notice": "정보가 정확한지 참고한 페이지를 확인하세요.",
     "sources": "참고한 페이지 {{count}}건",
     "error": {
       "title": "오류가 발생했습니다",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -539,7 +539,7 @@
   "ai_sidebar": {
     "new_chat": "新建对话",
     "recent_threads": "最近的项目",
-    "accuracy_notice": "请核对来源以确认信息是否准确。",
+    "accuracy_notice": "请查看参考页面以确认信息是否准确。",
     "sources": "已参考 {{count}} 个页面",
     "error": {
       "title": "发生错误",


### PR DESCRIPTION
## Task
https://redmine.weseek.co.jp/issues/187057

## 概要

AI チャットサイドバーの入力欄下に常時表示している注意書きの文言を変更します（#11437 のフォローアップ）。

| | 変更前 | 変更後 |
|---|---|---|
| ja | 情報が正しいか**出典**を確認しましょう。 | 情報が正しいか**参照ページ**を確認しましょう。 |

「出典」という語よりも、アシスタントの回答に実際に表示される「参照したページ」（`ai_sidebar.sources`）と対応する「参照ページ」の方が、ユーザーがどこを確認すればよいか分かりやすいためです。

## 変更内容

- `ai_sidebar.accuracy_notice` を全 5 ロケールで変更。訳語は各ロケールの `ai_sidebar.sources`（参照したページ / pages referenced / 参考页面 / 참고한 페이지 / pages référencées）に揃えています。
  - ja: 「情報が正しいか参照ページを確認しましょう。」
  - en: "Check the referenced pages to verify the information."
  - zh: 「请查看参考页面以确认信息是否准确。」
  - ko: 「정보가 정확한지 참고한 페이지를 확인하세요.」
  - fr: « Vérifiez les pages référencées pour vous assurer de l'exactitude des informations. »

## 検証

- 全 5 ロケールの translation.json が有効な JSON であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)