### PR TITLE
imprv: Lazy-load mail transports to keep nodemailer/aws-sdk out of boot

### DIFF
--- a/apps/app/src/features/mastra/server/no-eager-ai-imports.spec.ts
+++ b/apps/app/src/features/mastra/server/no-eager-ai-imports.spec.ts
@@ -2,6 +2,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { BOOT_ENTRYPOINTS } from '~/test-utils/boot-entrypoints';
+import {
+  formatViolation,
+  traceStaticImportChains,
+} from '~/test-utils/static-import-graph';
+
 // --- Contract --------------------------------------------------------------
 //
 // The heavy AI packages (@mastra/*, @ai-sdk/*, ai, tokenlens) cost ~140MB RSS
@@ -16,6 +22,12 @@ import { fileURLToPath } from 'node:url';
 // runtime behavior: they only load when executed. `import type` lines are
 // skipped (erased at build). Mixed value/type imports are followed —
 // conservative in the right direction.
+//
+// The walk itself (extension resolution, `~/` alias handling, type-import
+// skipping, dynamic-import boundary) lives in the shared
+// `test-utils/static-import-graph` helper; the boot entrypoints live in
+// `test-utils/boot-entrypoints` (shared with the mail-transport boundary
+// spec); this spec only supplies the banned-package pattern.
 
 const SRC_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -24,106 +36,20 @@ const SRC_ROOT = path.resolve(
 
 const HEAVY_PACKAGE = /^(@mastra\/|@ai-sdk\/|ai$|tokenlens)/;
 
-// Boot-time entrypoints: the Express server side that loads unconditionally.
-// (Client/SSR bundles are built by Turbopack with their own graph and load
-// page-wise; they are out of scope here.)
-const BOOT_ENTRYPOINTS = [
-  'server/crowi/index.ts',
-  'server/routes/apiv3/index.js',
-  'utils/prisma.ts',
-];
-
-const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx'];
-
-type Resolved =
-  | { kind: 'file'; file: string }
-  | { kind: 'external'; specifier: string }
-  | { kind: 'unresolved' };
-
-const resolveSpecifier = (fromFile: string, specifier: string): Resolved => {
-  let base: string;
-  if (specifier.startsWith('~/')) {
-    base = path.join(SRC_ROOT, specifier.slice(2));
-  } else if (specifier.startsWith('.')) {
-    base = path.resolve(path.dirname(fromFile), specifier);
-  } else {
-    return { kind: 'external', specifier };
-  }
-  for (const ext of ['', ...EXTENSIONS]) {
-    const candidate = base + ext;
-    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
-      return { kind: 'file', file: candidate };
-    }
-  }
-  for (const ext of EXTENSIONS) {
-    const candidate = path.join(base, `index${ext}`);
-    if (fs.existsSync(candidate)) {
-      return { kind: 'file', file: candidate };
-    }
-  }
-  return { kind: 'unresolved' };
-};
-
-// Static imports only: `import ... from 'x'`, `export ... from 'x'`, bare
-// `import 'x'`. Skips `import type`; dynamic import() never matches.
-const STATIC_IMPORT_RE =
-  /^\s*(?:import|export)\s+(?!type[\s{])[^;]*?from\s+['"]([^'"]+)['"]|^\s*import\s+['"]([^'"]+)['"]/gm;
-
-const traceHeavyImportChains = (): string[] => {
-  const violations: string[] = [];
-  const visited = new Set<string>();
-  const queue: { file: string; chain: string[] }[] = BOOT_ENTRYPOINTS.map(
-    (entry) => ({
-      file: path.join(SRC_ROOT, entry),
-      chain: [entry],
-    }),
-  );
-
-  while (queue.length > 0) {
-    const item = queue.shift();
-    if (item == null || visited.has(item.file)) continue;
-    visited.add(item.file);
-
-    let text: string;
-    try {
-      text = fs.readFileSync(item.file, 'utf8');
-    } catch {
-      continue;
-    }
-
-    for (const match of text.matchAll(STATIC_IMPORT_RE)) {
-      const specifier = match[1] ?? match[2];
-      if (specifier == null) continue;
-      const resolved = resolveSpecifier(item.file, specifier);
-      if (resolved.kind === 'external') {
-        if (HEAVY_PACKAGE.test(resolved.specifier)) {
-          violations.push(
-            `${item.chain.join('\n  -> ')}\n  => ${resolved.specifier}`,
-          );
-        }
-        continue;
-      }
-      if (resolved.kind === 'file' && !visited.has(resolved.file)) {
-        queue.push({
-          file: resolved.file,
-          chain: [...item.chain, path.relative(SRC_ROOT, resolved.file)],
-        });
-      }
-    }
-  }
-
-  return violations;
-};
-
 describe('boot-time import boundary for heavy AI packages', () => {
   it('has no static import chain from a boot entrypoint to @mastra / @ai-sdk / ai / tokenlens', () => {
-    const violations = traceHeavyImportChains();
+    const violations = traceStaticImportChains({
+      srcRoot: SRC_ROOT,
+      entrypoints: BOOT_ENTRYPOINTS,
+      bannedPattern: HEAVY_PACKAGE,
+    });
+    const formatted = violations.map(formatViolation);
 
     expect(
-      violations,
+      formatted,
       `Boot entrypoints must not statically reach heavy AI packages.\n` +
         `Break the chain with a light intermediate module or a guarded dynamic import.\n\n` +
-        `${violations.join('\n\n')}`,
+        `${formatted.join('\n\n')}`,
     ).toEqual([]);
   });
 

--- a/apps/app/src/server/crowi/index.ts
+++ b/apps/app/src/server/crowi/index.ts
@@ -543,6 +543,10 @@ class Crowi {
     // this hub module; loading it at import time would surface the cycle
     const { default: MailService } = await import('~/server/service/mail');
     this.mailService = new MailService(this);
+    // initialize() is async because it lazy-loads the configured transport
+    // (smtp/ses/oauth2) via dynamic import(), so it can no longer run inside
+    // the constructor; await it explicitly before the mailer is used.
+    await this.mailService.initialize();
 
     // add as a message handler
     if (this.s2sMessagingService != null) {

--- a/apps/app/src/server/routes/apiv3/app-settings/index.ts
+++ b/apps/app/src/server/routes/apiv3/app-settings/index.ts
@@ -17,7 +17,6 @@ import adminRequiredFactory from '~/server/middlewares/admin-required';
 import loginRequiredFactory from '~/server/middlewares/login-required';
 import { configManager } from '~/server/service/config-manager';
 import { getTranslation } from '~/server/service/i18next';
-import { createSMTPClient } from '~/server/service/mail/smtp';
 import loggerFactory from '~/utils/logger';
 
 import { generateAddActivityMiddleware } from '../../../middlewares/add-activity';
@@ -730,6 +729,10 @@ export const setup = (crowi: Crowi): Router => {
       throw Error('fromAddress is not setup');
     }
 
+    // Lazy: nodemailer must not load at server boot merely because this
+    // admin route module is statically registered (~/server/routes/apiv3/index.js
+    // -> app-settings/index.ts); only load it when a test email is actually sent.
+    const { createSMTPClient } = await import('~/server/service/mail/smtp');
     const smtpClient = createSMTPClient(configManager);
     if (smtpClient == null) {
       throw Error(

--- a/apps/app/src/server/service/mail/mail.spec.ts
+++ b/apps/app/src/server/service/mail/mail.spec.ts
@@ -39,6 +39,122 @@ describe('MailService', () => {
     mailService = new MailService(mockCrowi);
   });
 
+  describe('initialize', () => {
+    it('leaves the mailer unset up when mail:from is not configured', async () => {
+      mockConfigManager.getConfig.mockReturnValue(undefined);
+
+      await mailService.initialize();
+
+      expect(mailService.isMailerSetup).toBe(false);
+      expect(mailService.mailer).toBeNull();
+    });
+
+    it('leaves the mailer unset up when the transmission method is unrecognized', async () => {
+      mockConfigManager.getConfig.mockImplementation((key: string) => {
+        if (key === 'mail:from') return 'noreply@example.com';
+        if (key === 'mail:transmissionMethod') return undefined;
+        return undefined;
+      });
+
+      await mailService.initialize();
+
+      expect(mailService.isMailerSetup).toBe(false);
+      expect(mailService.mailer).toBeNull();
+    });
+
+    it('sets up an SMTP mailer when the transmission method is smtp', async () => {
+      mockConfigManager.getConfig.mockImplementation((key: string) => {
+        if (key === 'mail:from') return 'noreply@example.com';
+        if (key === 'mail:transmissionMethod') return 'smtp';
+        if (key === 'mail:smtpHost') return 'smtp.example.com';
+        if (key === 'mail:smtpPort') return 587;
+        return undefined;
+      });
+
+      await mailService.initialize();
+
+      expect(mailService.isMailerSetup).toBe(true);
+      expect(mailService.mailer).not.toBeNull();
+      expect(mailService.mailer.options).toMatchObject({
+        host: 'smtp.example.com',
+        port: 587,
+      });
+    });
+
+    it('sets up an SES mailer when the transmission method is ses', async () => {
+      mockConfigManager.getConfig.mockImplementation((key: string) => {
+        if (key === 'mail:from') return 'noreply@example.com';
+        if (key === 'mail:transmissionMethod') return 'ses';
+        if (key === 'mail:sesAccessKeyId') return 'AKIAIOSFODNN7EXAMPLE';
+        if (key === 'mail:sesSecretAccessKey') {
+          return 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+        }
+        return undefined;
+      });
+
+      await mailService.initialize();
+
+      expect(mailService.isMailerSetup).toBe(true);
+      expect(mailService.mailer).not.toBeNull();
+    });
+
+    it('sets up an OAuth2 mailer when the transmission method is oauth2', async () => {
+      mockConfigManager.getConfig.mockImplementation((key: string) => {
+        if (key === 'mail:from') return 'noreply@example.com';
+        if (key === 'mail:transmissionMethod') return 'oauth2';
+        if (key === 'mail:oauth2ClientId') {
+          return 'client-id.apps.googleusercontent.com';
+        }
+        if (key === 'mail:oauth2ClientSecret') return 'client-secret-value';
+        if (key === 'mail:oauth2RefreshToken') return 'refresh-token-value';
+        if (key === 'mail:oauth2User') return 'user@gmail.com';
+        return undefined;
+      });
+
+      await mailService.initialize();
+
+      expect(mailService.isMailerSetup).toBe(true);
+      expect(mailService.mailer).not.toBeNull();
+    });
+
+    it('leaves the mailer unset up when the smtp transport factory returns null', async () => {
+      mockConfigManager.getConfig.mockImplementation((key: string) => {
+        if (key === 'mail:from') return 'noreply@example.com';
+        if (key === 'mail:transmissionMethod') return 'smtp';
+        // smtpHost/smtpPort intentionally omitted -> createSMTPClient returns null
+        return undefined;
+      });
+
+      await mailService.initialize();
+
+      expect(mailService.isMailerSetup).toBe(false);
+      expect(mailService.mailer).toBeNull();
+    });
+  });
+
+  describe('send', () => {
+    it('rejects with a setup-guidance error when the mailer has not been initialized', async () => {
+      // mailService here was constructed but initialize() was never awaited,
+      // matching the state between construction and setup during boot.
+      await expect(
+        mailService.send({ to: 'recipient@example.com' }),
+      ).rejects.toThrow(
+        'Mailer is not completed to set up. Please set up SMTP, SES, or OAuth 2.0 setting.',
+      );
+    });
+
+    it('rejects with the same setup-guidance error after initialize() finds no usable transport', async () => {
+      mockConfigManager.getConfig.mockReturnValue(undefined);
+      await mailService.initialize();
+
+      await expect(
+        mailService.send({ to: 'recipient@example.com' }),
+      ).rejects.toThrow(
+        'Mailer is not completed to set up. Please set up SMTP, SES, or OAuth 2.0 setting.',
+      );
+    });
+  });
+
   describe('exponentialBackoff', () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/apps/app/src/server/service/mail/mail.ts
+++ b/apps/app/src/server/service/mail/mail.ts
@@ -1,4 +1,5 @@
 import ejs from 'ejs';
+import type { Transporter } from 'nodemailer';
 import { promisify } from 'util';
 
 import loggerFactory from '~/utils/logger';
@@ -8,12 +9,29 @@ import { FailedEmail } from '../../models/failed-email';
 import S2sMessage from '../../models/vo/s2s-message';
 import type { IConfigManagerForApp } from '../config-manager';
 import type { S2sMessageHandlable } from '../s2s-messaging/handlable';
-import { createOAuth2Client } from './oauth2';
-import { createSESClient } from './ses';
-import { createSMTPClient } from './smtp';
 import type { EmailConfig, MailConfig, SendResult } from './types';
 
 const logger = loggerFactory('growi:service:mail');
+
+type TransportFactory = (
+  configManager: IConfigManagerForApp,
+) => Transporter | null;
+
+// Static loader map keyed by the configured transmission method, mirroring
+// the pattern in service/file-uploader/index.ts: each entry is an explicit,
+// statically analyzable specifier (not a computed `import(\`./${method}\`)`,
+// which a bundler/runtime resolver cannot follow). nodemailer and its
+// transport packages (nodemailer-ses-transport -> aws-sdk) therefore only
+// load once a transmission method is actually selected, instead of whenever
+// the mail service module itself loads.
+const transportFactoryLoaders: Record<
+  'smtp' | 'ses' | 'oauth2',
+  () => Promise<TransportFactory>
+> = {
+  smtp: async () => (await import('./smtp')).createSMTPClient,
+  ses: async () => (await import('./ses')).createSESClient,
+  oauth2: async () => (await import('./oauth2')).createOAuth2Client,
+};
 
 class MailService implements S2sMessageHandlable {
   appService!: any;
@@ -26,7 +44,11 @@ class MailService implements S2sMessageHandlable {
 
   mailConfig: MailConfig = {};
 
-  mailer: any = {};
+  // `null` (not `{}`) so that `send()` sees an unambiguous "not set up" state
+  // for the window between construction and the caller's awaited
+  // `initialize()` call — initialize() can no longer run synchronously in the
+  // constructor now that transport loading is async.
+  mailer: any = null;
 
   lastLoadedAt?: Date;
 
@@ -40,8 +62,6 @@ class MailService implements S2sMessageHandlable {
     this.appService = crowi.appService;
     this.configManager = crowi.configManager;
     this.s2sMessagingService = crowi.s2sMessagingService;
-
-    this.initialize();
   }
 
   /**
@@ -67,7 +87,7 @@ class MailService implements S2sMessageHandlable {
 
     logger.info('Initialize mail settings by pubsub notification');
     await configManager.loadConfigs();
-    this.initialize();
+    await this.initialize();
   }
 
   async publishUpdatedMessage() {
@@ -89,7 +109,7 @@ class MailService implements S2sMessageHandlable {
     }
   }
 
-  initialize() {
+  async initialize(): Promise<void> {
     const { appService, configManager } = this;
 
     this.isMailerSetup = false;
@@ -103,15 +123,15 @@ class MailService implements S2sMessageHandlable {
       'mail:transmissionMethod',
     );
 
-    if (transmissionMethod === 'smtp') {
-      this.mailer = createSMTPClient(configManager);
-    } else if (transmissionMethod === 'ses') {
-      this.mailer = createSESClient(configManager);
-    } else if (transmissionMethod === 'oauth2') {
-      this.mailer = createOAuth2Client(configManager);
-    } else {
-      this.mailer = null;
-    }
+    const loadTransportFactory =
+      transmissionMethod != null
+        ? transportFactoryLoaders[transmissionMethod]
+        : undefined;
+
+    this.mailer =
+      loadTransportFactory != null
+        ? (await loadTransportFactory())(configManager)
+        : null;
 
     if (this.mailer != null) {
       this.isMailerSetup = true;

--- a/apps/app/src/server/service/mail/no-eager-transport-imports.spec.ts
+++ b/apps/app/src/server/service/mail/no-eager-transport-imports.spec.ts
@@ -1,0 +1,112 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { BOOT_ENTRYPOINTS } from '~/test-utils/boot-entrypoints';
+import {
+  formatViolation,
+  traceStaticImportChains,
+} from '~/test-utils/static-import-graph';
+
+// --- Contract --------------------------------------------------------------
+//
+// nodemailer (~13-19MB RSS) and nodemailer-ses-transport, which drags in the
+// full aws-sdk v2 (~23MB RSS), must only load once a mail transport is
+// actually selected by config — not merely because the mail service module
+// itself was loaded, and not merely because the server booted.
+//
+// Two walks guard this from different angles:
+//
+// 1. From the mail service's own barrel (not a server boot entrypoint: crowi
+//    loads this module via a dynamic `import()`, which is itself already a
+//    boundary the walker won't cross — this walk instead guards the module's
+//    *internal* static graph, which is where a `./smtp`/`./ses`/`./oauth2`
+//    top-level import would reintroduce the cost unconditionally).
+// 2. From the server's boot entrypoints (shared with the heavy-AI-package
+//    boundary spec, see `test-utils/boot-entrypoints`). This is the
+//    realistic leak path: crowi only reaches the mail service through a
+//    dynamic import(), so walk (1) alone would miss a top-level transport
+//    import sneaking into some *other* module reachable from boot — e.g. an
+//    admin route module under routes/apiv3 statically importing
+//    `~/server/service/mail/smtp` (see app-settings/index.ts, which does this
+//    lazily via a dynamic import() specifically to avoid the regression this
+//    walk catches).
+//
+// Dynamic import() calls are treated as boundaries (not followed). `import
+// type` lines are skipped (erased at build) — the type-only nodemailer
+// imports in types.ts/smtp.ts/ses.ts/oauth2.ts are fine and must remain.
+
+const SRC_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../..',
+);
+
+const TRANSPORT_PACKAGE =
+  /^(nodemailer|nodemailer-ses-transport|aws-sdk)($|\/)/;
+
+const MAIL_ENTRYPOINTS = ['server/service/mail/index.ts'];
+
+describe('lazy-load boundary for mail transport packages', () => {
+  it('has no static import chain from the mail service entry to nodemailer / nodemailer-ses-transport / aws-sdk', () => {
+    const violations = traceStaticImportChains({
+      srcRoot: SRC_ROOT,
+      entrypoints: MAIL_ENTRYPOINTS,
+      bannedPattern: TRANSPORT_PACKAGE,
+    });
+    const formatted = violations.map(formatViolation);
+
+    expect(
+      formatted,
+      `The mail service entry must not statically reach transport packages.\n` +
+        `Select the transport factory via a dynamic import() keyed by the ` +
+        `configured transmission method instead of a top-level import.\n\n` +
+        `${formatted.join('\n\n')}`,
+    ).toEqual([]);
+  });
+
+  // Guards the tracer itself: if the entrypoint were renamed/moved, the walk
+  // would silently trace nothing and the boundary test above would pass
+  // vacuously.
+  it('still finds the mail service entrypoint it traces from', () => {
+    for (const entry of MAIL_ENTRYPOINTS) {
+      expect(
+        fs.existsSync(path.join(SRC_ROOT, entry)),
+        `mail entrypoint disappeared: ${entry} — update MAIL_ENTRYPOINTS`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('boot-time import boundary for mail transport packages', () => {
+  it('has no static import chain from a boot entrypoint to nodemailer / nodemailer-ses-transport / aws-sdk', () => {
+    const violations = traceStaticImportChains({
+      srcRoot: SRC_ROOT,
+      entrypoints: BOOT_ENTRYPOINTS,
+      bannedPattern: TRANSPORT_PACKAGE,
+    });
+    const formatted = violations.map(formatViolation);
+
+    expect(
+      formatted,
+      `Boot entrypoints must not statically reach transport packages.\n` +
+        `crowi reaches the mail service only through a dynamic import(), so this ` +
+        `catches the realistic leak: a *different* boot-reachable module (e.g. an ` +
+        `admin route under routes/apiv3) adding a top-level ` +
+        `'~/server/service/mail/smtp'-style import. Load the transport factory via a ` +
+        `dynamic import() at the call site instead.\n\n` +
+        `${formatted.join('\n\n')}`,
+    ).toEqual([]);
+  });
+
+  // Guards the tracer itself: if the boot entrypoints were renamed/moved, the
+  // walk would silently trace nothing and the boundary test above would pass
+  // vacuously.
+  it('still finds every boot entrypoint it traces from', () => {
+    for (const entry of BOOT_ENTRYPOINTS) {
+      expect(
+        fs.existsSync(path.join(SRC_ROOT, entry)),
+        `boot entrypoint disappeared: ${entry} — update BOOT_ENTRYPOINTS`,
+      ).toBe(true);
+    }
+  });
+});

--- a/apps/app/src/test-utils/boot-entrypoints.ts
+++ b/apps/app/src/test-utils/boot-entrypoints.ts
@@ -1,0 +1,19 @@
+/**
+ * Boot-time entrypoints of the Express server's STATIC import graph.
+ *
+ * Declared once here so every "drift test" that walks this graph — the
+ * heavy-AI-package boundary, the mail-transport-package boundary, and any
+ * future one — traces from the same work-set instead of each keeping its
+ * own copy that can silently drift out of sync. Per the "declare the
+ * work-set once, executors receive it as input" convention: this module owns
+ * *what* to trace from; `test-utils/static-import-graph.ts` owns *how* to
+ * walk it.
+ *
+ * (Client/SSR bundles are built by Turbopack with their own graph and load
+ * page-wise; they are out of scope here.)
+ */
+export const BOOT_ENTRYPOINTS = [
+  'server/crowi/index.ts',
+  'server/routes/apiv3/index.js',
+  'utils/prisma.ts',
+] as const;

--- a/apps/app/src/test-utils/static-import-graph.ts
+++ b/apps/app/src/test-utils/static-import-graph.ts
@@ -1,0 +1,134 @@
+/**
+ * Static-import-graph walker.
+ *
+ * Extracted from `features/mastra/server/no-eager-ai-imports.spec.ts` so that
+ * other "drift tests" (e.g. the mail service's transport-loading boundary)
+ * can reuse the same walk logic against a different entrypoint set / banned
+ * package pattern, without duplicating the parsing and resolution rules.
+ *
+ * Per the "executors take their work-set as input" convention, the walker
+ * owns *how* to walk (extension resolution, `~/` alias handling, type-import
+ * skipping, dynamic-import boundary) but never *what* to walk — the caller
+ * supplies `srcRoot`, `entrypoints`, and `bannedPattern`.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** A static import chain from an entrypoint down to a banned specifier. */
+export type ImportChainViolation = {
+  /** The banned external specifier reached by this chain (e.g. 'nodemailer'). */
+  readonly specifier: string;
+  /** File chain, relative to srcRoot, from the entrypoint to the importing file. */
+  readonly chain: readonly string[];
+};
+
+export type StaticImportGraphParams = {
+  /** Absolute path that entrypoints and relative/`~/` specifiers resolve against. */
+  readonly srcRoot: string;
+  /** Entrypoint files, relative to srcRoot, to start walking from. */
+  readonly entrypoints: readonly string[];
+  /** Tested against each externally-resolved specifier; a match is a violation. */
+  readonly bannedPattern: RegExp;
+};
+
+type Resolved =
+  | { kind: 'file'; file: string }
+  | { kind: 'external'; specifier: string }
+  | { kind: 'unresolved' };
+
+const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx'];
+
+// Static imports only: `import ... from 'x'`, `export ... from 'x'`, bare
+// `import 'x'`. Skips `import type`; dynamic import() never matches.
+const STATIC_IMPORT_RE =
+  /^\s*(?:import|export)\s+(?!type[\s{])[^;]*?from\s+['"]([^'"]+)['"]|^\s*import\s+['"]([^'"]+)['"]/gm;
+
+const resolveSpecifier = (
+  srcRoot: string,
+  fromFile: string,
+  specifier: string,
+): Resolved => {
+  let base: string;
+  if (specifier.startsWith('~/')) {
+    base = path.join(srcRoot, specifier.slice(2));
+  } else if (specifier.startsWith('.')) {
+    base = path.resolve(path.dirname(fromFile), specifier);
+  } else {
+    return { kind: 'external', specifier };
+  }
+  for (const ext of ['', ...EXTENSIONS]) {
+    const candidate = base + ext;
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return { kind: 'file', file: candidate };
+    }
+  }
+  for (const ext of EXTENSIONS) {
+    const candidate = path.join(base, `index${ext}`);
+    if (fs.existsSync(candidate)) {
+      return { kind: 'file', file: candidate };
+    }
+  }
+  return { kind: 'unresolved' };
+};
+
+/**
+ * Walks the STATIC import graph from `entrypoints` and reports every chain
+ * that reaches an external specifier matching `bannedPattern`.
+ *
+ * Dynamic `import()` calls are treated as boundaries (not followed), matching
+ * runtime behavior: they only load when executed. `import type` lines are
+ * skipped (erased at build). Mixed value/type imports are followed —
+ * conservative in the right direction.
+ */
+export const traceStaticImportChains = ({
+  srcRoot,
+  entrypoints,
+  bannedPattern,
+}: StaticImportGraphParams): ImportChainViolation[] => {
+  const violations: ImportChainViolation[] = [];
+  const visited = new Set<string>();
+  const queue: { file: string; chain: string[] }[] = entrypoints.map(
+    (entry) => ({
+      file: path.join(srcRoot, entry),
+      chain: [entry],
+    }),
+  );
+
+  while (queue.length > 0) {
+    const item = queue.shift();
+    if (item == null || visited.has(item.file)) continue;
+    visited.add(item.file);
+
+    let text: string;
+    try {
+      text = fs.readFileSync(item.file, 'utf8');
+    } catch {
+      continue;
+    }
+
+    for (const match of text.matchAll(STATIC_IMPORT_RE)) {
+      const specifier = match[1] ?? match[2];
+      if (specifier == null) continue;
+      const resolved = resolveSpecifier(srcRoot, item.file, specifier);
+      if (resolved.kind === 'external') {
+        if (bannedPattern.test(resolved.specifier)) {
+          violations.push({ specifier: resolved.specifier, chain: item.chain });
+        }
+        continue;
+      }
+      if (resolved.kind === 'file' && !visited.has(resolved.file)) {
+        queue.push({
+          file: resolved.file,
+          chain: [...item.chain, path.relative(srcRoot, resolved.file)],
+        });
+      }
+    }
+  }
+
+  return violations;
+};
+
+/** Formats a violation as a human-readable chain: `a -> b -> c => banned-pkg`. */
+export const formatViolation = (violation: ImportChainViolation): string =>
+  `${violation.chain.join('\n  -> ')}\n  => ${violation.specifier}`;


### PR DESCRIPTION
## Problem

The mail service statically imported all three transport factories, and `ses.ts` pulls `nodemailer-ses-transport` (2015-era, hard-depends on **full aws-sdk v2**). Measured on a production build: aws-sdk v2 costs **+23.1 MiB RSS** and nodemailer **+13–19 MiB**, loaded at every boot even when the app has no mail configuration. A second, independent leak: the `app-settings` route (statically registered from the boot entrypoint) also imported `createSMTPClient` at top level.

## Changes

- `mail.ts`: the three top-level factory imports are replaced with a data-driven map of dynamic imports (same pattern as `file-uploader/index.ts`); `initialize()` is now async and no longer called from the constructor — crowi awaits it (`app-settings` routes already had pre-existing `await mailService.initialize()` call sites, which this makes meaningful)
- `app-settings` route: `createSMTPClient` is imported lazily inside `sendTestEmail`
- The static-import-graph walker from `no-eager-ai-imports.spec.ts` is extracted into a shared parameterized test util (`src/test-utils/static-import-graph.ts`), `BOOT_ENTRYPOINTS` is declared once (`src/test-utils/boot-entrypoints.ts`), and a new drift spec bans `nodemailer` / `nodemailer-ses-transport` / `aws-sdk` from both the mail-service graph and the boot graph (the boot-graph root is what catches app-settings-style regressions; both were mutation-tested red→green)

Behavior when mail IS configured is unchanged: same transport selection semantics (including unknown/unset → disabled), same `send()` guard error before/after initialization.

## Measurements (production build, fresh DB, installer + 1 SSR request, 90 s idle)

Together with #11480 (measured stacked): installed-idle RSS **269 → 256 MiB (−13)**, boot-phase peak **375 → 365 MiB (−10)**, boot-time module loads **5,000 → 4,035 (−965 files)** — aws-sdk (419 files) and nodemailer (37 files) fully absent from the boot module graph, verified with a runtime module-load logger.

## Notes

- Adversarially reviewed (race-window analysis: crowi's staged `Promise.all` boot blocks guarantee `setupMailer()` completes before `setUpGlobalNotification()`, the only non-HTTP `send()` consumer; all HTTP consumers are reachable only after `listen()`)
- Backport candidate for `master` (v7.5): same structure there, benefits the whole fleet
- Follow-up candidate (separate PR): replace `nodemailer-ses-transport` with nodemailer's built-in SES transport (@aws-sdk/client-ses v3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
