### PR TITLE
feat: Persist search filters in the URL

### DIFF
--- a/apps/app/src/features/search/client/components/SearchPage/SearchControl.tsx
+++ b/apps/app/src/features/search/client/components/SearchPage/SearchControl.tsx
@@ -15,6 +15,7 @@ import {
   createEmptyFilterState,
   isSameFilterState,
   type SearchFilterState,
+  sanitizeFilterState,
 } from '../../utils/search-query';
 import { SearchFilterChips } from './SearchFilterChips';
 import { SearchFilterPanel } from './SearchFilterPanel';
@@ -139,8 +140,9 @@ const SearchControl = React.memo((props: Props): JSX.Element => {
 
   const changeFiltersHandler = useCallback(
     (newFilters: SearchFilterState) => {
-      setFilters(newFilters);
-      invokeSearch(keyword, { filters: newFilters });
+      const sanitized = sanitizeFilterState(newFilters);
+      setFilters(sanitized);
+      invokeSearch(keyword, { filters: sanitized });
     },
     [invokeSearch, keyword],
   );
@@ -149,9 +151,9 @@ const SearchControl = React.memo((props: Props): JSX.Element => {
     setKeyword(keywordOnInit);
   }, [keywordOnInit]);
 
-  // Re-seed filters when the incoming URL-derived state changes (reload, back/
-  // forward, a hand-typed operator parsed into a chip). Guarded to the actual
-  // values so the new-object churn from our own onChange round-trip is a no-op.
+  // Re-seed filters when the URL-derived state changes (reload, back/forward, a
+  // hand-typed operator). Guarded so our own round-trip — which re-parses to the
+  // same values — is a no-op rather than a loop.
   const filtersOnInit = initialSearchConditions.filters;
   useEffect(() => {
     const next = filtersOnInit ?? createEmptyFilterState();

--- a/apps/app/src/features/search/client/components/SearchPage/SearchControl.tsx
+++ b/apps/app/src/features/search/client/components/SearchPage/SearchControl.tsx
@@ -13,6 +13,7 @@ import type { ISearchConditions, ISearchConfigurations } from '~/stores/search';
 
 import {
   createEmptyFilterState,
+  isSameFilterState,
   type SearchFilterState,
 } from '../../utils/search-query';
 import { SearchFilterChips } from './SearchFilterChips';
@@ -147,6 +148,15 @@ const SearchControl = React.memo((props: Props): JSX.Element => {
   useEffect(() => {
     setKeyword(keywordOnInit);
   }, [keywordOnInit]);
+
+  // Re-seed filters when the incoming URL-derived state changes (reload, back/
+  // forward, a hand-typed operator parsed into a chip). Guarded to the actual
+  // values so the new-object churn from our own onChange round-trip is a no-op.
+  const filtersOnInit = initialSearchConditions.filters;
+  useEffect(() => {
+    const next = filtersOnInit ?? createEmptyFilterState();
+    setFilters((prev) => (isSameFilterState(prev, next) ? prev : next));
+  }, [filtersOnInit]);
 
   return (
     <div className="shadow-sm">

--- a/apps/app/src/features/search/client/components/SearchPage/SearchPage.tsx
+++ b/apps/app/src/features/search/client/components/SearchPage/SearchPage.tsx
@@ -152,7 +152,10 @@ export const SearchPage = (): JSX.Element => {
   const searchInvokedHandler = useCallback(
     (newKeyword: string, newConfigurations: Partial<ISearchConfigurations>) => {
       setOffset(0);
-      setConfigurationsByControl(newConfigurations);
+      // Filters travel via the URL (`?q=`), not this filters config — the SWR call always
+      // sources them from the parsed query, so we don't retain them here.
+      const { filters: _filters, ...configWithoutFilters } = newConfigurations;
+      setConfigurationsByControl(configWithoutFilters);
 
       // Serialize free text + filters into `?q=`. A new keyword pushes (a fresh
       // search in history); a filter/sort-only change replaces (no history spam).

--- a/apps/app/src/features/search/client/components/SearchPage/SearchPage.tsx
+++ b/apps/app/src/features/search/client/components/SearchPage/SearchPage.tsx
@@ -24,6 +24,7 @@ import {
 import {
   buildSearchQuery,
   createEmptyFilterState,
+  normalizeKeyword,
   parseSearchQuery,
 } from '../../utils/search-query';
 import { OperateAllControl } from './OperateAllControl';
@@ -38,6 +39,10 @@ import styles from './SearchPage.module.scss';
 
 // TODO: replace with "customize:showPageLimitationS"
 const INITIAL_PAGIONG_SIZE = 20;
+
+// The search runs off the raw `?q=` (which already carries the operators), so the
+// structured filters are always empty here. Shared to keep the SWR key stable.
+const EMPTY_FILTER_STATE = createEmptyFilterState();
 
 /**
  * SearchResultListHead
@@ -111,12 +116,11 @@ export const SearchPage = (): JSX.Element => {
   const { t } = useTranslation();
   const showPageLimitationL = useAtomValue(showPageLimitationLAtom);
 
-  // The URL `?q=` is the single source of truth: it carries free text AND the
-  // inline filter operators. Parse it to hydrate the keyword box (free text only)
-  // and the filter chips/panel (structured filters) — see searchInvokedHandler
-  // for the reverse (serialize) direction.
+  // The URL `?q=` is the single source of truth (free text + inline operators).
+  // Parse it to hydrate the keyword box and the filter chips/panel;
+  // searchInvokedHandler does the reverse.
   const keyword = useSearchKeyword();
-  const parsedQuery = useMemo(() => parseSearchQuery(keyword ?? ''), [keyword]);
+  const parsedQuery = useMemo(() => parseSearchQuery(keyword), [keyword]);
   const setSearchKeyword = useSetSearchKeyword();
 
   const disableUserPages = useAtomValue(disableUserPagesAtom);
@@ -138,11 +142,9 @@ export const SearchPage = (): JSX.Element => {
     (ISelectableAll & IReturnSelectedPageIds) | null
   >(null);
 
-  // `keyword` already encodes the filter operators, so the structured `filters`
-  // must be empty here — passing both would serialize each operator twice.
-  const { data, conditions, mutate } = useSWRxSearch(keyword ?? '', null, {
+  const { data, conditions, mutate } = useSWRxSearch(keyword, null, {
     ...configurationsByControl,
-    filters: createEmptyFilterState(),
+    filters: EMPTY_FILTER_STATE,
     offset,
     limit,
   });
@@ -152,14 +154,15 @@ export const SearchPage = (): JSX.Element => {
       setOffset(0);
       setConfigurationsByControl(newConfigurations);
 
-      // Serialize free text + filters into the single `?q=` string. A new keyword
-      // is a fresh search (push, so back/forward steps through searches); a change
-      // to only filters/sort reuses the current entry (replace, no history spam).
+      // Serialize free text + filters into `?q=`. A new keyword pushes (a fresh
+      // search in history); a filter/sort-only change replaces (no history spam).
       const q = buildSearchQuery(
         newKeyword,
         newConfigurations.filters ?? createEmptyFilterState(),
       );
-      const isNewKeyword = newKeyword.trim() !== parsedQuery.keyword;
+      // Normalize both sides so an internal-whitespace-only difference is not
+      // misread as a new keyword.
+      const isNewKeyword = normalizeKeyword(newKeyword) !== parsedQuery.keyword;
       setSearchKeyword(q, { replace: !isNewKeyword });
 
       mutate();

--- a/apps/app/src/features/search/client/components/SearchPage/SearchPage.tsx
+++ b/apps/app/src/features/search/client/components/SearchPage/SearchPage.tsx
@@ -21,6 +21,11 @@ import {
   useSWRxSearch,
 } from '~/stores/search';
 
+import {
+  buildSearchQuery,
+  createEmptyFilterState,
+  parseSearchQuery,
+} from '../../utils/search-query';
 import { OperateAllControl } from './OperateAllControl';
 import SearchControl from './SearchControl';
 import type { IReturnSelectedPageIds } from './SearchPageBase';
@@ -106,7 +111,12 @@ export const SearchPage = (): JSX.Element => {
   const { t } = useTranslation();
   const showPageLimitationL = useAtomValue(showPageLimitationLAtom);
 
+  // The URL `?q=` is the single source of truth: it carries free text AND the
+  // inline filter operators. Parse it to hydrate the keyword box (free text only)
+  // and the filter chips/panel (structured filters) — see searchInvokedHandler
+  // for the reverse (serialize) direction.
   const keyword = useSearchKeyword();
+  const parsedQuery = useMemo(() => parseSearchQuery(keyword ?? ''), [keyword]);
   const setSearchKeyword = useSetSearchKeyword();
 
   const disableUserPages = useAtomValue(disableUserPagesAtom);
@@ -128,8 +138,11 @@ export const SearchPage = (): JSX.Element => {
     (ISelectableAll & IReturnSelectedPageIds) | null
   >(null);
 
+  // `keyword` already encodes the filter operators, so the structured `filters`
+  // must be empty here — passing both would serialize each operator twice.
   const { data, conditions, mutate } = useSWRxSearch(keyword ?? '', null, {
     ...configurationsByControl,
+    filters: createEmptyFilterState(),
     offset,
     limit,
   });
@@ -139,11 +152,19 @@ export const SearchPage = (): JSX.Element => {
       setOffset(0);
       setConfigurationsByControl(newConfigurations);
 
-      setSearchKeyword(newKeyword);
+      // Serialize free text + filters into the single `?q=` string. A new keyword
+      // is a fresh search (push, so back/forward steps through searches); a change
+      // to only filters/sort reuses the current entry (replace, no history spam).
+      const q = buildSearchQuery(
+        newKeyword,
+        newConfigurations.filters ?? createEmptyFilterState(),
+      );
+      const isNewKeyword = newKeyword.trim() !== parsedQuery.keyword;
+      setSearchKeyword(q, { replace: !isNewKeyword });
 
       mutate();
     },
-    [mutate, setSearchKeyword],
+    [mutate, setSearchKeyword, parsedQuery.keyword],
   );
 
   const selectAllCheckboxChangedHandler = useCallback((isChecked: boolean) => {
@@ -205,10 +226,12 @@ export const SearchPage = (): JSX.Element => {
 
   const initialSearchConditions: Partial<ISearchConditions> = useMemo(() => {
     return {
-      keyword,
+      // Box shows free text only; the panel/chips hydrate from the parsed filters.
+      keyword: parsedQuery.keyword,
+      filters: parsedQuery.filters,
       limit: INITIAL_PAGIONG_SIZE,
     };
-  }, [keyword]);
+  }, [parsedQuery]);
 
   // for bulk deletion
   const deleteAllButtonClickedHandler = usePageDeleteModalForBulkDeletion(
@@ -345,7 +368,7 @@ export const SearchPage = (): JSX.Element => {
       className={styles['search-page']}
       ref={searchPageBaseRef}
       pages={data?.data}
-      searchingKeyword={keyword}
+      searchingKeyword={parsedQuery.keyword}
       onSelectedPagesByCheckboxesChanged={
         selectedPagesByCheckboxesChangedHandler
       }

--- a/apps/app/src/features/search/client/utils/search-query.spec.ts
+++ b/apps/app/src/features/search/client/utils/search-query.spec.ts
@@ -5,6 +5,7 @@ import {
   isSameFilterState,
   parseSearchQuery,
   type SearchFilterState,
+  sanitizeFilterState,
 } from './search-query';
 
 const filterState = (
@@ -203,6 +204,24 @@ describe('isFilterStateEmpty', () => {
     expect(isFilterStateEmpty(filterState({ authors: ['alice'] }))).toBe(false);
     expect(isFilterStateEmpty(filterState({ editors: ['bob'] }))).toBe(false);
     expect(isFilterStateEmpty(filterState({ groups: ['Docs'] }))).toBe(false);
+  });
+});
+
+describe('sanitizeFilterState', () => {
+  it('strips embedded double-quotes so state matches the built query', () => {
+    const sanitized = sanitizeFilterState(
+      filterState({ groups: ['a"b'], authors: ['alice'] }),
+    );
+    expect(sanitized.groups).toEqual(['ab']);
+    // The sanitized value round-trips losslessly (no further rewrite on reload).
+    expect(parseSearchQuery(buildSearchQuery('', sanitized)).filters).toEqual(
+      sanitized,
+    );
+  });
+
+  it('leaves quote-free values untouched', () => {
+    const input = filterState({ tags: ['wiki', 'dev docs'] });
+    expect(sanitizeFilterState(input)).toEqual(input);
   });
 });
 

--- a/apps/app/src/features/search/client/utils/search-query.spec.ts
+++ b/apps/app/src/features/search/client/utils/search-query.spec.ts
@@ -223,6 +223,23 @@ describe('sanitizeFilterState', () => {
     const input = filterState({ tags: ['wiki', 'dev docs'] });
     expect(sanitizeFilterState(input)).toEqual(input);
   });
+
+  it('trims surrounding whitespace so state matches the built query', () => {
+    // buildSearchQuery trims values; sanitize must too, or the chip would show
+    // ` x ` while the URL/search used `x`.
+    const sanitized = sanitizeFilterState(
+      filterState({ authors: ['  alice '] }),
+    );
+    expect(sanitized.authors).toEqual(['alice']);
+  });
+
+  it('drops values that are empty after cleaning', () => {
+    const sanitized = sanitizeFilterState(
+      filterState({ authors: ['alice', '   ', '""'], tags: [''] }),
+    );
+    expect(sanitized.authors).toEqual(['alice']);
+    expect(sanitized.tags).toEqual([]);
+  });
 });
 
 describe('isSameFilterState', () => {

--- a/apps/app/src/features/search/client/utils/search-query.spec.ts
+++ b/apps/app/src/features/search/client/utils/search-query.spec.ts
@@ -2,6 +2,7 @@ import {
   buildSearchQuery,
   createEmptyFilterState,
   isFilterStateEmpty,
+  isSameFilterState,
   parseSearchQuery,
   type SearchFilterState,
 } from './search-query';
@@ -202,5 +203,30 @@ describe('isFilterStateEmpty', () => {
     expect(isFilterStateEmpty(filterState({ authors: ['alice'] }))).toBe(false);
     expect(isFilterStateEmpty(filterState({ editors: ['bob'] }))).toBe(false);
     expect(isFilterStateEmpty(filterState({ groups: ['Docs'] }))).toBe(false);
+  });
+});
+
+describe('isSameFilterState', () => {
+  it('is true for equal values across all fields', () => {
+    const a = filterState({ authors: ['alice'], tags: ['wiki', 'docs'] });
+    const b = filterState({ authors: ['alice'], tags: ['wiki', 'docs'] });
+    // Different object identities, same values — the round-trip re-seed case.
+    expect(isSameFilterState(a, b)).toBe(true);
+  });
+
+  it('is false when a value differs, is added, or is reordered', () => {
+    const base = filterState({ tags: ['wiki', 'docs'] });
+    expect(isSameFilterState(base, filterState({ tags: ['wiki'] }))).toBe(
+      false,
+    );
+    expect(
+      isSameFilterState(base, filterState({ tags: ['docs', 'wiki'] })),
+    ).toBe(false);
+    expect(
+      isSameFilterState(
+        base,
+        filterState({ tags: ['wiki', 'docs'], authors: ['a'] }),
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/app/src/features/search/client/utils/search-query.ts
+++ b/apps/app/src/features/search/client/utils/search-query.ts
@@ -72,6 +72,28 @@ export const isFilterStateEmpty = (filters: SearchFilterState): boolean =>
   filters.groups.length === 0 &&
   filters.tags.length === 0;
 
+/**
+ * Order-sensitive value equality across all fields. Used to decide whether an
+ * incoming (e.g. URL-derived) filter state actually differs from the current one,
+ * so a re-seed can no-op instead of clobbering identical state on every render.
+ */
+export const isSameFilterState = (
+  a: SearchFilterState,
+  b: SearchFilterState,
+): boolean => {
+  const fields: (keyof SearchFilterState)[] = [
+    'authors',
+    'editors',
+    'groups',
+    'tags',
+  ];
+  return fields.every(
+    (field) =>
+      a[field].length === b[field].length &&
+      a[field].every((value, i) => value === b[field][i]),
+  );
+};
+
 const normalizeKeyword = (keyword: string): string =>
   keyword.trim().replace(/\s+/g, ' ');
 

--- a/apps/app/src/features/search/client/utils/search-query.ts
+++ b/apps/app/src/features/search/client/utils/search-query.ts
@@ -55,12 +55,13 @@ const FILTER_REGEXP = new RegExp(
   'g',
 );
 
-export const createEmptyFilterState = (): SearchFilterState => ({
-  authors: [],
-  editors: [],
-  groups: [],
-  tags: [],
-});
+export const createEmptyFilterState = (): SearchFilterState => {
+  const state = {} as SearchFilterState;
+  for (const field of SEARCH_FILTER_FIELDS) {
+    state[field] = [];
+  }
+  return state;
+};
 
 const cleanFilterValue = (value: string) => {
   return value.replace(/"/g, '').trim();
@@ -101,12 +102,11 @@ export const sanitizeFilterState = (
 ): SearchFilterState => {
   const clean = (values: string[]) =>
     values.map((v) => cleanFilterValue(v)).filter((v) => v !== '');
-  return {
-    authors: clean(filters.authors),
-    editors: clean(filters.editors),
-    groups: clean(filters.groups),
-    tags: clean(filters.tags),
-  };
+  const state = {} as SearchFilterState;
+  for (const field of SEARCH_FILTER_FIELDS) {
+    state[field] = clean(filters[field]);
+  }
+  return state;
 };
 
 const quoteIfNeeded = (value: string): string =>

--- a/apps/app/src/features/search/client/utils/search-query.ts
+++ b/apps/app/src/features/search/client/utils/search-query.ts
@@ -25,6 +25,7 @@
 
 import {
   FILTER_FIELDS,
+  SEARCH_FILTER_FIELDS,
   SEARCH_FILTER_PREFIXES,
   type SearchFilterField,
   type SearchFilterState,
@@ -67,10 +68,7 @@ const cleanFilterValue = (value: string) => {
 
 /** True when no filter field holds any value. */
 export const isFilterStateEmpty = (filters: SearchFilterState): boolean =>
-  filters.authors.length === 0 &&
-  filters.editors.length === 0 &&
-  filters.groups.length === 0 &&
-  filters.tags.length === 0;
+  SEARCH_FILTER_FIELDS.every((field) => filters[field].length === 0);
 
 /**
  * Order-sensitive value equality. Lets a re-seed skip identical state instead of
@@ -80,13 +78,7 @@ export const isSameFilterState = (
   a: SearchFilterState,
   b: SearchFilterState,
 ): boolean => {
-  const fields: (keyof SearchFilterState)[] = [
-    'authors',
-    'editors',
-    'groups',
-    'tags',
-  ];
-  return fields.every(
+  return SEARCH_FILTER_FIELDS.every(
     (field) =>
       a[field].length === b[field].length &&
       a[field].every((value, i) => value === b[field][i]),

--- a/apps/app/src/features/search/client/utils/search-query.ts
+++ b/apps/app/src/features/search/client/utils/search-query.ts
@@ -97,19 +97,23 @@ export const normalizeKeyword = (keyword: string): string =>
   keyword.trim().replace(/\s+/g, ' ');
 
 /**
- * Strip embedded double-quotes — the one character the inline grammar (and the
- * server) drop. Committing them unstripped would show `a"b` in a chip while the
- * URL/search use `ab`, so sanitizing keeps state, URL, and search in agreement.
+ * Clean each filter value the same way `buildSearchQuery` does before it emits
+ * one: strip embedded double-quotes (the one character the inline grammar and the
+ * server drop), trim surrounding whitespace, and drop values left empty. Applying
+ * the identical rules here keeps the chip state, the URL, and the executed search
+ * in agreement — otherwise a value like `a"b` or ` x ` would render in a chip
+ * while the URL/search used `ab` / `x`.
  */
 export const sanitizeFilterState = (
   filters: SearchFilterState,
 ): SearchFilterState => {
-  const strip = (values: string[]) => values.map((v) => v.replace(/"/g, ''));
+  const clean = (values: string[]) =>
+    values.map((v) => v.replace(/"/g, '').trim()).filter((v) => v !== '');
   return {
-    authors: strip(filters.authors),
-    editors: strip(filters.editors),
-    groups: strip(filters.groups),
-    tags: strip(filters.tags),
+    authors: clean(filters.authors),
+    editors: clean(filters.editors),
+    groups: clean(filters.groups),
+    tags: clean(filters.tags),
   };
 };
 

--- a/apps/app/src/features/search/client/utils/search-query.ts
+++ b/apps/app/src/features/search/client/utils/search-query.ts
@@ -73,9 +73,8 @@ export const isFilterStateEmpty = (filters: SearchFilterState): boolean =>
   filters.tags.length === 0;
 
 /**
- * Order-sensitive value equality across all fields. Used to decide whether an
- * incoming (e.g. URL-derived) filter state actually differs from the current one,
- * so a re-seed can no-op instead of clobbering identical state on every render.
+ * Order-sensitive value equality. Lets a re-seed skip identical state instead of
+ * clobbering it when the URL round-trips back the values already shown.
  */
 export const isSameFilterState = (
   a: SearchFilterState,
@@ -94,8 +93,25 @@ export const isSameFilterState = (
   );
 };
 
-const normalizeKeyword = (keyword: string): string =>
+export const normalizeKeyword = (keyword: string): string =>
   keyword.trim().replace(/\s+/g, ' ');
+
+/**
+ * Strip embedded double-quotes — the one character the inline grammar (and the
+ * server) drop. Committing them unstripped would show `a"b` in a chip while the
+ * URL/search use `ab`, so sanitizing keeps state, URL, and search in agreement.
+ */
+export const sanitizeFilterState = (
+  filters: SearchFilterState,
+): SearchFilterState => {
+  const strip = (values: string[]) => values.map((v) => v.replace(/"/g, ''));
+  return {
+    authors: strip(filters.authors),
+    editors: strip(filters.editors),
+    groups: strip(filters.groups),
+    tags: strip(filters.tags),
+  };
+};
 
 const quoteIfNeeded = (value: string): string =>
   /\s/.test(value) ? `"${value}"` : value;

--- a/apps/app/src/features/search/client/utils/search-query.ts
+++ b/apps/app/src/features/search/client/utils/search-query.ts
@@ -61,6 +61,10 @@ export const createEmptyFilterState = (): SearchFilterState => ({
   tags: [],
 });
 
+const cleanFilterValue = (value: string) => {
+  return value.replace(/"/g, '').trim();
+};
+
 /** True when no filter field holds any value. */
 export const isFilterStateEmpty = (filters: SearchFilterState): boolean =>
   filters.authors.length === 0 &&
@@ -104,7 +108,7 @@ export const sanitizeFilterState = (
   filters: SearchFilterState,
 ): SearchFilterState => {
   const clean = (values: string[]) =>
-    values.map((v) => v.replace(/"/g, '').trim()).filter((v) => v !== '');
+    values.map((v) => cleanFilterValue(v)).filter((v) => v !== '');
   return {
     authors: clean(filters.authors),
     editors: clean(filters.editors),
@@ -137,7 +141,7 @@ export const buildSearchQuery = (
       // Strip embedded double-quotes: the grammar has no way to escape them, and
       // the server strips quotes too, so emitting one would corrupt the query
       // (the value could be truncated or partly reinterpreted as free text).
-      const cleaned = value.replace(/"/g, '').trim();
+      const cleaned = cleanFilterValue(value);
       if (cleaned === '') {
         continue;
       }
@@ -162,7 +166,7 @@ export const parseSearchQuery = (queryString: string): ParsedSearchQuery => {
     (_match, lead: string, prefix: string, rawValue: string) => {
       // Strip quotes: unwraps a quoted value, no-op for a bare one, and cleans a
       // stray quote from a malformed `author:"x` (matching the server).
-      const value = rawValue.replace(/"/g, '');
+      const value = cleanFilterValue(rawValue);
       // A quotes-only operator (`author:""`, `author:"`) carries no value; drop
       // it instead of committing a blank chip and running an empty-value filter.
       if (value !== '') {

--- a/apps/app/src/features/search/utils/filter-fields.ts
+++ b/apps/app/src/features/search/utils/filter-fields.ts
@@ -33,3 +33,4 @@ export const FILTER_FIELDS = [
 // `.map` infers the literal element union (`'author:' | ...`), which a `string[]`
 // annotation would widen away, so consumers deriving a type from these stay exact.
 export const SEARCH_FILTER_PREFIXES = FILTER_FIELDS.map(([, prefix]) => prefix);
+export const SEARCH_FILTER_FIELDS = FILTER_FIELDS.map(([key]) => key);

--- a/apps/app/src/states/search/keyword-manager.ts
+++ b/apps/app/src/states/search/keyword-manager.ts
@@ -51,9 +51,8 @@ export const useKeywordManager = (): void => {
 };
 
 type SetSearchKeywordOptions = {
-  // Use router.replace instead of push. For updates that should not add a
-  // history entry — e.g. live filter/sort tweaks on the search page, where
-  // pushing per change would flood back/forward with intermediate states.
+  // router.replace instead of push — for updates that should not add a history
+  // entry, e.g. live filter/sort tweaks that would otherwise flood back/forward.
   replace?: boolean;
 };
 

--- a/apps/app/src/states/search/keyword-manager.ts
+++ b/apps/app/src/states/search/keyword-manager.ts
@@ -50,11 +50,21 @@ export const useKeywordManager = (): void => {
   }, [setKeyword]);
 };
 
-type SetSearchKeyword = (newKeyword: string) => void;
+type SetSearchKeywordOptions = {
+  // Use router.replace instead of push. For updates that should not add a
+  // history entry — e.g. live filter/sort tweaks on the search page, where
+  // pushing per change would flood back/forward with intermediate states.
+  replace?: boolean;
+};
+
+type SetSearchKeyword = (
+  newKeyword: string,
+  options?: SetSearchKeywordOptions,
+) => void;
 
 /**
  * Hook to set the search keyword and update the URL
- * @returns A function to update the search keyword and push to router history
+ * @returns A function to update the search keyword and navigate the router
  */
 export const useSetSearchKeyword = (
   pathname = '/_search',
@@ -64,14 +74,19 @@ export const useSetSearchKeyword = (
   const setKeyword = useSetAtom(searchKeywordAtom);
 
   return useCallback(
-    (newKeyword: string) => {
+    (newKeyword: string, options?: SetSearchKeywordOptions) => {
       setKeyword((prevKeyword) => {
         const isOnSearchPage = routerRef.current.pathname === pathname;
         // Navigate if keyword changed OR if not currently on search page
         if (prevKeyword !== newKeyword || !isOnSearchPage) {
           const newUrl = new URL(pathname, 'http://example.com');
           newUrl.searchParams.append('q', newKeyword);
-          routerRef.current.push(`${newUrl.pathname}${newUrl.search}`, '');
+          const href = `${newUrl.pathname}${newUrl.search}`;
+          if (options?.replace) {
+            routerRef.current.replace(href, '');
+          } else {
+            routerRef.current.push(href, '');
+          }
         }
 
         return newKeyword;


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/186841
https://redmine.weseek.co.jp/issues/187283

# Dependent on #11463 merging first
- http://github.com/growilabs/growi/pull/11463


# Links get preserved with filters enabled
- Before
  - `http://localhost:3000/_search?q=test`
- After
  - `http://localhost:3000/_search?q=test+author%3Aadmin+editor%3Aarvid`