### PR TITLE
imprv(activity): fetch audit log via POST to avoid long-URL risk

### DIFF
--- a/apps/app/src/client/components/Admin/AuditLog/build-search-filter.spec.ts
+++ b/apps/app/src/client/components/Admin/AuditLog/build-search-filter.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for buildActivitySearchFilter (pure function).
+ *
+ * Contract: given the selected/available actions plus dates and usernames,
+ * produce the ISearchFilter the audit-log list request sends. The key behaviour
+ * under test is the `actions` omission: when every available action is selected
+ * the filter must NOT carry `actions` (server matches everything, request stays
+ * small); a strict subset must carry exactly the selected actions.
+ */
+
+import type { SupportedActionType } from '~/interfaces/activity';
+
+import { buildActivitySearchFilter } from './build-search-filter';
+
+const AVAILABLE = [
+  'PAGE_CREATE',
+  'PAGE_UPDATE',
+  'PAGE_DELETE',
+] as SupportedActionType[];
+
+const DATES = { startDate: '', endDate: '' };
+
+describe('buildActivitySearchFilter', () => {
+  describe('actions omission', () => {
+    it('omits actions when every available action is selected', () => {
+      const filter = buildActivitySearchFilter({
+        selectedActions: [...AVAILABLE],
+        availableActions: AVAILABLE,
+        dates: DATES,
+        usernames: [],
+      });
+
+      expect(filter).not.toHaveProperty('actions');
+    });
+
+    it('omits actions regardless of selection order', () => {
+      const filter = buildActivitySearchFilter({
+        selectedActions: ['PAGE_DELETE', 'PAGE_CREATE', 'PAGE_UPDATE'],
+        availableActions: AVAILABLE,
+        dates: DATES,
+        usernames: [],
+      });
+
+      expect(filter).not.toHaveProperty('actions');
+    });
+
+    it('includes exactly the selected actions when a strict subset is selected', () => {
+      const filter = buildActivitySearchFilter({
+        selectedActions: ['PAGE_CREATE', 'PAGE_UPDATE'],
+        availableActions: AVAILABLE,
+        dates: DATES,
+        usernames: [],
+      });
+
+      expect(filter.actions).toEqual(['PAGE_CREATE', 'PAGE_UPDATE']);
+    });
+
+    it('includes actions:[] when nothing is selected (→ server returns zero rows)', () => {
+      // Unchecking every action must stay observable as "zero results", not
+      // collapse into the all-selected "match everything" case.
+      const filter = buildActivitySearchFilter({
+        selectedActions: [],
+        availableActions: AVAILABLE,
+        dates: DATES,
+        usernames: [],
+      });
+
+      expect(filter.actions).toEqual([]);
+    });
+
+    it('does not treat an empty available list as all-selected', () => {
+      // Guard against `0 === 0` false positives: with no available actions there
+      // is nothing to match, so `actions` must still be sent (as []).
+      const filter = buildActivitySearchFilter({
+        selectedActions: [],
+        availableActions: [],
+        dates: DATES,
+        usernames: [],
+      });
+
+      expect(filter.actions).toEqual([]);
+    });
+  });
+
+  describe('dates and usernames passthrough', () => {
+    it('always carries the provided dates and usernames', () => {
+      const dates = { startDate: '2025-01-01', endDate: '2025-01-31' };
+      const filter = buildActivitySearchFilter({
+        selectedActions: [...AVAILABLE],
+        availableActions: AVAILABLE,
+        dates,
+        usernames: ['alice', 'bob'],
+      });
+
+      expect(filter).toMatchObject({
+        dates,
+        usernames: ['alice', 'bob'],
+      });
+    });
+  });
+});

--- a/apps/app/src/client/components/Admin/AuditLog/build-search-filter.ts
+++ b/apps/app/src/client/components/Admin/AuditLog/build-search-filter.ts
@@ -1,0 +1,39 @@
+import type { ISearchFilter, SupportedActionType } from '~/interfaces/activity';
+
+type BuildActivitySearchFilterArgs = {
+  selectedActions: SupportedActionType[];
+  availableActions: SupportedActionType[];
+  dates: ISearchFilter['dates'];
+  usernames: string[];
+};
+
+/**
+ * Build the audit-log list search filter, omitting `actions` when every
+ * available action is selected.
+ *
+ * The server treats an absent `actions` filter as "match every activity", so
+ * sending the full action list adds nothing but weight. Historically that list
+ * was serialized into the GET query string and, for large action-group configs
+ * (~145 actions), pushed the URL past common proxy header limits. `actions` is
+ * therefore sent only when the selection is a strict subset; the all-selected
+ * default (and the "clear" reset) omit it entirely.
+ */
+export const buildActivitySearchFilter = ({
+  selectedActions,
+  availableActions,
+  dates,
+  usernames,
+}: BuildActivitySearchFilterArgs): ISearchFilter => {
+  const filter: ISearchFilter = { usernames, dates };
+
+  const selectedSet = new Set<SupportedActionType>(selectedActions);
+  const isAllSelected =
+    availableActions.length > 0 &&
+    availableActions.every((action) => selectedSet.has(action));
+
+  if (!isAllSelected) {
+    filter.actions = selectedActions;
+  }
+
+  return filter;
+};

--- a/apps/app/src/client/components/Admin/AuditLogManagement.tsx
+++ b/apps/app/src/client/components/Admin/AuditLogManagement.tsx
@@ -21,6 +21,7 @@ import { ActivityTable } from './AuditLog/ActivityTable';
 import { AuditLogDisableMode } from './AuditLog/AuditLogDisableMode';
 import { AuditLogExportModal } from './AuditLog/AuditLogExportModal';
 import { AuditLogSettings } from './AuditLog/AuditLogSettings';
+import { buildActivitySearchFilter } from './AuditLog/build-search-filter';
 import { DateRangePicker } from './AuditLog/DateRangePicker';
 import { SearchUsernameTypeahead } from './AuditLog/SearchUsernameTypeahead';
 import { SelectActionDropdown } from './AuditLog/SelectActionDropdown';
@@ -76,11 +77,12 @@ export const AuditLogManagement: FC = () => {
   const selectedActionList = Array.from(actionMap.entries())
     .filter((v) => v[1])
     .map((v) => v[0]);
-  const searchFilter = {
-    actions: selectedActionList,
+  const searchFilter = buildActivitySearchFilter({
+    selectedActions: selectedActionList,
+    availableActions: auditLogAvailableActionsData ?? [],
     dates: selectedDate,
     usernames: selectedUsernames,
-  };
+  });
 
   const {
     data: activityData,

--- a/apps/app/src/server/routes/apiv3/activity.integ.ts
+++ b/apps/app/src/server/routes/apiv3/activity.integ.ts
@@ -665,4 +665,137 @@ describe('GET /api/v3/activity', () => {
       expect(docs[1].action).toBe('PAGE_CREATE');
     });
   });
+
+  // POST /api/v3/activity/list carries the same filter in the request body so a
+  // fully-selected action list never bloats the query string. Behaviour must
+  // match GET, EXCEPT the offset handling: the body carries a real numeric
+  // offset, so 0 means "no skip" (there is no query-string "0" truthiness).
+  describe('POST /api/v3/activity/list — body-carried filter', () => {
+    it('returns the same-shape paginated response (no userId, user present, _id/__v)', async () => {
+      await prisma.activities.createMany({
+        data: [
+          makeActivityData({
+            userId: userId1,
+            username: 'alice',
+            action: 'PAGE_CREATE',
+          }),
+        ],
+      });
+
+      const res = await request(app)
+        .post('/api/v3/activity/list')
+        .send({ limit: 10, offset: 0, searchFilter: { usernames: ['alice'] } });
+
+      expect(res.status).toBe(200);
+      const { docs } = res.body.data.serializedPaginationResult;
+      expect(docs).toHaveLength(1);
+
+      const doc = docs[0];
+      expect(doc).not.toHaveProperty('userId');
+      expect(doc).toHaveProperty('user');
+      expect(doc).toHaveProperty('_id');
+      expect(doc).toHaveProperty('__v');
+    });
+
+    it('treats offset 0 as no-skip: page 1 returns the newest record first', async () => {
+      const now = Date.now();
+      await prisma.activities.createMany({
+        data: [
+          makeActivityData({
+            userId: userId1,
+            username: 'alice',
+            action: 'PAGE_CREATE',
+            createdAt: new Date(now),
+          }),
+          makeActivityData({
+            userId: userId1,
+            username: 'alice',
+            action: 'PAGE_UPDATE',
+            createdAt: new Date(now - 1000),
+          }),
+          makeActivityData({
+            userId: userId1,
+            username: 'alice',
+            action: 'PAGE_DELETE',
+            createdAt: new Date(now - 2000),
+          }),
+        ],
+      });
+
+      const res = await request(app)
+        .post('/api/v3/activity/list')
+        .send({ limit: 10, offset: 0, searchFilter: { usernames: ['alice'] } });
+
+      expect(res.status).toBe(200);
+      const { docs } = res.body.data.serializedPaginationResult;
+      // Unlike GET's `offset || 1` quirk (which only skips on an ABSENT offset),
+      // numeric offset 0 must NOT skip: all 3 records return, newest first.
+      expect(docs).toHaveLength(3);
+      expect(docs[0].action).toBe('PAGE_CREATE');
+    });
+
+    it('filters by action supplied in the body searchFilter', async () => {
+      await prisma.activities.createMany({
+        data: [
+          makeActivityData({
+            userId: userId1,
+            username: 'alice',
+            action: 'PAGE_CREATE',
+          }),
+          makeActivityData({
+            userId: userId2,
+            username: 'bob',
+            action: 'PAGE_DELETE',
+          }),
+        ],
+      });
+
+      const res = await request(app)
+        .post('/api/v3/activity/list')
+        .send({
+          limit: 10,
+          offset: 0,
+          searchFilter: { actions: ['PAGE_DELETE'] },
+        });
+
+      expect(res.status).toBe(200);
+      const { docs } = res.body.data.serializedPaginationResult;
+      expect(docs.length).toBeGreaterThan(0);
+      for (const doc of docs) {
+        expect(doc.action).toBe('PAGE_DELETE');
+      }
+    });
+
+    it('returns all matching rows when the body omits searchFilter entirely (all-selected path)', async () => {
+      // The UI omits `actions` (and may omit the whole searchFilter) when every
+      // available action is selected; the server must then match every activity.
+      await prisma.activities.createMany({
+        data: [
+          makeActivityData({
+            userId: userId1,
+            username: 'alice',
+            action: 'PAGE_CREATE',
+          }),
+          makeActivityData({
+            userId: userId1,
+            username: 'alice',
+            action: 'PAGE_UPDATE',
+          }),
+          makeActivityData({
+            userId: userId2,
+            username: 'bob',
+            action: 'PAGE_DELETE',
+          }),
+        ],
+      });
+
+      const res = await request(app)
+        .post('/api/v3/activity/list')
+        .send({ limit: 100, offset: 0 });
+
+      expect(res.status).toBe(200);
+      const { totalDocs } = res.body.data.serializedPaginationResult;
+      expect(totalDocs).toBeGreaterThanOrEqual(3);
+    });
+  });
 });

--- a/apps/app/src/server/routes/apiv3/activity.ts
+++ b/apps/app/src/server/routes/apiv3/activity.ts
@@ -1,23 +1,21 @@
 import { SCOPE } from '@growi/core/dist/interfaces';
-import { serializeUserSecurely } from '@growi/core/dist/models/serializers';
-import { isValid } from 'date-fns/isValid';
-import { parseISO } from 'date-fns/parseISO';
-import type { Request, Router } from 'express';
+import type { NextFunction, Request, Router } from 'express';
 import express from 'express';
-import { query } from 'express-validator';
+import { body, query } from 'express-validator';
 
-import type { Prisma } from '~/generated/prisma/client';
 import type { ISearchFilter } from '~/interfaces/activity';
 import { accessTokenParser } from '~/server/middlewares/access-token-parser';
 import adminRequiredFactory from '~/server/middlewares/admin-required';
 import loginRequiredFactory from '~/server/middlewares/login-required';
 import { configManager } from '~/server/service/config-manager';
 import loggerFactory from '~/utils/logger';
-import { prisma } from '~/utils/prisma';
 
 import type Crowi from '../../crowi';
 import { apiV3FormValidator } from '../../middlewares/apiv3-form-validator';
-import { buildActivityListWhere } from './build-activity-list-where';
+import {
+  paginateAndSerializeActivities,
+  resolveActivityListWhere,
+} from './fetch-activity-list';
 import type { ApiV3Response } from './interfaces/apiv3-response';
 
 const logger = loggerFactory('growi:routes:apiv3:activity');
@@ -33,6 +31,19 @@ const validator = {
       .optional()
       .isString()
       .withMessage('query must be a string'),
+  ],
+  // POST /activity/list carries the same parameters in the request body so the
+  // searchFilter (which lists every selected action) never bloats the URL.
+  listByPost: [
+    body('limit')
+      .optional()
+      .isInt({ max: 100 })
+      .withMessage('limit must be a number less than or equal to 100'),
+    body('offset').optional().isInt().withMessage('offset must be a number'),
+    body('searchFilter')
+      .optional()
+      .isObject()
+      .withMessage('searchFilter must be an object'),
   ],
 };
 
@@ -226,6 +237,21 @@ export const setup = (crowi: Crowi): Router => {
 
   const router = express.Router();
 
+  // Shared gate for every list transport: 405 when the audit log is disabled.
+  // Kept as one middleware so the GET and POST routes cannot drift apart.
+  const ensureAuditLogEnabled = (
+    _req: Request,
+    res: ApiV3Response,
+    next: NextFunction,
+  ) => {
+    if (!configManager.getConfig('app:auditLogEnabled')) {
+      const msg = 'AuditLog is not enabled';
+      logger.error(msg);
+      return res.apiv3Err(msg, 405);
+    }
+    next();
+  };
+
   /**
    * @swagger
    *
@@ -268,98 +294,141 @@ export const setup = (crowi: Crowi): Router => {
     adminRequired,
     validator.list,
     apiV3FormValidator,
+    ensureAuditLogEnabled,
     async (req: Request, res: ApiV3Response) => {
-      const auditLogEnabled = configManager.getConfig('app:auditLogEnabled');
-      if (!auditLogEnabled) {
-        const msg = 'AuditLog is not enabled';
-        logger.error(msg);
-        return res.apiv3Err(msg, 405);
-      }
-
       const limit =
         req.query.limit ||
         configManager.getConfig('customize:showPageLimitationS');
       // Preserve the existing offset || 1 quirk exactly (pure migration, req 2.1):
-      // When the frontend sends offset=0 for page 1, it is falsy and becomes 1,
-      // skipping the first record. This behaviour is intentional to maintain
-      // observational parity before a separate fix is landed.
+      // an absent offset is falsy and becomes 1, skipping the first record. This
+      // behaviour is intentional to maintain observational parity before a
+      // separate fix is landed. Note: a query string turns an explicit offset=0
+      // into the truthy "0", so page 1 (offset=0) is NOT skipped here — only a
+      // fully absent offset is. The POST route below must reproduce that.
       const offset = req.query.offset || 1;
 
-      let where: ReturnType<typeof buildActivityListWhere> = {};
-
+      let where: ReturnType<typeof resolveActivityListWhere> = {};
       try {
         const parsedSearchFilter = JSON.parse(
           req.query.searchFilter as string,
         ) as ISearchFilter;
-
-        // resolve action filter: only include actions that are actually available
-        let searchableActions: string[] | undefined;
-        if (parsedSearchFilter.actions != null) {
-          const availableActions =
-            crowi.activityService.getAvailableActions(false);
-          searchableActions = parsedSearchFilter.actions.filter((action) =>
-            availableActions.includes(action),
-          );
-        }
-
-        // parse date range
-        const startDate = parseISO(parsedSearchFilter?.dates?.startDate || '');
-        const endDate = parseISO(parsedSearchFilter?.dates?.endDate || '');
-
-        where = buildActivityListWhere({
-          usernames: parsedSearchFilter.usernames,
-          actions: searchableActions,
-          startDate: isValid(startDate) ? startDate : undefined,
-          endDate: isValid(endDate) ? endDate : undefined,
-        });
+        where = resolveActivityListWhere(
+          crowi.activityService.getAvailableActions(false),
+          parsedSearchFilter,
+        );
       } catch (err) {
         logger.error('Invalid value', err);
         return res.apiv3Err(err, 400);
       }
 
       try {
-        const paginateResult = await prisma.activities.paginate({
+        const serializedPaginationResult = await paginateAndSerializeActivities(
           where,
-          orderBy: { createdAt: 'desc' },
-          offset: offset as number,
-          limit: limit as number,
-          include: { user: true },
-        });
+          limit as number,
+          offset as number,
+        );
+        return res.apiv3({ serializedPaginationResult });
+      } catch (err) {
+        logger.error('Failed to get paginated activity', err);
+        return res.apiv3Err(err, 500);
+      }
+    },
+  );
 
-        // Remap each doc to match the old Mongoose response shape (req 2.3):
-        // - drop `userId` (not present in old Mongoose docs)
-        // - keep serialized `user` (populated relation, same as Mongoose populate)
-        // - keep _id/__v (computed fields) and all other scalar fields
-        //
-        // Type note: the `paginate` generic resolves via PaginateOptions<…> which
-        // does not propagate `include` into the result type, so `docs` is typed as
-        // the base scalar shape (no `user` property). We route through `unknown`
-        // to reach the correct payload type — this is the Tier-2 cast rationale:
-        // the cast is confined to the map boundary; the underlying runtime value
-        // is correct because `include: { user: true }` was passed to `paginate`.
-        type ActivityWithUser = Prisma.activitiesGetPayload<{
-          include: { user: true };
-        }>;
-        const serializedDocs = (
-          paginateResult.docs as unknown as ActivityWithUser[]
-        ).map((doc) => {
-          const { user, userId, ...rest } = doc;
-          return {
-            // The Prisma `users` type has nullable fields (e.g. name: string|null)
-            // while `IUser` requires non-nullable. At runtime they map to the same
-            // MongoDB document. Cast to Ref<IUser> so serializeUserSecurely resolves.
-            // Tier-2 rationale: cast is confined to this single field expression.
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            user: serializeUserSecurely(user as any),
-            ...rest,
-          };
-        });
+  /**
+   * @swagger
+   *
+   * /activity/list:
+   *   post:
+   *     summary: /activity/list
+   *     description: >-
+   *       Same as `GET /activity` but takes limit / offset / searchFilter in the
+   *       request body. The audit-log UI uses this so the searchFilter (which
+   *       lists every selected action) never bloats the query string and hits a
+   *       URL-length limit for large action-group configurations.
+   *     tags: [Activity]
+   *     security:
+   *       - bearer: []
+   *       - accessTokenInQuery: []
+   *       - accessTokenHeaderAuth: []
+   *     requestBody:
+   *       required: false
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               limit:
+   *                 type: integer
+   *               offset:
+   *                 type: integer
+   *               searchFilter:
+   *                 type: object
+   *                 properties:
+   *                   usernames:
+   *                     type: array
+   *                     items:
+   *                       type: string
+   *                   actions:
+   *                     type: array
+   *                     description: >-
+   *                       Omit this field to match every activity. Send it only
+   *                       to restrict the result to the listed actions.
+   *                     items:
+   *                       type: string
+   *                   dates:
+   *                     type: object
+   *                     properties:
+   *                       startDate:
+   *                         type: string
+   *                         nullable: true
+   *                       endDate:
+   *                         type: string
+   *                         nullable: true
+   *     responses:
+   *       200:
+   *         description: Activity fetched successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ActivityResponse'
+   */
+  router.post(
+    '/list',
+    accessTokenParser([SCOPE.READ.ADMIN.AUDIT_LOG], { acceptLegacy: true }),
+    loginRequiredStrictly,
+    adminRequired,
+    validator.listByPost,
+    apiV3FormValidator,
+    ensureAuditLogEnabled,
+    async (req: Request, res: ApiV3Response) => {
+      const limit =
+        req.body.limit ||
+        configManager.getConfig('customize:showPageLimitationS');
+      // The body carries a real numeric offset, so 0 MUST mean "no skip" (page 1
+      // shows the newest record). The GET route's `offset || 1` quirk only
+      // survives there because the query string turns 0 into the truthy "0";
+      // applying `|| 1` to a numeric 0 here would wrongly skip the newest record.
+      const offset = req.body.offset ?? 0;
+      const parsedSearchFilter = (req.body.searchFilter ?? {}) as ISearchFilter;
 
-        const serializedPaginationResult = {
-          ...paginateResult,
-          docs: serializedDocs,
-        };
+      let where: ReturnType<typeof resolveActivityListWhere>;
+      try {
+        where = resolveActivityListWhere(
+          crowi.activityService.getAvailableActions(false),
+          parsedSearchFilter,
+        );
+      } catch (err) {
+        logger.error('Invalid value', err);
+        return res.apiv3Err(err, 400);
+      }
 
+      try {
+        const serializedPaginationResult = await paginateAndSerializeActivities(
+          where,
+          limit as number,
+          offset as number,
+        );
         return res.apiv3({ serializedPaginationResult });
       } catch (err) {
         logger.error('Failed to get paginated activity', err);

--- a/apps/app/src/server/routes/apiv3/fetch-activity-list.spec.ts
+++ b/apps/app/src/server/routes/apiv3/fetch-activity-list.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for resolveActivityListWhere (pure function).
+ *
+ * Contract: given the actions available under the current audit-log config and
+ * a parsed search filter, produce the Prisma `where` object — intersecting the
+ * submitted actions with the available ones and parsing the date range. No DB
+ * access.
+ *
+ * The action-intersection and date-parsing logic used to live inline in the GET
+ * route handler; extracting it here lets both the GET and the new POST route
+ * share one implementation, and makes the intersection behaviour testable.
+ */
+
+import { addMinutes } from 'date-fns/addMinutes';
+import { parseISO } from 'date-fns/parseISO';
+
+import { resolveActivityListWhere } from './fetch-activity-list';
+
+const AVAILABLE = ['PAGE_CREATE', 'PAGE_UPDATE', 'PAGE_DELETE'] as const;
+
+describe('resolveActivityListWhere', () => {
+  describe('action intersection', () => {
+    it('omits the action clause when actions is absent (→ all results)', () => {
+      const where = resolveActivityListWhere(AVAILABLE, {});
+
+      expect(where).not.toHaveProperty('action');
+    });
+
+    it('keeps every action when all submitted actions are available', () => {
+      const where = resolveActivityListWhere(AVAILABLE, {
+        actions: ['PAGE_CREATE', 'PAGE_UPDATE'],
+      });
+
+      expect(where).toMatchObject({
+        action: { in: ['PAGE_CREATE', 'PAGE_UPDATE'] },
+      });
+    });
+
+    it('drops submitted actions that are not currently available', () => {
+      const where = resolveActivityListWhere(AVAILABLE, {
+        // PAGE_CREATE is available; ADMIN_APP_SETTING_UPDATE is not
+        actions: ['PAGE_CREATE', 'ADMIN_APP_SETTING_UPDATE'],
+      });
+
+      expect(where).toMatchObject({ action: { in: ['PAGE_CREATE'] } });
+    });
+
+    it('emits action.in:[] when every submitted action is unavailable (→ zero results)', () => {
+      const where = resolveActivityListWhere(AVAILABLE, {
+        actions: ['ADMIN_APP_SETTING_UPDATE'],
+      });
+
+      // present-but-all-invalid must be distinguishable from absent: in:[] means
+      // zero results, matching the original Mongoose { action: { $in: [] } }.
+      expect(where).toMatchObject({ action: { in: [] } });
+    });
+  });
+
+  describe('date range parsing', () => {
+    it('builds a createdAt clause from a valid ISO start/end range', () => {
+      const startDate = '2025-01-01T00:00:00.000Z';
+      const endDate = '2025-01-31T00:00:00.000Z';
+
+      const where = resolveActivityListWhere(AVAILABLE, {
+        dates: { startDate, endDate },
+      });
+
+      expect(where).toMatchObject({
+        createdAt: {
+          gte: parseISO(startDate),
+          lt: addMinutes(parseISO(endDate), 1439),
+        },
+      });
+    });
+
+    it('omits the createdAt clause when the dates are empty strings', () => {
+      const where = resolveActivityListWhere(AVAILABLE, {
+        dates: { startDate: '', endDate: '' },
+      });
+
+      expect(where).not.toHaveProperty('createdAt');
+    });
+
+    it('omits the createdAt clause when dates is absent', () => {
+      const where = resolveActivityListWhere(AVAILABLE, {});
+
+      expect(where).not.toHaveProperty('createdAt');
+    });
+  });
+
+  describe('usernames', () => {
+    it('passes usernames through to the snapshot composite filter', () => {
+      const where = resolveActivityListWhere(AVAILABLE, {
+        usernames: ['alice'],
+      });
+
+      expect(where).toMatchObject({
+        snapshot: { is: { username: { in: ['alice'] } } },
+      });
+    });
+  });
+});

--- a/apps/app/src/server/routes/apiv3/fetch-activity-list.ts
+++ b/apps/app/src/server/routes/apiv3/fetch-activity-list.ts
@@ -1,0 +1,99 @@
+/**
+ * Shared audit-log list logic used by both transports:
+ *  - GET  /_api/v3/activity        (legacy, kept for API/PAT backward compat)
+ *  - POST /_api/v3/activity/list   (used by the admin UI to avoid a long URL)
+ *
+ * Extracted from the route handler so the two routes share one implementation
+ * (single source of truth — no filter/serialize drift between GET and POST).
+ *
+ * `resolveActivityListWhere` is pure and receives `availableActions` as input
+ * (the caller owns "what actions exist"), so it is unit-testable without a
+ * Crowi/DB (coding-style: executors take their work-set as input).
+ */
+
+import { serializeUserSecurely } from '@growi/core/dist/models/serializers';
+import { isValid } from 'date-fns/isValid';
+import { parseISO } from 'date-fns/parseISO';
+
+import type { Prisma } from '~/generated/prisma/client';
+import type { ISearchFilter } from '~/interfaces/activity';
+import { prisma } from '~/utils/prisma';
+
+import { buildActivityListWhere } from './build-activity-list-where';
+
+/**
+ * Convert a parsed search filter into a Prisma `where` object.
+ *
+ * The action list is intersected with `availableActions` (the actions actually
+ * available under the current audit-log config). The null-vs-empty distinction
+ * is preserved for buildActivityListWhere (req 2.2):
+ *  - `actions` absent (undefined)        → searchableActions undefined → clause omitted → all results
+ *  - `actions` present but all invalid   → searchableActions []        → in:[]          → zero results
+ */
+export function resolveActivityListWhere(
+  availableActions: readonly string[],
+  parsedSearchFilter: ISearchFilter,
+): ReturnType<typeof buildActivityListWhere> {
+  let searchableActions: string[] | undefined;
+  if (parsedSearchFilter.actions != null) {
+    searchableActions = parsedSearchFilter.actions.filter((action) =>
+      availableActions.includes(action),
+    );
+  }
+
+  const startDate = parseISO(parsedSearchFilter?.dates?.startDate || '');
+  const endDate = parseISO(parsedSearchFilter?.dates?.endDate || '');
+
+  return buildActivityListWhere({
+    usernames: parsedSearchFilter.usernames,
+    actions: searchableActions,
+    startDate: isValid(startDate) ? startDate : undefined,
+    endDate: isValid(endDate) ? endDate : undefined,
+  });
+}
+
+/**
+ * Paginate activities and remap each doc to the old Mongoose response shape
+ * (req 2.3): drop `userId`, keep serialized `user`, keep _id/__v and all other
+ * scalar fields.
+ */
+export async function paginateAndSerializeActivities(
+  where: ReturnType<typeof buildActivityListWhere>,
+  limit: number,
+  offset: number,
+): Promise<Record<string, unknown>> {
+  const paginateResult = await prisma.activities.paginate({
+    where,
+    orderBy: { createdAt: 'desc' },
+    offset,
+    limit,
+    include: { user: true },
+  });
+
+  // Type note: the `paginate` generic resolves via PaginateOptions<…> which
+  // does not propagate `include` into the result type, so `docs` is typed as
+  // the base scalar shape (no `user` property). We route through `unknown` to
+  // reach the correct payload type — the runtime value is correct because
+  // `include: { user: true }` was passed to `paginate`.
+  type ActivityWithUser = Prisma.activitiesGetPayload<{
+    include: { user: true };
+  }>;
+  const serializedDocs = (
+    paginateResult.docs as unknown as ActivityWithUser[]
+  ).map((doc) => {
+    const { user, userId, ...rest } = doc;
+    return {
+      // The Prisma `users` type has nullable fields (e.g. name: string|null)
+      // while `IUser` requires non-nullable. At runtime they map to the same
+      // MongoDB document. Cast to Ref<IUser> so serializeUserSecurely resolves.
+      // biome-ignore lint/suspicious/noExplicitAny: Prisma users type diverges from Ref<IUser> only in nullability; same runtime document
+      user: serializeUserSecurely(user as any),
+      ...rest,
+    };
+  });
+
+  return {
+    ...paginateResult,
+    docs: serializedDocs,
+  };
+}

--- a/apps/app/src/stores/activity.ts
+++ b/apps/app/src/stores/activity.ts
@@ -2,7 +2,7 @@ import { useAtomValue } from 'jotai';
 import type { SWRResponse } from 'swr';
 import useSWRImmutable from 'swr/immutable';
 
-import { apiv3Get } from '~/client/util/apiv3-client';
+import { apiv3Post } from '~/client/util/apiv3-client';
 import type { IActivityHasId, ISearchFilter } from '~/interfaces/activity';
 import type { PaginateResult } from '~/interfaces/mongoose-utils';
 import { auditLogEnabledAtom } from '~/states/server-configurations';
@@ -14,16 +14,23 @@ export const useSWRxActivity = (
 ): SWRResponse<PaginateResult<IActivityHasId>, Error> => {
   const auditLogEnabled = useAtomValue(auditLogEnabledAtom);
 
+  // POST the filter in the request body instead of a GET query string: the
+  // searchFilter lists every selected action, which for large action-group
+  // configurations pushed the URL past common proxy header limits.
+  // The SWR key still uses the stringified filter for stable cache identity.
   const stringifiedSearchFilter = JSON.stringify(searchFilter);
   return useSWRImmutable(
     auditLogEnabled
-      ? ['/activity', limit, offset, stringifiedSearchFilter]
+      ? ['/activity/list', limit, offset, stringifiedSearchFilter]
       : null,
     ([endpoint, limit, offset, stringifiedSearchFilter]) =>
-      apiv3Get(endpoint, {
+      apiv3Post(endpoint, {
         limit,
         offset,
-        searchFilter: stringifiedSearchFilter,
+        searchFilter:
+          stringifiedSearchFilter != null
+            ? JSON.parse(stringifiedSearchFilter)
+            : undefined,
       }).then((result) => result.data.serializedPaginationResult),
   );
 };


### PR DESCRIPTION
## 背景 / 課題

`/admin/audit-log` を開くと、一覧取得が `GET /_api/v3/activity?limit=…&offset=…&searchFilter=<JSON>` として飛びます。`searchFilter` には選択中の action 一覧が JSON で埋め込まれますが、**全 available action が既定でチェック済み**のため、初回リクエストで利用可能な action がすべて query に並びます。

action 数は `app:auditLogActionGroupSize` 設定で決まり、**Small=12（既定）/ Medium≈53 / Large≈145**。Large で全選択の場合、URL エンコード後（`"`→`%22`、`,`→`%2C`）でおよそ **9KB** に達し、nginx 等の既定ヘッダバッファ（8KB）を超え得ます。将来的な文字列長の問題を未然に防ぐための改善です。

## 対応方針（2点）

### 1. POST 化（本命）
一覧取得を `POST /_api/v3/activity/list` に切り替え、`limit` / `offset` / `searchFilter` を**リクエストボディ**で受けるようにしました。これで URL 長制約が構造的に消えます。

- 一覧ロジックは `fetch-activity-list.ts`（純粋関数 `resolveActivityListWhere` ＋ DB 処理 `paginateAndSerializeActivities`）に切り出し、**GET と POST が同一実装を共有**します（フィルタ/整形が乖離しない）。
- 既存の `GET /_api/v3/activity` は **PAT 等の外部 API 互換のため据え置き**（同じ共有ロジックを使用）。
- bulk-export はすでに POST ボディ方式のため、feature 内に前例があります。CSRF はトークン方式ではなく `X-Requested-With` ヘッダ方式で、追加処理は不要です。

### 2. actions フィルタの省略（ペイロード圧縮）
フロントで**全 available action がチェック済みのときは `actions` を送らない**ようにしました（純粋関数 `buildActivitySearchFilter`）。サーバは `actions` 不在を「全件」として扱います。厳密な部分選択のときのみ `actions` を送ります。

## ⚠️ 開示済みの挙動変更

方針2により、**「全選択」ビューは現行の `app:auditLogActionGroupSize` 設定外（＝過去に広いグループで記録された）古いレコードも表示**するようになります。従来は全選択時も `where.action = { in: getAvailableActions(false) }` で設定内 action に絞っていました。監査ログとしては「記録済みの活動をすべて見せる」方が妥当と判断しています。

## `offset` に関する注意（実装上の落とし穴）

GET は query 文字列なので明示 `offset=0` が truthy な `"0"` になり、`offset || 1` の quirk はページ1では発動しません（発動するのは offset 完全省略時のみ）。一方 POST はボディの数値 `0` が falsy なので、同じ `offset || 1` を使うと**ページ1で最新レコードを skip する新バグ**になります。そのため POST 側は `offset` を 0 起点の skip カウント（`req.body.offset ?? 0`、0→skip なし）として扱い、integ テストで「offset 0 はページ1に最新を出す」を明示的にガードしています。

## 変更ファイル

**サーバ**
- `apps/app/src/server/routes/apiv3/fetch-activity-list.ts`（新規・共有ロジック）＋ spec
- `apps/app/src/server/routes/apiv3/activity.ts`（POST ルート追加・GET を共有関数へ・OpenAPI 追記）
- `apps/app/src/server/routes/apiv3/activity.integ.ts`（POST 用テスト4件追加）

**フロント**
- `apps/app/src/client/components/Admin/AuditLog/build-search-filter.ts`（新規・純粋ヘルパ）＋ spec
- `apps/app/src/client/components/Admin/AuditLogManagement.tsx`（ヘルパ配線）
- `apps/app/src/stores/activity.ts`（`useSWRxActivity` を POST 化）

## 検証

- 単体テスト **28 件 pass**（`resolveActivityListWhere` 8・`buildActivitySearchFilter` 6・既存 where builder 14）
- 結合テスト **18 件 pass**（既存 GET 14 ＋ 新規 POST 4）
- `tsgo` typecheck: clean
- biome / route-guard / no-cjs / import-convention: OK
- OpenAPI 生成・検証: pass（GET・POST 両方が spec に出力されることを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
