### PR TITLE
imprv(activity-log): format attachment ADD/DOWNLOAD snapshots in the audit log viewer

### DIFF
--- a/.kiro/specs/activity-log-snapshot-viewer/design.md
+++ b/.kiro/specs/activity-log-snapshot-viewer/design.md
@@ -437,3 +437,98 @@ const isAttachmentRemoveActivity = (
 
 - 監査ログは 1 ページ最大 100 行。詳細サブ行は**展開時のみ mount**するため、既定表示のコストは disclosure セル追加分のみ。
 - レジストリ走査は `find`（O(エントリ数)=実質 O(1)）。追加のネットワーク往復は無し（`useSWRxActivity` の既存取得データを描画）。
+
+## 増分（2026-07-16）: 添付追加/ダウンロード（ADD/DOWNLOAD）の整形表示
+
+> **設計の位置づけ**: 初回設計（要件 1〜5）はレジストリ + dispatcher の宣言的パターンで「action 追加＝レジストリへ1エントリ追記」を拡張点として用意済み。本増分はその拡張点をそのまま使い、ADD/DOWNLOAD の整形 renderer を登録するだけで、dispatcher・テーブル・既存 renderer・型定義は一切変更しない。上流 `activity-log-snapshot` の ADD/DOWNLOAD capture 完了（PR #11433）により、下記 Revalidation Trigger が満たされたことがトリガ。
+
+### 増分による Boundary の更新
+
+- 初回の Out of Boundary「添付追加 ADD の整形（上流の ADD capture 完了後の将来増分）」は、本増分で **In Boundary** へ移る（ADD に加え DOWNLOAD も対象）。
+- 初回の Revalidation Trigger「上流の ADD capture／ADD 型ガードが提供される（→ レジストリに ADD エントリを追記する将来作業のトリガ。既存挙動には非破壊）」は **満たされた**（PR #11433 で `isAttachmentAddActivity` / `isAttachmentDownloadActivity` と capture が提供済み）。本増分がその「将来作業」に当たる。
+- Allowed Dependencies に以下を追加（いずれも既存・read-only 消費）:
+  - `~/interfaces/activity` の `isAttachmentAddActivity` / `isAttachmentDownloadActivity` / `AttachmentSnapshot`（型・型ガードの consume。定義は上流所有・不変）。
+  - `IActivityHasId.target`（attachment ID。ダウンロード URL 構築のため read-only 参照）。
+- Out of Boundary（増分でも維持）: サムネイル表示（snapshot も `target` も MIME/画像判定情報を持たない）、上流の capture・型・API 契約の変更。
+
+### 追加コンポーネント設計
+
+#### LiveAttachmentSnapshotDetail（new）— ADD/DOWNLOAD 共有の整形レンダラ
+
+| Field | Detail |
+|-------|--------|
+| Intent | 実体が残る添付（`ACTION_ATTACHMENT_ADD` / `ACTION_ATTACHMENT_DOWNLOAD`）の snapshot を整形表示し、`activity.target` からダウンロードリンクを添える |
+| Requirements | 6.1–6.3, 7.1, 7.2, 7.4, 8.1 |
+
+**命名の意図**: 「Live（＝ファイルの実体がまだ存在する）」で REMOVE（削除済み）と対比する。ADD と DOWNLOAD はどちらも実体が残り、snapshot 形状もダウンロードリンクの可否も同じなので、action ごとに別コンポーネントを作らず**1つの共有 renderer** を両 action に登録する（coding-style: data-driven / 消費側でモード分岐しない）。
+
+**Responsibilities & Constraints**
+- `defineRenderer` 経由で登録されるため、props の `activity` は `snapshot?: AttachmentSnapshot` へ絞り込み済みで受け取る（再 narrow 不要）。ダウンロード URL に使う `target` は `IActivityHasId` 側のフィールドなので、`IActivityHasId & { snapshot?: AttachmentSnapshot }` から参照できる。
+- フィールド表示（ファイル名・人間可読サイズ・所属ページリンク）は REMOVE と同一仕様・同一フォールバック（要件 3.1–3.4）。**REMOVE と共通のフィールド描画は共有の presentational 部品 `AttachmentSnapshotFields` に抽出**し、REMOVE 側もそれを使うよう置き換える（挙動不変のリファクタ。重複と将来のドリフトを防ぐ）。`LiveAttachmentSnapshotDetail` はその共有部品に**ダウンロードリンク行**を1つ足したもの。
+- ダウンロードリンクは `activity.target != null` のときだけ描画（`href={/download/${activity.target}}`）。`target` 欠損時はリンク行を出さず、他フィールドの描画は継続（要件 7.2）。
+- REMOVE の整形（`AttachmentRemoveSnapshotDetail`）は**ダウンロードリンクを出さない**まま（要件 2.4 / 7.3）。差は「共有部品にダウンロード行を足すか否か」だけで、REMOVE 側の観察可能な挙動は変えない。
+
+**Dependencies**
+- External: `pretty-bytes`（サイズ整形, P1）、`PagePathHierarchicalLink` + `LinkedPagePath`（ページリンク, P1）
+- Inbound: `snapshot-detail-renderers`（`defineRenderer` で ADD/DOWNLOAD の2エントリとして登録, P0）
+
+**Contracts**: State [x]
+
+##### Props
+```typescript
+// isAttachmentAddActivity / isAttachmentDownloadActivity が絞り込む型。
+// defineRenderer がこの型を props 型として要求するため、renderer は narrow 済みで受け取る。
+type LiveAttachmentSnapshotDetailProps = {
+  activity: IActivityHasId & { snapshot?: AttachmentSnapshot };
+};
+```
+- Preconditions: dispatcher により `action === ACTION_ATTACHMENT_ADD | ACTION_ATTACHMENT_DOWNLOAD` が担保。
+- Postconditions: name/size/page をそれぞれの有無に応じ値またはフォールバック描画。`target` があればダウンロードリンクを描画、無ければ出さない。
+- Invariants: 値はテキストとして描画（React 自動エスケープ）。ダウンロード href は `/download/${target}` のみ（`target` はサーバ生成の ObjectId 文字列）。
+
+#### snapshot-detail-renderers（レジストリ更新）
+
+初回の1エントリに ADD/DOWNLOAD の2エントリを**追記するのみ**。dispatcher・テーブルは不変。
+
+```typescript
+export const snapshotDetailRenderers: SnapshotDetailRenderer[] = [
+  defineRenderer(isAttachmentRemoveActivity, AttachmentRemoveSnapshotDetail),
+  defineRenderer(isAttachmentAddActivity, LiveAttachmentSnapshotDetail),
+  defineRenderer(isAttachmentDownloadActivity, LiveAttachmentSnapshotDetail),
+];
+```
+- 3 エントリは `action` で互いに排他（各 action に高々1つ）＝先頭一致の不変条件を維持。
+- 同じ `LiveAttachmentSnapshotDetail` を2つの guard に割り当てるのは意図的（ADD/DOWNLOAD は同一整形）。`defineRenderer` の型検査により、両 guard の絞り込み型（`AttachmentSnapshot`）と renderer の props 型が一致することがコンパイル時に担保される。
+
+### 増分の Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces | Flows |
+|-------------|---------|------------|------------|-------|
+| 6.1 | ADD/DOWNLOAD の整形（ファイル名/サイズ/ページ） | LiveAttachmentSnapshotDetail, AttachmentSnapshotFields | `AttachmentSnapshot` 消費 | dispatch match→Fmt |
+| 6.2 | 整形があっても raw をタブで常時参照 | ActivitySnapshotDetail（不変） | tab state | dispatch match→Tabs |
+| 6.3 | 欠損フィールドの独立フォールバック | AttachmentSnapshotFields | i18n label | Fmt→Fb* |
+| 7.1 | target があればダウンロードリンク | LiveAttachmentSnapshotDetail | `IActivityHasId.target` | Fmt→DL |
+| 7.2 | target 欠損時はリンク無し・他は継続 | LiveAttachmentSnapshotDetail | — | Fmt→(DL 省略) |
+| 7.3 | REMOVE の整形は不変（DL なし） | AttachmentRemoveSnapshotDetail | — | Fmt（DL 描画なし） |
+| 7.4 | リンクに独自認可を持たせない | LiveAttachmentSnapshotDetail | `/download` 既存経路 | — |
+| 8.1 | 旧 ADD/DOWNLOAD レコードもフォールバック描画 | LiveAttachmentSnapshotDetail, RawSnapshotDetail | — | 全フォールバック分岐 |
+| 8.2 | データ移行不要 | （型が全 optional・後方互換） | — | — |
+
+### 増分の i18n
+
+- ダウンロードリンクのラベル（例 `audit_log_snapshot.download` = "Download"）を **en_US/admin.json に追加**する。ファイル名・サイズ・ページのラベルは初回追加分（`file_name` / `file_size` / `page` / `unknown_*` / `page_unavailable`）を再利用する。
+- ja/ko/zh/fr の翻訳は初回と同じ方針で**後続タスク**（要件 4.1 の翻訳タスク）に畳む。未了の間は i18next の欠落時フォールバックで英語表示となり機能は成立する。
+
+### 増分の Test Strategy
+
+`essential-test-design`（観察可能な契約をテスト）と `essential-test-patterns`（Vitest / RTL / `mock<T>()`）に従う。
+
+- **LiveAttachmentSnapshotDetail（unit）**: (a) 全フィールド＋`target` 有り → ファイル名・整形サイズ・ページリンク・**ダウンロードリンク（`/download/{target}` の href）**が現れる（6.1, 7.1）。(b) `target` 欠損 → ダウンロードリンクが**現れない**が他フィールドは描画される（7.2）。(c) `originalName` / `pagePath` / `fileSize` 各欠損 → 対応するフォールバック文言（6.3）。
+- **snapshot-detail-renderers（既存 spec を拡張）**: `action=ATTACHMENT_ADD` と `=ATTACHMENT_DOWNLOAD` が `LiveAttachmentSnapshotDetail` に、`=ATTACHMENT_REMOVE` が `AttachmentRemoveSnapshotDetail` に解決される。既存の負ゲート（`@ts-expect-error` による誤ペア検出）は維持。
+- **AttachmentRemoveSnapshotDetail（回帰）**: 共有部品抽出後もダウンロードリンクが**出ない**ことを再確認（7.3）。
+- **Integration（`ActivityTable.spec.tsx` の混在テストを拡張）**: 既存の旧/新 REMOVE 行に加え ADD/DOWNLOAD 行を混在させ、展開で既定=整形（ADD/DOWNLOAD はダウンロードリンク表示、REMOVE はリンク無し）、raw タブで全フィールド到達、旧レコード非破壊を1つの一覧で検証（6.1, 6.2, 7.1, 7.3, 8.1）。
+
+### 増分の Security Considerations
+
+- **ダウンロードリンクの妥当性**: href は `/download/${activity.target}` のみを組み立てる。`target` は上流がサーバ生成した attachment の ObjectId 文字列で、ユーザ自由入力ではない。リンク先の実体アクセス可否は `/download` 経路がサーバ側で権限判定する既存契約に委ね、本 spec はクライアントで認可判定を再実装しない（要件 7.4）。監査ログ画面自体が admin 限定ルートでガード済みという前提も初回設計から不変。
+- **XSS**: 追加分も `dangerouslySetInnerHTML` を使わず、値はテキストとして描画する。

--- a/.kiro/specs/activity-log-snapshot-viewer/requirements.md
+++ b/.kiro/specs/activity-log-snapshot-viewer/requirements.md
@@ -79,3 +79,54 @@
 1. When snapshot が username のみを持つ（従来形式の）activity を表示する, the 監査ログビューア shall 従来通り username を表示し、添付整形表示を要求しない。
 2. When action が整形表示未対応の activity を表示する, the 監査ログビューア shall 既存の action 名の多言語表示を維持する。
 3. The 監査ログビューア shall 既存レコード（添付フィールド無し）と新規レコード（添付フィールド有り）を、同一の一覧内で混在して表示できる。
+
+## 増分（2026-07-16）: 添付追加/ダウンロード（ADD/DOWNLOAD）の整形表示
+
+> **この増分の位置づけ**: 要件 1〜5（全 action の raw ビューア＋添付削除 `ACTION_ATTACHMENT_REMOVE` の整形表示）は実装完了済み（PR #11440）。本増分は**その実装を作り直さず**、宣言的レジストリに添付追加（`ACTION_ATTACHMENT_ADD`）とダウンロード（`ACTION_ATTACHMENT_DOWNLOAD`）の整形 renderer を追記する。初回の設計（design.md の Revalidation Triggers）が「上流の ADD capture が提供されたらレジストリに追記する将来作業」と予告していた着手条件は、上流 `activity-log-snapshot` の ADD/DOWNLOAD snapshot capture が PR #11433 で完了したことにより満たされている。
+
+> **ADD と DOWNLOAD をまとめて扱う根拠（実測）**: 両 action の snapshot は REMOVE と同一形（`AttachmentSnapshot` = `originalName` / `pagePath` / `pageId` / `fileSize` / `username`、いずれも optional。`apps/app/src/interfaces/activity.ts` で確認）。REMOVE と違い添付ファイルの実体が残るため、監査ログからその実体へのダウンロードリンクを出せる。上流 API（`apiv3/activity`）の OpenAPI も、`target` は attachment ID であり「snapshot フィールドと組み合わせれば、まだ存在する添付（ADD / DOWNLOAD、`action` で判別）のダウンロードリンクを consumer が構築できる」と明記している（`apps/app/src/server/routes/apiv3/activity.ts` で確認）。したがって ADD と DOWNLOAD は同一の整形（フィールド表示＋ダウンロードリンク）で扱うのが自然であり、両者を1つの共有 renderer に割り当てる。
+
+### 増分の Boundary Context
+
+- **In scope（増分）**:
+  - `ACTION_ATTACHMENT_ADD` / `ACTION_ATTACHMENT_DOWNLOAD` の整形表示（ファイル名・人間可読サイズ・所属ページリンク。REMOVE と同じフィールド群・同じ欠損フォールバック）。
+  - 実体が残る添付へのダウンロードリンク（`activity.target`＝attachment ID から構築）。
+  - ダウンロードリンクのラベルを en_US に追加。ja/ko/zh/fr の翻訳は既存の後続タスク（要件 4.1 の翻訳タスク）に畳む。
+- **Out of scope（増分）**:
+  - 非添付 action の整形表示（raw のみ、据え置き）。
+  - サムネイル（画像プレビュー）表示。snapshot も `target` も MIME タイプや画像であるかの情報を持たないため今回は出さない（将来課題）。
+  - 上流の capture・型・API 契約の変更（本 spec は read-only 消費のまま。型・型ガードは `~/interfaces/activity` を import するのみ）。
+  - `target × targetModel` の全面的な polymorphic「対象」列（将来課題）。
+- **Adjacent expectations（増分）**:
+  - ダウンロードリンクは `activity.target`（attachment ID）＋ `/download/{target}` で構築する。`target` は上流 API の応答に含まれる（`apiv3/activity` のシリアライズが `...rest` で保持し、`useSWRxActivity` が返す `IActivityHasId.target` に届くことを実測確認）。ダウンロード URL の形は attachment モデルの `downloadPathProxied`（`/download/{_id}`）に一致させる。
+  - ADD / DOWNLOAD は `MediumActionGroup` 以上でのみ記録される（`interfaces/activity.ts` で確認）。実際に snapshot が保存されるかは記録ゲート設定（`activity-log` spec が扱う）に依存する。本 spec は「記録済みデータの表示」のみを担う。
+
+### Requirement 6: 添付追加/ダウンロード action の整形表示
+
+**Objective:** 管理者として、添付ファイルの追加・ダウンロードの監査ログを、raw のキー羅列ではなく「どのファイルが、どのページで、どれだけのサイズか」を読める形で確認したい。REMOVE と同じ読みやすさを ADD/DOWNLOAD にも広げる。
+
+#### Acceptance Criteria
+
+1. When 表示対象の activity の action が `ACTION_ATTACHMENT_ADD` または `ACTION_ATTACHMENT_DOWNLOAD` である, the 監査ログビューア shall ファイル名（`originalName`）・人間可読サイズ（`fileSize`）・所属ページ（`pagePath` があればリンク）を整形表示する。
+2. The 監査ログビューア shall 要件 1.5 の併存を保つ（整形を既定タブとして見せ、raw タブで全フィールドへ常時到達でき、整形が raw を置き換えない）。
+3. If いずれかのフィールドが欠損している, the 監査ログビューア shall 要件 3.1〜3.4 と同じ独立フォールバック（欠損した欄だけをフォールバック表示し、他の描画を止めず、レンダリングエラーを起こさない）を適用する。
+
+### Requirement 7: 実体が残る添付のダウンロードリンク
+
+**Objective:** 管理者として、まだ存在する添付（ADD/DOWNLOAD）については、監査ログからその実体（ファイル）へ辿れるようにしたい。削除済み（REMOVE）との違いをここで表現する。
+
+#### Acceptance Criteria
+
+1. When action が `ACTION_ATTACHMENT_ADD` / `ACTION_ATTACHMENT_DOWNLOAD` かつ `activity.target`（attachment ID）が存在する, the 監査ログビューア shall その添付のダウンロードリンク（`/download/{target}`）を表示する。
+2. If `activity.target` が存在しない, the 監査ログビューア shall ダウンロードリンクを出さず、他フィールドの整形表示は継続する（要件 3.4 と同じ非破壊）。
+3. The 監査ログビューア shall 添付削除（REMOVE）の整形表示を変更しない（要件 2.4 のまま＝REMOVE にはダウンロードリンクを出さない）。
+4. The 監査ログビューア shall ダウンロードリンクの生成に独自の認可判定を持たせない。実体へのアクセス可否は `/download` 経路がサーバ側で行う既存の権限判定に委ねる（本 spec はリンクを描画するだけ）。
+
+### Requirement 8: ADD/DOWNLOAD レコードの後方互換
+
+**Objective:** 管理者として、本増分より前に記録された ADD/DOWNLOAD（添付フィールドを持たない catch-all snapshot、または snapshot 未設定）も、破綻なく閲覧したい。
+
+#### Acceptance Criteria
+
+1. When 本増分より前の ADD/DOWNLOAD レコード（`{ username? }` 形または snapshot 無し）を表示する, the 監査ログビューア shall 各フィールドを要件 3 と同じフォールバックで表示し、`activity.target` がある場合はダウンロードリンクのみを出す（要件 7.1）。
+2. The 監査ログビューア shall 破壊的なデータ移行を必要としない。

--- a/.kiro/specs/activity-log-snapshot-viewer/spec.json
+++ b/.kiro/specs/activity-log-snapshot-viewer/spec.json
@@ -1,7 +1,7 @@
 {
   "feature_name": "activity-log-snapshot-viewer",
   "created_at": "2026-07-10T09:49:50Z",
-  "updated_at": "2026-07-10T12:21:31Z",
+  "updated_at": "2026-07-16T00:00:00Z",
   "language": "ja",
   "phase": "tasks-approved",
   "approvals": {
@@ -18,5 +18,6 @@
       "approved": true
     }
   },
-  "ready_for_implementation": true
+  "ready_for_implementation": true,
+  "increment_note": "Initial scope (requirements 1-5, tasks 1-5) is implemented (PR #11440); task 6 (ja/ko/zh/fr translation) is a deferred follow-up. Increment (2026-07-16): ADD/DOWNLOAD formatted rendering + download link — requirements 6-8, design section, and tasks 7-10 are approved AND implemented (2026-07-16): shared LiveAttachmentSnapshotDetail for ADD/DOWNLOAD, AttachmentSnapshotFields extracted (REMOVE behavior-neutral), registry gains 2 entries, download link /download/{target}. Verified: 34 AuditLog specs green, tsgo clean, biome/import-convention clean, independent review GO. Trigger for this increment (upstream ADD/DOWNLOAD capture) was met by PR #11433. Task 6 (translation, now including audit_log_snapshot.download) remains a deferred follow-up."
 }

--- a/.kiro/specs/activity-log-snapshot-viewer/tasks.md
+++ b/.kiro/specs/activity-log-snapshot-viewer/tasks.md
@@ -80,3 +80,50 @@
 - 4.1: 「copied!」tooltip の開閉 state はテーブル共有から行ローカルへ移した（挙動は行単位で不変）。`formatDate` が ActivityTable と ActivityTableRow に重複しており、4.2 で ActivityTable を薄いコンテナへ変える際に解消すること。
 - 3.2: タブ見出し「Info」「Raw」は英語ハードコード（design の i18n 契約はフィールドラベル 8 キーのみでタブ見出しキーを定義していないため）。i18n キー化するなら admin.json を境界に含むタスク 4.2 で `audit_log_snapshot.tab_info` / `tab_raw` 等の追加を判断する。
 - 3.1: snapshot 型が全フィールド optional ＋ `FC` の呼び出しシグネチャが bivariant なため、「余分な必須フィールドを要求する Component」の誤登録は型エラーにならない。durable に検出できる誤ペアは「同名フィールドの型が矛盾する」場合のみで、負のゲートは `@ts-expect-error`（`fileSize: string` の dummy）として `snapshot-detail-renderers.spec.tsx` に常設。この directive の下の行がエラーでなくなると typecheck 自体が落ちる（TS2578）。
+
+## 増分（2026-07-16）: 添付追加/ダウンロード（ADD/DOWNLOAD）の整形表示
+
+> **位置づけ**: タスク 1〜5（raw ビューア＋REMOVE 整形）は実装完了（PR #11440）。本増分は作り直さず、宣言的レジストリに ADD/DOWNLOAD の整形 renderer を追記する。上流 `activity-log-snapshot` の ADD/DOWNLOAD capture は PR #11433 で完了済みで、着手条件は満たされている。dispatcher・テーブル・型定義・API は変更しない（read-only 消費のまま）。実装は各コンポーネント単位で先に失敗するテストを書いてから通す（red→green）。
+
+- [x] 7. Foundation: ダウンロードリンクのラベル（英語）追加
+- [x] 7.1 ダウンロードラベルを en_US に追加
+  - `apps/app/public/static/locales/en_US/admin.json` の `audit_log_snapshot` に `download`（値: "Download"）を追加する。ファイル名・サイズ・ページ等のラベルは既存キーを再利用する。
+  - ja/ko/zh/fr の翻訳は**追加しない**。既存の翻訳タスク（タスク 6.1）の対象キーに本キーを含める（後続・英語ファースト）。
+  - 完了状態: en_US に `audit_log_snapshot.download` が存在し、未翻訳ロケールでは i18next フォールバックで英語表示になる。
+  - _Requirements: 4.1, 4.3_
+
+- [x] 8. Core: 実体が残る添付の整形レンダラ（ADD/DOWNLOAD 共有）
+- [x] 8.1 (P) 共有フィールド部品 `AttachmentSnapshotFields` を抽出し、REMOVE 整形を置き換える（挙動不変）
+  - `AttachmentRemoveSnapshotDetail` のファイル名・人間可読サイズ・所属ページリンクの描画を、presentational な `AttachmentSnapshotFields`（`snapshot-detail/` 内の内部コンポーネント。barrel には公開しない）へ抽出する。`AttachmentRemoveSnapshotDetail` はこの共有部品を使う薄いラッパにする（ダウンロードリンクは足さない＝要件 2.4/7.3）。
+  - 先に既存 `AttachmentRemoveSnapshotDetail.spec.tsx` が green のまま（抽出前後で観察可能な出力が不変）であることを確認する回帰テストにする。フォールバック（`originalName`/`pagePath`/`fileSize` 各欠損）の断言を共有部品側でも担保する。
+  - 完了状態: REMOVE の描画が抽出前と同一（ダウンロードリンクは依然出ない）。共有部品の unit spec が green。
+  - _Requirements: 2.1-2.4, 3.1-3.4, 7.3_
+
+- [x] 8.2 (P) `LiveAttachmentSnapshotDetail`（ADD/DOWNLOAD 共有）を新規追加
+  - 先に失敗する unit spec を書く（red）→ green: `AttachmentSnapshotFields`（ファイル名/サイズ/ページ）に**ダウンロードリンク行**を1つ足したコンポーネント。`activity.target != null` のとき `href={/download/${activity.target}}` のリンクを、ラベル `audit_log_snapshot.download` で描画する。`target` 欠損時はリンク行を出さず、他フィールドは描画を継続する。
+  - props は `defineRenderer` が要求する絞り込み型 `IActivityHasId & { snapshot?: AttachmentSnapshot }` を受け取り、renderer 内で再 narrow しない。`target` は `IActivityHasId` 側のフィールドから読む。
+  - unit spec の断言（観察可能な出力のみ）: (a) 全フィールド＋`target` 有り→ファイル名・整形サイズ・ページリンク・`/download/{target}` の href リンク、(b) `target` 欠損→ダウンロードリンクが**無い**が他は出る、(c) 各フィールド欠損→対応フォールバック文言。
+  - 完了状態: 上記 spec が green。REMOVE の spec は影響を受けない。
+  - _Requirements: 6.1, 6.3, 7.1, 7.2, 7.4, 8.1_
+  - _Depends: 7.1, 8.1_
+
+- [x] 9. Core: レジストリへ ADD/DOWNLOAD を追記
+- [x] 9.1 `snapshot-detail-renderers` に ADD/DOWNLOAD の2エントリを追記
+  - `defineRenderer(isAttachmentAddActivity, LiveAttachmentSnapshotDetail)` と `defineRenderer(isAttachmentDownloadActivity, LiveAttachmentSnapshotDetail)` を配列に追記する（REMOVE エントリは不変。dispatcher・テーブルは触らない）。
+  - 既存 `snapshot-detail-renderers.spec.tsx` を拡張: `action=ATTACHMENT_ADD` / `=ATTACHMENT_DOWNLOAD` が `LiveAttachmentSnapshotDetail` に、`=ATTACHMENT_REMOVE` が `AttachmentRemoveSnapshotDetail` に解決されること（`canRender` の排他性）を断言する。既存の負ゲート（`@ts-expect-error` の誤ペア検出）は維持する。
+  - 完了状態: レジストリ 3 エントリ、既存＋新規の解決テストが green。dispatcher/テーブルの差分が無い。
+  - _Requirements: 6.1, 6.2_
+  - _Depends: 8.2_
+
+- [x] 10. Validation: 混在レンダリングの結合テスト拡張
+- [x] 10.1 (P) 混在一覧に ADD/DOWNLOAD 行を追加して検証
+  - 既存の混在結合テスト（`ActivityTable.spec.tsx`）の `activityList` に、ADD 行・DOWNLOAD 行（添付フィールド有り、`target` 有り）と、後方互換確認用の「添付フィールド無し ADD 行」を加える。
+  - 展開時: ADD/DOWNLOAD は既定タブで整形（ファイル名・サイズ・ページ・**ダウンロードリンク**）が出て、raw タブで全フィールドへ到達できる。REMOVE 行は従来どおりダウンロードリンク無し。旧レコード（snapshot 無し/username のみ）は破綻しない。
+  - 完了状態: 拡張した混在 spec が green。既存の REMOVE/旧レコードの断言は不変。
+  - _Requirements: 6.1, 6.2, 7.1, 7.3, 8.1_
+  - _Depends: 9.1_
+
+## Implementation Notes（増分）
+
+- ダウンロード URL は attachment モデルの `downloadPathProxied`（`/download/{_id}`）に一致させる。`activity.target` が attachment ID であること・API 応答に載ること・URL 形は、design の「増分の Boundary / Security」節に実測根拠を記載済み。inline 表示用の `/attachment/{_id}`（`filePathProxied`）ではなく、監査用途に合う強制ダウンロードの `/download/{_id}` を採用する。
+- サムネイル表示は本増分の対象外（snapshot も `target` も MIME/画像判定情報を持たないため）。将来課題として flagship `activity-log` の関心マップで管理する。

--- a/apps/app/public/static/locales/en_US/admin.json
+++ b/apps/app/public/static/locales/en_US/admin.json
@@ -973,7 +973,8 @@
     "no_detail": "No snapshot detail available",
     "unknown_file_name": "Unknown file name",
     "page_unavailable": "Page unavailable",
-    "unknown_size": "Unknown size"
+    "unknown_size": "Unknown size",
+    "download": "Download"
   },
   "g2g_data_transfer": {
     "transfer_data_to_another_growi": "Transfer data from this GROWI to another GROWI",

--- a/apps/app/src/client/components/Admin/AuditLog/ActivityTable.spec.tsx
+++ b/apps/app/src/client/components/Admin/AuditLog/ActivityTable.spec.tsx
@@ -103,10 +103,64 @@ const attachmentRemoveActivity = buildActivity({
   },
 });
 
+// New record: ATTACHMENT_ADD with a full attachment snapshot. The file still
+// exists, so `target` (the attachment id) drives a download link.
+const attachmentAddActivity = buildActivity({
+  _id: 'activity-id-new-d',
+  action: SupportedAction.ACTION_ATTACHMENT_ADD,
+  ip: '10.0.0.4',
+  endpoint: '/attachment-add',
+  target: 'attachment-id-add',
+  user: mock<IUserHasId>({ _id: 'user-id-d', username: 'dave' }),
+  snapshot: {
+    username: 'dave',
+    originalName: 'diagram.png',
+    pagePath: '/design',
+    pageId: 'page-id-2',
+    fileSize: 2048,
+  },
+});
+
+// New record: ATTACHMENT_DOWNLOAD with a full attachment snapshot. Shares the
+// live-attachment renderer with ADD (same shape, file still exists).
+const attachmentDownloadActivity = buildActivity({
+  _id: 'activity-id-new-e',
+  action: SupportedAction.ACTION_ATTACHMENT_DOWNLOAD,
+  ip: '10.0.0.5',
+  endpoint: '/attachment-download',
+  target: 'attachment-id-dl',
+  user: mock<IUserHasId>({ _id: 'user-id-e', username: 'erin' }),
+  snapshot: {
+    username: 'erin',
+    originalName: 'manual.pdf',
+    pagePath: '/docs',
+    pageId: 'page-id-3',
+    fileSize: 4096,
+  },
+});
+
+// Backward-compat record: an ATTACHMENT_ADD recorded before the attachment
+// snapshot capture existed — its snapshot has only `username` (no attachment
+// fields), but the activity still carries `target` (a core activity field that
+// predates the snapshot increment). The live renderer must fall back per field
+// yet still offer the download link (Requirement 8.1).
+const legacyAttachmentAddActivity = buildActivity({
+  _id: 'activity-id-legacy-add',
+  action: SupportedAction.ACTION_ATTACHMENT_ADD,
+  ip: '10.0.0.6',
+  endpoint: '/attachment-add-legacy',
+  target: 'attachment-id-legacy-add',
+  user: mock<IUserHasId>({ _id: 'user-id-f', username: 'frank' }),
+  snapshot: { username: 'frank' },
+});
+
 const mixedActivityList: IActivityHasId[] = [
   legacyUsernameOnlyActivity,
   legacyNoSnapshotActivity,
   attachmentRemoveActivity,
+  attachmentAddActivity,
+  attachmentDownloadActivity,
+  legacyAttachmentAddActivity,
 ];
 
 // Each fixture's `ip` is unique, so it identifies the fixture's own <tr> even
@@ -131,13 +185,13 @@ const expandRowByIp = async (
 };
 
 describe('ActivityTable (feature-level, mixed legacy/new records)', () => {
-  it('renders all three rows without throwing, keeping the existing user/action display for legacy rows (Requirements 1.2, 5.1, 5.3)', () => {
+  it('renders every row without throwing, keeping the existing user/action display for legacy rows (Requirements 1.2, 5.1, 5.3)', () => {
     expect(() =>
       render(<ActivityTable activityList={mixedActivityList} />),
     ).not.toThrow();
 
-    // 3 main rows, one per activity
-    expect(screen.getAllByTestId('activity-table')).toHaveLength(3);
+    // One main row per activity
+    expect(screen.getAllByTestId('activity-table')).toHaveLength(6);
 
     // Legacy record A: username-only snapshot renders the username as before
     expect(screen.getByText('legacy-user-a')).toBeInTheDocument();
@@ -221,6 +275,89 @@ describe('ActivityTable (feature-level, mixed legacy/new records)', () => {
     for (const anchor of detailRow.querySelectorAll('a')) {
       expect(anchor.getAttribute('href')).not.toMatch(/download/i);
     }
+  });
+
+  it('expanding the ATTACHMENT_ADD row shows the formatted view with a download link to /download/{target}, and the raw tab still reveals every field (Requirements 6.1, 6.2, 7.1)', async () => {
+    const user = userEvent.setup();
+    render(<ActivityTable activityList={mixedActivityList} />);
+
+    await expandRowByIp(user, '10.0.0.4');
+
+    const detailRow = screen.getByTestId('activity-snapshot-detail');
+
+    // Formatted view is the default
+    expect(
+      within(detailRow).getByText('admin:audit_log_snapshot.file_name'),
+    ).toBeInTheDocument();
+    expect(within(detailRow).getByText('diagram.png')).toBeInTheDocument();
+    expect(within(detailRow).getByText(prettyBytes(2048))).toBeInTheDocument();
+    expect(
+      within(detailRow).getByRole('link', { name: 'design' }),
+    ).toHaveAttribute('href', '/design');
+
+    // A still-existing attachment shows a download link built from `target`
+    expect(
+      within(detailRow).getByRole('link', {
+        name: 'admin:audit_log_snapshot.download',
+      }),
+    ).toHaveAttribute('href', '/download/attachment-id-add');
+
+    // Info is selected, Raw is reachable
+    expect(
+      within(detailRow).getByRole('tab', { name: 'Info' }),
+    ).toHaveAttribute('aria-selected', 'true');
+
+    // Raw tab reveals all fields, including pageId (formatting augments raw)
+    await user.click(within(detailRow).getByRole('tab', { name: 'Raw' }));
+    expect(within(detailRow).getByText('pageId')).toBeInTheDocument();
+    expect(within(detailRow).getByText('page-id-2')).toBeInTheDocument();
+  });
+
+  it('expanding the ATTACHMENT_DOWNLOAD row shows the same formatted view with a download link (shared renderer with ADD) (Requirements 6.1, 7.1)', async () => {
+    const user = userEvent.setup();
+    render(<ActivityTable activityList={mixedActivityList} />);
+
+    await expandRowByIp(user, '10.0.0.5');
+
+    const detailRow = screen.getByTestId('activity-snapshot-detail');
+
+    expect(within(detailRow).getByText('manual.pdf')).toBeInTheDocument();
+    expect(within(detailRow).getByText(prettyBytes(4096))).toBeInTheDocument();
+    expect(
+      within(detailRow).getByRole('link', { name: 'docs' }),
+    ).toHaveAttribute('href', '/docs');
+    expect(
+      within(detailRow).getByRole('link', {
+        name: 'admin:audit_log_snapshot.download',
+      }),
+    ).toHaveAttribute('href', '/download/attachment-id-dl');
+  });
+
+  it('expanding a legacy ATTACHMENT_ADD row (no attachment fields) falls back per field yet still shows the download link from target (Requirements 8.1, 7.1)', async () => {
+    const user = userEvent.setup();
+    render(<ActivityTable activityList={mixedActivityList} />);
+
+    await expandRowByIp(user, '10.0.0.6');
+
+    const detailRow = screen.getByTestId('activity-snapshot-detail');
+
+    // Attachment fields are missing → per-field fallbacks, no throw
+    expect(
+      within(detailRow).getByText('admin:audit_log_snapshot.unknown_file_name'),
+    ).toBeInTheDocument();
+    expect(
+      within(detailRow).getByText('admin:audit_log_snapshot.unknown_size'),
+    ).toBeInTheDocument();
+    expect(
+      within(detailRow).getByText('admin:audit_log_snapshot.page_unavailable'),
+    ).toBeInTheDocument();
+
+    // The download link still appears because `target` is present
+    expect(
+      within(detailRow).getByRole('link', {
+        name: 'admin:audit_log_snapshot.download',
+      }),
+    ).toHaveAttribute('href', '/download/attachment-id-legacy-add');
   });
 
   it('expanding a legacy username-only row shows raw only (no tab chrome), with the username field visible as key-value (Requirements 1.2, 5.1)', async () => {

--- a/apps/app/src/client/components/Admin/AuditLog/snapshot-detail/AttachmentRemoveSnapshotDetail.tsx
+++ b/apps/app/src/client/components/Admin/AuditLog/snapshot-detail/AttachmentRemoveSnapshotDetail.tsx
@@ -1,13 +1,11 @@
 import type { FC } from 'react';
-import prettyBytes from 'pretty-bytes';
-import { useTranslation } from 'react-i18next';
 
-import { PagePathHierarchicalLink } from '~/components/Common/PagePathHierarchicalLink';
 import type {
   AttachmentRemoveSnapshot,
   IActivityHasId,
 } from '~/interfaces/activity';
-import { LinkedPagePath } from '~/models/linked-page-path';
+
+import { AttachmentSnapshotFields } from './AttachmentSnapshotFields';
 
 type AttachmentRemoveSnapshotDetailProps = {
   activity: IActivityHasId & { snapshot?: AttachmentRemoveSnapshot };
@@ -15,52 +13,25 @@ type AttachmentRemoveSnapshotDetailProps = {
 
 /**
  * Formatted viewer for an ATTACHMENT_REMOVE activity's snapshot: file name,
- * human-readable size, and a link to the page the attachment belonged to.
- * The renderer is registered only for the REMOVE action (see
- * snapshot-detail-renderers), so `activity` arrives already narrowed to
- * `snapshot?: AttachmentRemoveSnapshot` and is not re-narrowed here.
+ * human-readable size, and a link to the page the attachment belonged to
+ * (delegated to AttachmentSnapshotFields). The renderer is registered only for
+ * the REMOVE action (see snapshot-detail-renderers), so `activity` arrives
+ * already narrowed to `snapshot?: AttachmentRemoveSnapshot` and is not
+ * re-narrowed here.
  *
- * Every field is judged independently so that one missing field never stops
- * the others from rendering. No download link is ever rendered here: the
- * underlying file no longer exists once it has been removed.
+ * No download link is ever rendered: the underlying file no longer exists once
+ * it has been removed. This is the sole behavioral difference from the
+ * still-existing-attachment renderer (LiveAttachmentSnapshotDetail), which adds
+ * a download link on top of the same shared fields.
  */
 export const AttachmentRemoveSnapshotDetail: FC<
   AttachmentRemoveSnapshotDetailProps
 > = (props) => {
   const { activity } = props;
-  const { t } = useTranslation();
-
-  const { originalName, fileSize, pagePath } = activity.snapshot ?? {};
-
-  const fileNameContent =
-    originalName ?? t('admin:audit_log_snapshot.unknown_file_name');
-  // `fileSize` may legitimately be 0 (an empty file), so check presence with
-  // `== null` rather than falsiness.
-  const fileSizeContent =
-    fileSize == null
-      ? t('admin:audit_log_snapshot.unknown_size')
-      : prettyBytes(fileSize);
-  const pageContent =
-    pagePath != null ? (
-      <PagePathHierarchicalLink linkedPagePath={new LinkedPagePath(pagePath)} />
-    ) : (
-      t('admin:audit_log_snapshot.page_unavailable')
-    );
 
   return (
     <dl className="row mb-0">
-      <div className="col-12 d-flex">
-        <dt className="me-2">{t('admin:audit_log_snapshot.file_name')}</dt>
-        <dd>{fileNameContent}</dd>
-      </div>
-      <div className="col-12 d-flex">
-        <dt className="me-2">{t('admin:audit_log_snapshot.file_size')}</dt>
-        <dd>{fileSizeContent}</dd>
-      </div>
-      <div className="col-12 d-flex">
-        <dt className="me-2">{t('admin:audit_log_snapshot.page')}</dt>
-        <dd>{pageContent}</dd>
-      </div>
+      <AttachmentSnapshotFields snapshot={activity.snapshot} />
     </dl>
   );
 };

--- a/apps/app/src/client/components/Admin/AuditLog/snapshot-detail/AttachmentSnapshotFields.tsx
+++ b/apps/app/src/client/components/Admin/AuditLog/snapshot-detail/AttachmentSnapshotFields.tsx
@@ -1,0 +1,64 @@
+import type { FC } from 'react';
+import prettyBytes from 'pretty-bytes';
+import { useTranslation } from 'react-i18next';
+
+import { PagePathHierarchicalLink } from '~/components/Common/PagePathHierarchicalLink';
+import type { AttachmentSnapshot } from '~/interfaces/activity';
+import { LinkedPagePath } from '~/models/linked-page-path';
+
+type AttachmentSnapshotFieldsProps = {
+  snapshot?: AttachmentSnapshot;
+};
+
+/**
+ * Presentational fields shared by every attachment snapshot renderer: file
+ * name, human-readable size, and a link to the page the attachment belonged
+ * to. Returns the `<dt>`/`<dd>` rows only (no `<dl>` wrapper) so the caller
+ * owns the list and can append its own rows (e.g. a download link for
+ * still-existing attachments).
+ *
+ * Every field is judged independently so that one missing field never stops
+ * the others from rendering. This component holds no download link: whether a
+ * link is appropriate depends on the action (removed vs. still existing) and
+ * is decided by the caller.
+ */
+export const AttachmentSnapshotFields: FC<AttachmentSnapshotFieldsProps> = (
+  props,
+) => {
+  const { snapshot } = props;
+  const { t } = useTranslation();
+
+  const { originalName, fileSize, pagePath } = snapshot ?? {};
+
+  const fileNameContent =
+    originalName ?? t('admin:audit_log_snapshot.unknown_file_name');
+  // `fileSize` may legitimately be 0 (an empty file), so check presence with
+  // `== null` rather than falsiness.
+  const fileSizeContent =
+    fileSize == null
+      ? t('admin:audit_log_snapshot.unknown_size')
+      : prettyBytes(fileSize);
+  const pageContent =
+    pagePath != null ? (
+      <PagePathHierarchicalLink linkedPagePath={new LinkedPagePath(pagePath)} />
+    ) : (
+      t('admin:audit_log_snapshot.page_unavailable')
+    );
+
+  return (
+    <>
+      <div className="col-12 d-flex">
+        <dt className="me-2">{t('admin:audit_log_snapshot.file_name')}</dt>
+        <dd>{fileNameContent}</dd>
+      </div>
+      <div className="col-12 d-flex">
+        <dt className="me-2">{t('admin:audit_log_snapshot.file_size')}</dt>
+        <dd>{fileSizeContent}</dd>
+      </div>
+      <div className="col-12 d-flex">
+        <dt className="me-2">{t('admin:audit_log_snapshot.page')}</dt>
+        <dd>{pageContent}</dd>
+      </div>
+    </>
+  );
+};

--- a/apps/app/src/client/components/Admin/AuditLog/snapshot-detail/LiveAttachmentSnapshotDetail.spec.tsx
+++ b/apps/app/src/client/components/Admin/AuditLog/snapshot-detail/LiveAttachmentSnapshotDetail.spec.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment happy-dom
+
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import prettyBytes from 'pretty-bytes';
+
+import type { AttachmentSnapshot, IActivityHasId } from '~/interfaces/activity';
+import { SupportedAction } from '~/interfaces/activity';
+
+import { LiveAttachmentSnapshotDetail } from './LiveAttachmentSnapshotDetail';
+
+// `t` returns the i18n key verbatim (established convention for admin AuditLog
+// specs; see AttachmentRemoveSnapshotDetail.spec.tsx), so assertions target the
+// key itself.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// next/link reaches for the Pages-Router context (prefetch); render a plain
+// anchor so PagePathHierarchicalLink is queryable without a router provider
+// (established convention; see AttachmentRemoveSnapshotDetail.spec.tsx).
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+type ActivityWithAttachmentSnapshot = IActivityHasId & {
+  snapshot?: AttachmentSnapshot;
+};
+
+const buildActivity = (
+  overrides: Partial<ActivityWithAttachmentSnapshot> = {},
+): ActivityWithAttachmentSnapshot => ({
+  _id: 'activity-id-1',
+  action: SupportedAction.ACTION_ATTACHMENT_ADD,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  target: 'attachment-id-1',
+  snapshot: {
+    originalName: 'photo.png',
+    fileSize: 123456,
+    pagePath: '/reports',
+  },
+  ...overrides,
+});
+
+const getDownloadLink = (): HTMLAnchorElement | null =>
+  screen.queryByRole('link', {
+    name: 'admin:audit_log_snapshot.download',
+  }) as HTMLAnchorElement | null;
+
+describe('LiveAttachmentSnapshotDetail', () => {
+  it('renders the file name, human-readable size, a page link, and a download link to /download/{target} when every field and the target are present', () => {
+    const activity = buildActivity();
+
+    render(<LiveAttachmentSnapshotDetail activity={activity} />);
+
+    // Shared fields
+    expect(
+      screen.getByText('admin:audit_log_snapshot.file_name'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('photo.png')).toBeInTheDocument();
+    expect(screen.getByText(prettyBytes(123456))).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'reports' })).toHaveAttribute(
+      'href',
+      '/reports',
+    );
+
+    // Download link built from the activity's target (the attachment id)
+    const downloadLink = getDownloadLink();
+    expect(downloadLink).toHaveAttribute('href', '/download/attachment-id-1');
+  });
+
+  it('does not render a download link when the target is absent, while the other fields still render', () => {
+    const activity = buildActivity({ target: undefined });
+
+    render(<LiveAttachmentSnapshotDetail activity={activity} />);
+
+    // No download link
+    expect(getDownloadLink()).not.toBeInTheDocument();
+    // No anchor points at a download path at all
+    for (const anchor of document.querySelectorAll('a')) {
+      expect(anchor.getAttribute('href')).not.toMatch(/\/download\//);
+    }
+
+    // Other fields still render
+    expect(screen.getByText('photo.png')).toBeInTheDocument();
+    expect(screen.getByText(prettyBytes(123456))).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'reports' })).toBeInTheDocument();
+  });
+
+  it('falls back per field when originalName / pagePath / fileSize are missing, still showing the download link when target is present', () => {
+    const activity = buildActivity({ snapshot: {} });
+
+    expect(() =>
+      render(<LiveAttachmentSnapshotDetail activity={activity} />),
+    ).not.toThrow();
+
+    expect(
+      screen.getByText('admin:audit_log_snapshot.unknown_file_name'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('admin:audit_log_snapshot.unknown_size'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('admin:audit_log_snapshot.page_unavailable'),
+    ).toBeInTheDocument();
+
+    // The download link depends on target, not on the snapshot fields
+    expect(getDownloadLink()).toHaveAttribute(
+      'href',
+      '/download/attachment-id-1',
+    );
+  });
+
+  it('treats a fileSize of 0 bytes as present, not missing', () => {
+    const activity = buildActivity({
+      snapshot: {
+        originalName: 'empty.txt',
+        fileSize: 0,
+        pagePath: '/reports',
+      },
+    });
+
+    render(<LiveAttachmentSnapshotDetail activity={activity} />);
+
+    expect(screen.getByText(prettyBytes(0))).toBeInTheDocument();
+    expect(
+      screen.queryByText('admin:audit_log_snapshot.unknown_size'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/app/src/client/components/Admin/AuditLog/snapshot-detail/LiveAttachmentSnapshotDetail.tsx
+++ b/apps/app/src/client/components/Admin/AuditLog/snapshot-detail/LiveAttachmentSnapshotDetail.tsx
@@ -1,0 +1,45 @@
+import type { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { AttachmentSnapshot, IActivityHasId } from '~/interfaces/activity';
+
+import { AttachmentSnapshotFields } from './AttachmentSnapshotFields';
+
+type LiveAttachmentSnapshotDetailProps = {
+  activity: IActivityHasId & { snapshot?: AttachmentSnapshot };
+};
+
+/**
+ * Formatted viewer for an attachment activity whose file still exists
+ * (ACTION_ATTACHMENT_ADD / ACTION_ATTACHMENT_DOWNLOAD). Shares the file name /
+ * size / page fields with the REMOVE renderer via AttachmentSnapshotFields, and
+ * additionally links to the live file.
+ *
+ * Registered for both ADD and DOWNLOAD (see snapshot-detail-renderers), so
+ * `activity` arrives already narrowed and is not re-narrowed here. The download
+ * link is built from the activity's `target` (the attachment id, exposed by the
+ * audit-log API) to match the attachment's `downloadPathProxied`
+ * (`/download/{id}`). When `target` is absent (e.g. a legacy record) the link is
+ * simply omitted while the other fields still render.
+ */
+export const LiveAttachmentSnapshotDetail: FC<
+  LiveAttachmentSnapshotDetailProps
+> = (props) => {
+  const { activity } = props;
+  const { t } = useTranslation();
+
+  const { target } = activity;
+
+  return (
+    <dl className="row mb-0">
+      <AttachmentSnapshotFields snapshot={activity.snapshot} />
+      {target != null && (
+        <div className="col-12">
+          <a href={`/download/${target}`}>
+            {t('admin:audit_log_snapshot.download')}
+          </a>
+        </div>
+      )}
+    </dl>
+  );
+};

--- a/apps/app/src/client/components/Admin/AuditLog/snapshot-detail/snapshot-detail-renderers.spec.tsx
+++ b/apps/app/src/client/components/Admin/AuditLog/snapshot-detail/snapshot-detail-renderers.spec.tsx
@@ -7,39 +7,64 @@ import {
 } from '~/interfaces/activity';
 
 import { AttachmentRemoveSnapshotDetail } from './AttachmentRemoveSnapshotDetail';
+import { LiveAttachmentSnapshotDetail } from './LiveAttachmentSnapshotDetail';
 import {
   defineRenderer,
   snapshotDetailRenderers,
 } from './snapshot-detail-renderers';
 
-// This spec is primarily a TYPE-LEVEL gate: the `@ts-expect-error` below fails
+// This spec is partly a TYPE-LEVEL gate: the `@ts-expect-error` below fails
 // `tsgo --noEmit` (as "Unused '@ts-expect-error' directive") if the mismatched
 // pairing ever stops being a compile error, so it durably proves property (a) of
 // defineRenderer. The runtime `it`s document the registry's observable contract.
 
+const buildActivity = (action: IActivityHasId['action']): IActivityHasId => ({
+  _id: `activity-id-${action}`,
+  action,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  snapshot: { originalName: 'photo.png' },
+});
+
+// The registered Component is widened to FC<{ activity: IActivityHasId }> by
+// defineRenderer, so returning `unknown` here lets the identity assertions
+// compare against the concrete component without fighting the widening.
+const componentFor = (activity: IActivityHasId): unknown =>
+  snapshotDetailRenderers.find((r) => r.canRender(activity))?.Component;
+
 describe('snapshot-detail-renderers', () => {
-  it('registers exactly one entry (the ATTACHMENT_REMOVE renderer)', () => {
-    expect(snapshotDetailRenderers).toHaveLength(1);
+  it('registers one entry per attachment action (REMOVE, ADD, DOWNLOAD)', () => {
+    expect(snapshotDetailRenderers).toHaveLength(3);
   });
 
-  it('discriminates the registered entry purely by action', () => {
-    const [entry] = snapshotDetailRenderers;
+  it('routes each attachment action to its renderer purely by action', () => {
+    // ADD and DOWNLOAD share the live-attachment renderer; REMOVE has its own.
+    expect(
+      componentFor(buildActivity(SupportedAction.ACTION_ATTACHMENT_ADD)),
+    ).toBe(LiveAttachmentSnapshotDetail);
+    expect(
+      componentFor(buildActivity(SupportedAction.ACTION_ATTACHMENT_DOWNLOAD)),
+    ).toBe(LiveAttachmentSnapshotDetail);
+    expect(
+      componentFor(buildActivity(SupportedAction.ACTION_ATTACHMENT_REMOVE)),
+    ).toBe(AttachmentRemoveSnapshotDetail);
+  });
 
-    const removeActivity: IActivityHasId = {
-      _id: 'activity-id-remove',
-      action: SupportedAction.ACTION_ATTACHMENT_REMOVE,
-      createdAt: new Date('2026-01-01T00:00:00.000Z'),
-      snapshot: { originalName: 'photo.png' },
-    };
-    const otherActivity: IActivityHasId = {
-      _id: 'activity-id-other',
-      action: SupportedAction.ACTION_PAGE_CREATE,
-      createdAt: new Date('2026-01-01T00:00:00.000Z'),
-      snapshot: { username: 'alice' },
-    };
+  it('matches no entry for an unrelated action (raw fallback territory)', () => {
+    const other = buildActivity(SupportedAction.ACTION_PAGE_CREATE);
+    expect(snapshotDetailRenderers.some((r) => r.canRender(other))).toBe(false);
+  });
 
-    expect(entry.canRender(removeActivity)).toBe(true);
-    expect(entry.canRender(otherActivity)).toBe(false);
+  it('keeps the entries mutually exclusive (each action matches exactly one)', () => {
+    for (const action of [
+      SupportedAction.ACTION_ATTACHMENT_ADD,
+      SupportedAction.ACTION_ATTACHMENT_REMOVE,
+      SupportedAction.ACTION_ATTACHMENT_DOWNLOAD,
+    ]) {
+      const matches = snapshotDetailRenderers.filter((r) =>
+        r.canRender(buildActivity(action)),
+      );
+      expect(matches).toHaveLength(1);
+    }
   });
 
   it('accepts a guard paired with its matching component (compiles)', () => {
@@ -70,6 +95,6 @@ describe('snapshot-detail-renderers', () => {
     // requiring fileSize: string is not an assignable pairing.
     defineRenderer(isAttachmentRemoveActivity, MismatchedComponent);
 
-    expect(snapshotDetailRenderers).toHaveLength(1);
+    expect(snapshotDetailRenderers).toHaveLength(3);
   });
 });

--- a/apps/app/src/client/components/Admin/AuditLog/snapshot-detail/snapshot-detail-renderers.ts
+++ b/apps/app/src/client/components/Admin/AuditLog/snapshot-detail/snapshot-detail-renderers.ts
@@ -1,9 +1,14 @@
 import type { FC } from 'react';
 
 import type { IActivity, IActivityHasId } from '~/interfaces/activity';
-import { isAttachmentRemoveActivity } from '~/interfaces/activity';
+import {
+  isAttachmentAddActivity,
+  isAttachmentDownloadActivity,
+  isAttachmentRemoveActivity,
+} from '~/interfaces/activity';
 
 import { AttachmentRemoveSnapshotDetail } from './AttachmentRemoveSnapshotDetail';
+import { LiveAttachmentSnapshotDetail } from './LiveAttachmentSnapshotDetail';
 
 /**
  * A per-action formatted renderer. The dispatcher (ActivitySnapshotDetail) picks
@@ -57,10 +62,13 @@ export const defineRenderer = <
  *   mutually exclusive (1 action = 1 entry).
  * - The dispatcher picks the FIRST match, so array order is precedence order.
  *
- * Adding a formatted renderer for another action is a one-line append here (e.g.
- * `defineRenderer(isAttachmentAddActivity, AttachmentAddSnapshotDetail)` once the
- * upstream ADD capture and guard exist); the dispatcher and table are untouched.
+ * Adding a formatted renderer for another action is a one-line append here; the
+ * dispatcher and table are untouched. ADD and DOWNLOAD share one renderer
+ * (LiveAttachmentSnapshotDetail): their snapshots have the same shape and both
+ * files still exist, so both get the same formatted view plus a download link.
  */
 export const snapshotDetailRenderers: SnapshotDetailRenderer[] = [
   defineRenderer(isAttachmentRemoveActivity, AttachmentRemoveSnapshotDetail),
+  defineRenderer(isAttachmentAddActivity, LiveAttachmentSnapshotDetail),
+  defineRenderer(isAttachmentDownloadActivity, LiveAttachmentSnapshotDetail),
 ];


### PR DESCRIPTION
## Summary

Follow-up increment to #11440 (audit-log snapshot detail viewer). #11440 shipped the raw snapshot viewer plus a formatted view for attachment **removal** (`ACTION_ATTACHMENT_REMOVE`). This PR extends the same declarative renderer registry to also format attachment **add** and **download** activities (`ACTION_ATTACHMENT_ADD` / `ACTION_ATTACHMENT_DOWNLOAD`).

The upstream snapshot capture for ADD/DOWNLOAD landed in #11433, which satisfied the "future increment" trigger the original design recorded — so this is purely a **read/UI** change: no changes to activity types, the audit-log API, or the capture side.

## What changed

- **`LiveAttachmentSnapshotDetail`** (new) — one shared renderer for ADD and DOWNLOAD. ADD and DOWNLOAD snapshots have the same shape as REMOVE, and their files still exist, so both get the same formatted fields **plus a download link**.
- **`AttachmentSnapshotFields`** (new, internal) — the file name / human-readable size / page-link rows, extracted from `AttachmentRemoveSnapshotDetail` so REMOVE and the live renderer share them. `AttachmentRemoveSnapshotDetail` is now a thin wrapper; **its observable behavior is unchanged** (still no download link, since the file is gone).
- **Download link** — built as `/download/{activity.target}` (matching the attachment model's `downloadPathProxied`). `activity.target` is the attachment id, already exposed by the audit-log API. The link is omitted when `target` is absent; REMOVE never shows one.
- **Registry** — two entries appended (`isAttachmentAddActivity` → live renderer, `isAttachmentDownloadActivity` → live renderer). The dispatcher, `ActivityTable`, `ActivityTableRow`, and the activity types are **untouched** (the registry is the designed extension point).
- **i18n** — adds the `en_US` `audit_log_snapshot.download` label. Other locales (ja/ko/zh/fr) are folded into the existing deferred translation task; until then i18next falls back to English.

## Out of scope (intentional)

- Thumbnails / image previews (neither the snapshot nor `target` carries MIME/type info).
- Formatted views for non-attachment actions (raw only).
- Any change to upstream capture, activity types, or the API.

## Testing

- **34 AuditLog component specs pass** (7 files), incl. new `LiveAttachmentSnapshotDetail` unit specs, extended registry discrimination specs (with the `@ts-expect-error` type-level gate preserved), and the mixed legacy/new feature-level integration test extended with ADD/DOWNLOAD rows (formatted default + download link + raw-tab reachable) and a backward-compat legacy-ADD row (per-field fallback + download link from `target`).
- `tsgo --noEmit`, Biome, and `lint:import-convention` all clean.

## Spec

`.kiro/specs/activity-log-snapshot-viewer/` updated with the increment: Requirements 6–8, a design section, and tasks 7–10 (all implemented). See `spec.json` `increment_note`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
