### PR TITLE
fix(import): Harden admin data import (re-enable button on failure, await import)

### DIFF
--- a/apps/app/src/client/components/Admin/ImportData/GrowiArchive/ImportForm.jsx
+++ b/apps/app/src/client/components/Admin/ImportData/GrowiArchive/ImportForm.jsx
@@ -355,6 +355,11 @@ class ImportForm extends React.Component {
         toastError(t('admin:importer_management.error.only_upsert_available'));
       }
       toastError(err);
+
+      // Re-enable the form so the user can retry; otherwise the Import button
+      // stays disabled forever because progress events (which reset this flag)
+      // never arrive when the request itself failed.
+      this.setState({ isImporting: false });
     }
   }
 

--- a/apps/app/src/client/components/Admin/ImportData/GrowiArchive/ImportForm.spec.tsx
+++ b/apps/app/src/client/components/Admin/ImportData/GrowiArchive/ImportForm.spec.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { Socket } from 'socket.io-client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import ImportFormWrapperFc from './ImportForm';
+
+// --- module mocks -----------------------------------------------------------
+
+const useAdminSocket = vi.hoisted(() => vi.fn());
+vi.mock('~/features/admin/states/socket-io', () => ({ useAdminSocket }));
+
+vi.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const apiv3Post = vi.hoisted(() => vi.fn());
+vi.mock('~/client/util/apiv3-client', () => ({ apiv3Post }));
+
+vi.mock('~/client/util/toastr', () => ({
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+// --- helpers ----------------------------------------------------------------
+
+const renderForm = () =>
+  render(
+    <ImportFormWrapperFc
+      fileName="archive.zip"
+      innerFileStats={[
+        { fileName: 'tags.json', collectionName: 'tags', size: 1 },
+      ]}
+      onDiscard={vi.fn()}
+    />,
+  );
+
+const importButton = () =>
+  screen.getByRole('button', { name: 'admin:importer_management.import' });
+
+describe('ImportFormWrapperFc', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // socket must be non-null so the actual ImportForm renders; its event
+    // handlers are irrelevant to these tests, so an auto-stubbed mock is enough.
+    useAdminSocket.mockReturnValue(mock<Socket>());
+  });
+
+  it('renders nothing (no crash) while the admin socket is not yet initialised', () => {
+    useAdminSocket.mockReturnValue(null);
+    const { container } = renderForm();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('re-enables the Import button after a failed import so the user can retry', async () => {
+    // Contract: when the import request fails, the form must return to an
+    // importable state. Regression guarded: the button staying disabled
+    // forever because isImporting was never reset in the catch block.
+    apiv3Post.mockRejectedValue(new Error('network down'));
+
+    renderForm();
+
+    // select a collection so the form becomes importable
+    // (the button label is prefixed by a material-symbols icon glyph, so match loosely)
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /export_management\.check_all/,
+      }),
+    );
+    await waitFor(() => expect(importButton()).toBeEnabled());
+
+    // trigger the (failing) import
+    fireEvent.click(importButton());
+
+    // the button must become usable again once the failure is handled
+    await waitFor(() => expect(importButton()).toBeEnabled());
+    expect(apiv3Post).toHaveBeenCalledWith('/import', expect.any(Object));
+  });
+});

--- a/apps/app/src/server/routes/apiv3/import-executor.spec.ts
+++ b/apps/app/src/server/routes/apiv3/import-executor.spec.ts
@@ -1,0 +1,70 @@
+import type EventEmitter from 'node:events';
+import { describe, expect, it, vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import { SupportedAction } from '~/interfaces/activity';
+
+import { executeImport, type ImportRunner } from './import-executor';
+
+vi.mock('~/utils/logger', () => ({
+  default: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+describe('executeImport', () => {
+  const collections = ['tags'];
+  const importSettingsMap = new Map();
+  const activityId = 'activity-1';
+
+  it('emits an activity update when the import succeeds', async () => {
+    const importService = mock<ImportRunner>();
+    importService.import.mockResolvedValue(undefined);
+    const adminEvent = mock<EventEmitter>();
+    const activityEvent = mock<EventEmitter>();
+
+    await executeImport({
+      importService,
+      adminEvent,
+      activityEvent,
+      activityId,
+      collections,
+      importSettingsMap,
+    });
+
+    expect(activityEvent.emit).toHaveBeenCalledWith('update', activityId, {
+      action: SupportedAction.ACTION_ADMIN_GROWI_DATA_IMPORTED,
+    });
+    expect(adminEvent.emit).not.toHaveBeenCalledWith(
+      'onErrorForImport',
+      expect.anything(),
+    );
+  });
+
+  it('reports the failure over onErrorForImport when the import rejects', async () => {
+    // Regression guarded: the import must be awaited so its rejection is caught
+    // and surfaced to the client, instead of escaping as an unhandled rejection
+    // while the activity is wrongly marked as completed.
+    const importService = mock<ImportRunner>();
+    importService.import.mockRejectedValue(new Error('boom'));
+    const adminEvent = mock<EventEmitter>();
+    const activityEvent = mock<EventEmitter>();
+
+    await executeImport({
+      importService,
+      adminEvent,
+      activityEvent,
+      activityId,
+      collections,
+      importSettingsMap,
+    });
+
+    expect(adminEvent.emit).toHaveBeenCalledWith('onErrorForImport', {
+      message: 'boom',
+    });
+    expect(activityEvent.emit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/server/routes/apiv3/import-executor.ts
+++ b/apps/app/src/server/routes/apiv3/import-executor.ts
@@ -1,0 +1,54 @@
+import type EventEmitter from 'node:events';
+
+import { SupportedAction } from '~/interfaces/activity';
+import type { ImportSettings } from '~/server/service/import';
+import loggerFactory from '~/utils/logger';
+
+const logger = loggerFactory('growi:routes:apiv3:import-executor');
+
+/** Minimal surface of ImportService needed to run an import. */
+export interface ImportRunner {
+  import(
+    collections: string[],
+    importSettingsMap: Map<string, ImportSettings>,
+  ): Promise<void>;
+}
+
+export interface ExecuteImportArgs {
+  importService: ImportRunner;
+  adminEvent: EventEmitter;
+  activityEvent: EventEmitter;
+  activityId: unknown;
+  collections: string[];
+  importSettingsMap: Map<string, ImportSettings>;
+}
+
+/**
+ * Run the archive import and report the outcome over the admin / activity event
+ * buses.
+ *
+ * The HTTP response has already been sent by the time this runs (the route
+ * responds immediately and streams progress over WebSocket), so the import must
+ * be awaited here: without the await a rejection from importService.import()
+ * escapes as an unhandled rejection, 'onErrorForImport' is never emitted, and
+ * the client sees the import silently do nothing.
+ */
+export const executeImport = async ({
+  importService,
+  adminEvent,
+  activityEvent,
+  activityId,
+  collections,
+  importSettingsMap,
+}: ExecuteImportArgs): Promise<void> => {
+  try {
+    await importService.import(collections, importSettingsMap);
+
+    activityEvent.emit('update', activityId, {
+      action: SupportedAction.ACTION_ADMIN_GROWI_DATA_IMPORTED,
+    });
+  } catch (err) {
+    logger.error(err);
+    adminEvent.emit('onErrorForImport', { message: (err as Error).message });
+  }
+};

--- a/apps/app/src/server/routes/apiv3/import.ts
+++ b/apps/app/src/server/routes/apiv3/import.ts
@@ -15,6 +15,7 @@ import type { ZipFileStat } from '~/server/service/interfaces/export';
 import loggerFactory from '~/utils/logger';
 
 import { generateAddActivityMiddleware } from '../../middlewares/add-activity';
+import { executeImport } from './import-executor';
 
 const logger = loggerFactory('growi:routes:apiv3:import');
 
@@ -354,17 +355,14 @@ export default function route(crowi: Crowi): Router {
       /*
        * import
        */
-      try {
-        importService.import(collections, importSettingsMap);
-
-        const parameters = {
-          action: SupportedAction.ACTION_ADMIN_GROWI_DATA_IMPORTED,
-        };
-        activityEvent.emit('update', res.locals.activity._id, parameters);
-      } catch (err) {
-        logger.error(err);
-        adminEvent.emit('onErrorForImport', { message: err.message });
-      }
+      await executeImport({
+        importService,
+        adminEvent,
+        activityEvent,
+        activityId: res.locals.activity._id,
+        collections,
+        importSettingsMap,
+      });
     },
   );
 


### PR DESCRIPTION
## What

Two latent-bug hardening fixes in the admin **GROWI archive data import** flow, found while investigating #11341.

1. **Re-enable the Import button after a failed import request** (`ImportForm.jsx`)
   `ImportForm` relied on WebSocket progress events to reset `isImporting`, but those never arrive when the `/import` request itself fails (network error, or a server-side rejection before the socket flow starts). The Import button therefore stayed disabled forever after a failed attempt. `isImporting` is now reset in the `catch` block so the user can retry.

2. **`await importService.import(...)` so failures reach the client** (`import.ts` → new `import-executor.ts`)
   The archive import ran without `await`, so a rejection from `importService.import()` escaped as an unhandled rejection: the route's `try/catch` never caught it, `onErrorForImport` was never emitted, and the import silently appeared to do nothing. The run-and-report logic is extracted into `executeImport()` — a pure, unit-testable function mirroring the existing `respondWithSinglePage` pattern — and the import is awaited there. The HTTP response is already sent before this runs, so awaiting does not delay the response.

## ⚠️ This does NOT fix the reported symptom of #11341

I reproduced the data-import flow exhaustively and **could not reproduce "import does not start" in the current code** (which is byte-identical to 7.5.5 for all the relevant files, same Next.js 16.2.6, same `socket.io-client`):

- dev server (API): `/admin` socket connects, `upload` → `POST /import` → progress/terminate events received, import completes
- dev server (browser): same, works
- production build (browser): same, works
- production build with the `socket.io-client` externalise symlink deliberately broken (simulating the `pnpm deploy --prod` devDependencies strip): **still works** — the client bundles `socket.io-client` into a static chunk

The previous root-cause comment on the issue (the `return;` / React-18 claim) was **disproven**: React 18 allows a function component to return `undefined` (it renders nothing, like `null`), so `return null` is a no-op. See the follow-up investigation: https://github.com/growilabs/growi/issues/11341#issuecomment-4991802018

These two fixes are real defects worth shipping, but the reported regression window (v7.4.7 → v7.5.0) coincides with the **Next.js 14 → 16 major upgrade** and most likely lives in the reporter's environment (awaiting browser console / WebSocket logs on the issue).

## Related latent issue (out of scope here)

`export.js` has the same missing-`await` pattern, but a plain `await` there would break its immediate-`200` contract (it needs an `onErrorForExport` event path first), so it is intentionally left for a separate change.

## Test

- `import-executor.spec.ts` — success emits the activity update; rejection surfaces `onErrorForImport` (red→green against the missing `await`)
- `ImportForm.spec.tsx` — the Import button re-enables after a failed import (red→green against the stuck-button bug); renders nothing (no crash) while the socket is not yet initialised
- `pnpm run lint:typecheck` / `biome check` clean; live smoke-tested a real import end-to-end on the dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)
