### PR TITLE
imprv: Lazy-load passport strategy SDKs and ldapjs

### DIFF
--- a/apps/app/src/server/service/ldap.ts
+++ b/apps/app/src/server/service/ldap.ts
@@ -1,8 +1,4 @@
-import ldap from 'ldapjs';
-
-// ldapjs is CJS and cjs-module-lexer cannot detect its named exports, so a
-// named import of NoSuchObjectError fails at runtime under native ESM.
-const { NoSuchObjectError } = ldap;
+import type { Client } from 'ldapjs';
 
 import loggerFactory from '~/utils/logger';
 
@@ -25,7 +21,7 @@ export interface SearchResultEntry {
  * User auth using LDAP is done with PassportService, not here.
  */
 class LdapService {
-  client: ldap.Client | null;
+  client: Client | null;
 
   searchBase: string;
 
@@ -34,7 +30,10 @@ class LdapService {
    * @param {string} userBindUsername Necessary when bind type is user bind
    * @param {string} userBindPassword Necessary when bind type is user bind
    */
-  initClient(userBindUsername?: string, userBindPassword?: string): void {
+  async initClient(
+    userBindUsername?: string,
+    userBindPassword?: string,
+  ): Promise<void> {
     const serverUrl = configManager.getConfig(
       'security:passport-ldap:serverUrl',
     );
@@ -49,6 +48,12 @@ class LdapService {
     }
     const url = match[1];
     this.searchBase = match[2] || '';
+
+    // Lazy-load ldapjs so it stays out of the boot module graph (~18 MiB RSS);
+    // it is only needed once LDAP directory access actually runs. ldapjs is CJS
+    // and cjs-module-lexer cannot detect its named exports, so reach
+    // createClient through the default (CJS module.exports) export.
+    const ldap = (await import('ldapjs')).default;
 
     this.client = ldap.createClient({
       url,
@@ -109,13 +114,17 @@ class LdapService {
    * @param {string} base Base DN to execute search on
    * @returns {SearchEntry[]} Search result. Default scope is set to 'sub'.
    */
-  search(
+  async search(
     filter?: string,
     base?: string,
     scope: 'sub' | 'base' | 'one' = 'sub',
   ): Promise<SearchResultEntry[]> {
     const client = this.client;
     if (client == null) throw new Error('LDAP client is not initialized');
+
+    // Lazy-load ldapjs (see initClient); the module is already cached after
+    // initClient. NoSuchObjectError is needed for the instanceof check below.
+    const { NoSuchObjectError } = (await import('ldapjs')).default;
 
     const searchResults: SearchResultEntry[] = [];
 

--- a/apps/app/src/server/service/no-eager-passport-strategy-imports.spec.ts
+++ b/apps/app/src/server/service/no-eager-passport-strategy-imports.spec.ts
@@ -1,0 +1,117 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { BOOT_ENTRYPOINTS } from '~/test-utils/boot-entrypoints';
+import {
+  formatViolation,
+  traceStaticImportChains,
+} from '~/test-utils/static-import-graph';
+
+// --- Contract --------------------------------------------------------------
+//
+// Every tenant boots the passport service, but the strategy SDKs are only
+// needed by tenants that actually enable the matching external auth provider.
+// Two of them are expensive to load: passport-ldapauth drags in ldapjs
+// (+18.4 MiB RSS measured) and openid-client drags in jose (84 files). Loading
+// them at boot for the local-auth-only majority is pure waste.
+//
+// So these five strategy SDKs must only load when their strategy is actually
+// set up (i.e. enabled in config) — reached through a dynamic import()
+// executed *after* the per-strategy "isEnabled" check inside each
+// setupXStrategy() method, never through a top-level import.
+//
+// passport itself and passport-local (always used) stay static, as do all
+// `import type` lines (erased at build).
+//
+// Two walks guard this from different angles, mirroring the mail-transport
+// boundary spec:
+//
+// 1. From the passport service module itself (server/service/passport.ts):
+//    guards the module's *internal* static graph, which is exactly where a
+//    top-level `import { Strategy } from 'passport-saml'` would reintroduce
+//    the cost unconditionally.
+// 2. From the server's boot entrypoints (shared BOOT_ENTRYPOINTS): crowi
+//    reaches the passport service through a *static* import, so this is the
+//    realistic boot-time leak path — and it also catches any *other*
+//    boot-reachable module (an admin route, another service) adding a
+//    top-level import of one of these packages.
+//
+// Dynamic import() calls are treated as boundaries (not followed), matching
+// runtime behavior: they only load when executed. `import type` lines are
+// skipped (erased at build) — the type-only `Profile`/`VerifiedCallback`
+// imports from passport-saml are fine and must remain.
+
+const SRC_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../..',
+);
+
+const STRATEGY_PACKAGE =
+  /^(openid-client|passport-ldapauth|ldapjs|passport-saml|passport-github|passport-google-oauth20)($|\/)/;
+
+const PASSPORT_ENTRYPOINTS = ['server/service/passport.ts'];
+
+describe('lazy-load boundary for passport strategy SDKs', () => {
+  it('has no static import chain from the passport service to openid-client / passport-ldapauth / ldapjs / passport-saml / passport-github / passport-google-oauth20', () => {
+    const violations = traceStaticImportChains({
+      srcRoot: SRC_ROOT,
+      entrypoints: PASSPORT_ENTRYPOINTS,
+      bannedPattern: STRATEGY_PACKAGE,
+    });
+    const formatted = violations.map(formatViolation);
+
+    expect(
+      formatted,
+      `The passport service must not statically reach strategy SDKs.\n` +
+        `Import each strategy SDK via a dynamic import() inside its setupXStrategy() ` +
+        `method, after the "isEnabled" check, instead of a top-level import.\n\n` +
+        `${formatted.join('\n\n')}`,
+    ).toEqual([]);
+  });
+
+  // Guards the tracer itself: if the entrypoint were renamed/moved, the walk
+  // would silently trace nothing and the boundary test above would pass
+  // vacuously.
+  it('still finds the passport service entrypoint it traces from', () => {
+    for (const entry of PASSPORT_ENTRYPOINTS) {
+      expect(
+        fs.existsSync(path.join(SRC_ROOT, entry)),
+        `passport entrypoint disappeared: ${entry} — update PASSPORT_ENTRYPOINTS`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('boot-time import boundary for passport strategy SDKs', () => {
+  it('has no static import chain from a boot entrypoint to openid-client / passport-ldapauth / ldapjs / passport-saml / passport-github / passport-google-oauth20', () => {
+    const violations = traceStaticImportChains({
+      srcRoot: SRC_ROOT,
+      entrypoints: BOOT_ENTRYPOINTS,
+      bannedPattern: STRATEGY_PACKAGE,
+    });
+    const formatted = violations.map(formatViolation);
+
+    expect(
+      formatted,
+      `Boot entrypoints must not statically reach passport strategy SDKs.\n` +
+        `crowi reaches the passport service through a static import, so a top-level ` +
+        `strategy-SDK import there (or in any other boot-reachable module) loads ` +
+        `ldapjs/jose for every tenant at boot. Load each SDK via a dynamic import() ` +
+        `inside its setupXStrategy() method instead.\n\n` +
+        `${formatted.join('\n\n')}`,
+    ).toEqual([]);
+  });
+
+  // Guards the tracer itself: if the boot entrypoints were renamed/moved, the
+  // walk would silently trace nothing and the boundary test above would pass
+  // vacuously.
+  it('still finds every boot entrypoint it traces from', () => {
+    for (const entry of BOOT_ENTRYPOINTS) {
+      expect(
+        fs.existsSync(path.join(SRC_ROOT, entry)),
+        `boot entrypoint disappeared: ${entry} — update BOOT_ENTRYPOINTS`,
+      ).toBe(true);
+    }
+  });
+});

--- a/apps/app/src/server/service/passport.spec.ts
+++ b/apps/app/src/server/service/passport.spec.ts
@@ -238,3 +238,44 @@ describe('strategy setup — lazy SDK loading contract', () => {
     });
   });
 });
+
+describe('setupStrategyById — dispatch and unknown-id boundary', () => {
+  let crowiMock: Crowi;
+  let passportService: PassportService;
+  let useSpy: MockInstance<typeof passport.use>;
+
+  beforeEach(() => {
+    crowiMock = mock<Crowi>({ configManager });
+    passportService = new PassportService(crowiMock);
+    useSpy = vi.spyOn(passport, 'use').mockReturnValue(passport);
+    vi.spyOn(passport, 'unuse').mockReturnValue(passport);
+    // every "...:isEnabled" lookup resolves falsy -> no strategy registered
+    vi.spyOn(configManager, 'getConfig').mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('dispatches a known id through the method table and records lastLoadedAt', async () => {
+    await expect(
+      passportService.setupStrategyById('github'),
+    ).resolves.toBeUndefined();
+
+    // github is disabled above, so nothing is registered, but the happy path
+    // ran to completion and stamped lastLoadedAt.
+    expect(useSpy).not.toHaveBeenCalled();
+    expect(passportService.lastLoadedAt).toBeInstanceOf(Date);
+  });
+
+  it('skips an unknown id without throwing, registering, or recording lastLoadedAt', async () => {
+    // Before the typed guard an unknown id crashed on a missing dispatch entry
+    // (a TypeError that escaped the un-awaited S2s path); now it is skipped.
+    await expect(
+      passportService.setupStrategyById('nonexistent'),
+    ).resolves.toBeUndefined();
+
+    expect(useSpy).not.toHaveBeenCalled();
+    expect(passportService.lastLoadedAt).toBeUndefined();
+  });
+});

--- a/apps/app/src/server/service/passport.spec.ts
+++ b/apps/app/src/server/service/passport.spec.ts
@@ -1,3 +1,4 @@
+import passport from 'passport';
 import type { MockInstance } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -91,5 +92,149 @@ describe('PassportService test', () => {
         });
       },
     );
+  });
+});
+
+describe('strategy setup — lazy SDK loading contract', () => {
+  let crowiMock: Crowi;
+  let passportService: PassportService;
+  let useSpy: MockInstance<typeof passport.use>;
+  let getConfigSpy: MockInstance<typeof configManager.getConfig>;
+
+  beforeEach(() => {
+    // In production `crowi.configManager` IS the module-level configManager
+    // singleton; wiring the mock to the real one lets a single getConfig spy
+    // drive every strategy (LDAP reads crowi.configManager; the others read
+    // the module import directly).
+    crowiMock = mock<Crowi>({ configManager });
+    passportService = new PassportService(crowiMock);
+
+    // Isolate from the real passport singleton: assert on registration without
+    // mutating global strategy state. `new XStrategy(...)` (the argument) is
+    // still constructed, so the enabled-path tests still exercise the real
+    // lazy import() and the SDK's runtime export shape.
+    useSpy = vi.spyOn(passport, 'use').mockReturnValue(passport);
+    vi.spyOn(passport, 'unuse').mockReturnValue(passport);
+
+    getConfigSpy = vi.spyOn(configManager, 'getConfig');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('when the provider is disabled', () => {
+    beforeEach(() => {
+      // every "...:isEnabled" lookup resolves falsy
+      getConfigSpy.mockReturnValue(undefined);
+    });
+
+    it.each`
+      method                   | flag
+      ${'setupLdapStrategy'}   | ${'isLdapStrategySetup'}
+      ${'setupSamlStrategy'}   | ${'isSamlStrategySetup'}
+      ${'setupOidcStrategy'}   | ${'isOidcStrategySetup'}
+      ${'setupGoogleStrategy'} | ${'isGoogleStrategySetup'}
+      ${'setupGitHubStrategy'} | ${'isGitHubStrategySetup'}
+    `(
+      '$method registers no strategy and leaves $flag false',
+      async ({ method, flag }) => {
+        await passportService[method]();
+
+        expect(useSpy).not.toHaveBeenCalled();
+        expect(passportService[flag]).toBe(false);
+      },
+    );
+  });
+
+  describe('when the provider is enabled', () => {
+    it('setupLdapStrategy lazy-loads passport-ldapauth (default export) and registers', async () => {
+      getConfigSpy.mockImplementation((key) => {
+        if (key === 'security:passport-ldap:isEnabled') return true;
+        if (key === 'security:passport-ldap:serverUrl')
+          return 'ldap://localhost:389/dc=example,dc=org';
+        return undefined;
+      });
+
+      await passportService.setupLdapStrategy();
+
+      expect(useSpy).toHaveBeenCalledTimes(1);
+      expect(passportService.isLdapStrategySetup).toBe(true);
+    });
+
+    it('setupSamlStrategy lazy-loads passport-saml and registers', async () => {
+      getConfigSpy.mockImplementation((key) => {
+        switch (key) {
+          case 'security:passport-saml:isEnabled':
+            return true;
+          case 'security:passport-saml:cert':
+            return 'dummy-cert';
+          case 'security:passport-saml:entryPoint':
+            return 'https://idp.example.com/sso';
+          case 'security:passport-saml:issuer':
+            return 'growi';
+          case 'security:passport-saml:callbackUrl':
+            return 'http://localhost:3000/passport/saml/callback';
+          default:
+            return undefined; // app:siteUrl null -> uses callbackUrl above
+        }
+      });
+
+      await passportService.setupSamlStrategy();
+
+      expect(useSpy).toHaveBeenCalledTimes(1);
+      expect(passportService.isSamlStrategySetup).toBe(true);
+    });
+
+    it.each`
+      provider    | method                   | flag
+      ${'google'} | ${'setupGoogleStrategy'} | ${'isGoogleStrategySetup'}
+      ${'github'} | ${'setupGitHubStrategy'} | ${'isGitHubStrategySetup'}
+    `(
+      '$method lazy-loads its OAuth SDK and registers',
+      async ({ provider, method, flag }) => {
+        getConfigSpy.mockImplementation((key) => {
+          switch (key) {
+            case `security:passport-${provider}:isEnabled`:
+              return true;
+            case `security:passport-${provider}:clientId`:
+              return 'test-client-id';
+            case `security:passport-${provider}:clientSecret`:
+              return 'test-client-secret';
+            default:
+              return undefined; // app:siteUrl null -> uses legacy callbackUrl
+          }
+        });
+        vi.spyOn(configManager, 'getConfigLegacy').mockReturnValue(
+          `http://localhost:3000/passport/${provider}/callback`,
+        );
+
+        await passportService[method]();
+
+        expect(useSpy).toHaveBeenCalledTimes(1);
+        expect(passportService[flag]).toBe(true);
+      },
+    );
+
+    it('setupOidcStrategy lazy-loads openid-client without throwing and does not register when the issuer is unreachable', async () => {
+      // enabled, but issuerHost is unset so getOIDCIssuerInstance returns early
+      // (no network). This still executes the openid-client import() and the
+      // `custom.setHttpOptionsDefaults` call, so it proves the named-export
+      // shape at runtime; if the import shape were wrong it would throw here.
+      getConfigSpy.mockImplementation((key) => {
+        if (key === 'security:passport-oidc:isEnabled') return true;
+        if (key === 'security:passport-oidc:oidcIssuerTimeoutOption')
+          return 5000;
+        return undefined; // issuerHost undefined -> early return, no network
+      });
+      vi.spyOn(configManager, 'getConfigLegacy').mockReturnValue(undefined);
+
+      await expect(
+        passportService.setupOidcStrategy(),
+      ).resolves.toBeUndefined();
+
+      expect(useSpy).not.toHaveBeenCalled();
+      expect(passportService.isOidcStrategySetup).toBe(false);
+    });
   });
 });

--- a/apps/app/src/server/service/passport.ts
+++ b/apps/app/src/server/service/passport.ts
@@ -1,19 +1,14 @@
 import axiosRetry from 'axios-retry';
 import type { IncomingMessage } from 'http';
 import luceneQueryParser from 'lucene-query-parser';
-import {
-  custom,
-  Issuer as OIDCIssuer,
-  Strategy as OidcStrategy,
-} from 'openid-client';
+// Only the `Issuer` type is needed at module scope (for the getOIDCIssuerInstance
+// return annotation); the value bindings (custom / Issuer / Strategy) are loaded
+// lazily inside the setup methods. See the lazy `import('openid-client')` calls.
+import type { Issuer } from 'openid-client';
 import pRetry from 'p-retry';
 import passport from 'passport';
-import { Strategy as GitHubStrategy } from 'passport-github';
-import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
-import LdapStrategy from 'passport-ldapauth';
 import { Strategy as LocalStrategy } from 'passport-local';
 import type { Profile, VerifiedCallback } from 'passport-saml';
-import { Strategy as SamlStrategy } from 'passport-saml';
 import urljoin from 'url-join';
 
 import type { IExternalAuthProviderType } from '~/interfaces/external-auth-provider';
@@ -311,7 +306,7 @@ class PassportService implements S2sMessageHandlable {
    *
    * @memberof PassportService
    */
-  setupLdapStrategy() {
+  async setupLdapStrategy(): Promise<void> {
     this.resetLdapStrategy();
 
     const config = this.crowi.config;
@@ -327,6 +322,11 @@ class PassportService implements S2sMessageHandlable {
     }
 
     logger.debug('LdapStrategy: setting up..');
+
+    // Lazy-load the strategy SDK only when LDAP is enabled, to keep
+    // passport-ldapauth (and its heavy ldapjs dependency, ~18 MiB RSS) out of
+    // the boot module graph. passport-ldapauth is a CJS default export.
+    const LdapStrategy = (await import('passport-ldapauth')).default;
 
     passport.use(
       new LdapStrategy(
@@ -508,7 +508,7 @@ class PassportService implements S2sMessageHandlable {
    *
    * @memberof PassportService
    */
-  setupGoogleStrategy() {
+  async setupGoogleStrategy(): Promise<void> {
     this.resetGoogleStrategy();
 
     const isGoogleEnabled = configManager.getConfig(
@@ -521,6 +521,13 @@ class PassportService implements S2sMessageHandlable {
     }
 
     logger.debug('GoogleStrategy: setting up..');
+
+    // Lazy-load the strategy SDK only when Google auth is enabled
+    // (see setupLdapStrategy for rationale).
+    const { Strategy: GoogleStrategy } = await import(
+      'passport-google-oauth20'
+    );
+
     passport.use(
       new GoogleStrategy(
         {
@@ -566,7 +573,7 @@ class PassportService implements S2sMessageHandlable {
     this.isGoogleStrategySetup = false;
   }
 
-  setupGitHubStrategy() {
+  async setupGitHubStrategy(): Promise<void> {
     this.resetGitHubStrategy();
 
     const isGitHubEnabled = configManager.getConfig(
@@ -579,6 +586,11 @@ class PassportService implements S2sMessageHandlable {
     }
 
     logger.debug('GitHubStrategy: setting up..');
+
+    // Lazy-load the strategy SDK only when GitHub auth is enabled
+    // (see setupLdapStrategy for rationale).
+    const { Strategy: GitHubStrategy } = await import('passport-github');
+
     passport.use(
       new GitHubStrategy(
         {
@@ -637,6 +649,15 @@ class PassportService implements S2sMessageHandlable {
     }
 
     logger.debug('OidcStrategy: setting up..');
+
+    // Lazy-load the strategy SDK only when OIDC is enabled, to keep
+    // openid-client (and its jose dependency) out of the boot module graph
+    // (see setupLdapStrategy for rationale).
+    const {
+      custom,
+      Issuer: OIDCIssuer,
+      Strategy: OidcStrategy,
+    } = await import('openid-client');
 
     // setup client
     // extend oidc request timeouts
@@ -839,7 +860,11 @@ class PassportService implements S2sMessageHandlable {
    */
   async getOIDCIssuerInstance(
     issuerHost: string | undefined,
-  ): Promise<void | OIDCIssuer> {
+  ): Promise<void | Issuer> {
+    // Lazy-load the strategy SDK only when OIDC is enabled (this method is
+    // only reached from setupOidcStrategy, after its enabled check).
+    const { custom, Issuer: OIDCIssuer } = await import('openid-client');
+
     const OIDC_TIMEOUT_MULTIPLIER = configManager.getConfig(
       'security:passport-oidc:timeoutMultiplier',
     );
@@ -885,7 +910,7 @@ class PassportService implements S2sMessageHandlable {
     return oidcIssuer;
   }
 
-  setupSamlStrategy(): void {
+  async setupSamlStrategy(): Promise<void> {
     this.resetSamlStrategy();
 
     const isSamlEnabled = configManager.getConfig(
@@ -904,6 +929,10 @@ class PassportService implements S2sMessageHandlable {
       logger.warn('SamlStrategy: cert is not set. setup is skipped.');
       return;
     }
+
+    // Lazy-load the strategy SDK only when SAML is enabled and configured
+    // (see setupLdapStrategy for rationale).
+    const { Strategy: SamlStrategy } = await import('passport-saml');
 
     passport.use(
       new SamlStrategy(

--- a/apps/app/src/server/service/passport.ts
+++ b/apps/app/src/server/service/passport.ts
@@ -23,6 +23,32 @@ import type { S2sMessageHandlable } from './s2s-messaging/handlable';
 
 const logger = loggerFactory('growi:service:PassportService');
 
+/**
+ * The single source of truth for the auth strategy ids this service dispatches.
+ * Kept module-private: no external caller needs the id set (the security-settings
+ * route validates authId against its own `isIn([...])` list, and getSetupStrategies
+ * returns plain strings).
+ */
+const STRATEGY_IDS = [
+  'local',
+  'ldap',
+  'saml',
+  'oidc',
+  'google',
+  'github',
+] as const;
+
+type StrategyId = (typeof STRATEGY_IDS)[number];
+
+const isStrategyId = (id: string): id is StrategyId =>
+  STRATEGY_IDS.some((strategyId) => strategyId === id);
+
+/** One strategy's setup/reset pair, referenced by the dispatch table. */
+type StrategySetup = {
+  setup: () => Promise<void>;
+  reset: () => void;
+};
+
 interface IncomingMessageWithLdapAccountInfo extends IncomingMessage {
   ldapAccountInfo: any;
 }
@@ -91,30 +117,36 @@ class PassportService implements S2sMessageHandlable {
     'security:passport-saml:attrMapMail',
   ] satisfies ConfigKey[];
 
-  setupFunction = {
+  /**
+   * Dispatch table of method references keyed by strategy id. Using references
+   * (not string method names) makes the compiler verify each method exists and
+   * matches the setup/reset signatures, and requires every StrategyId to have an
+   * entry. Arrow initializers preserve the `this` binding at call time.
+   */
+  private readonly strategySetups: Record<StrategyId, StrategySetup> = {
     local: {
-      setup: 'setupLocalStrategy',
-      reset: 'resetLocalStrategy',
+      setup: () => this.setupLocalStrategy(),
+      reset: () => this.resetLocalStrategy(),
     },
     ldap: {
-      setup: 'setupLdapStrategy',
-      reset: 'resetLdapStrategy',
+      setup: () => this.setupLdapStrategy(),
+      reset: () => this.resetLdapStrategy(),
     },
     saml: {
-      setup: 'setupSamlStrategy',
-      reset: 'resetSamlStrategy',
+      setup: () => this.setupSamlStrategy(),
+      reset: () => this.resetSamlStrategy(),
     },
     oidc: {
-      setup: 'setupOidcStrategy',
-      reset: 'resetOidcStrategy',
+      setup: () => this.setupOidcStrategy(),
+      reset: () => this.resetOidcStrategy(),
     },
     google: {
-      setup: 'setupGoogleStrategy',
-      reset: 'resetGoogleStrategy',
+      setup: () => this.setupGoogleStrategy(),
+      reset: () => this.resetGoogleStrategy(),
     },
     github: {
-      setup: 'setupGitHubStrategy',
-      reset: 'resetGitHubStrategy',
+      setup: () => this.setupGitHubStrategy(),
+      reset: () => this.resetGitHubStrategy(),
     },
   };
 
@@ -205,26 +237,30 @@ class PassportService implements S2sMessageHandlable {
   }
 
   /**
-   * get SetupFunction
+   * setup strategy by target id
    *
-   * @return {Object}
-   * @param {string} authId
+   * `authId` crosses a trust boundary (e.g. an S2s pubsub payload), so it is a
+   * plain string here and narrowed by isStrategyId before dispatch. An unknown
+   * id is logged and skipped rather than dispatched: before this guard, an
+   * unknown id read `undefined.setup` (a TypeError caught and logged as debug),
+   * then the catch ran `undefined.reset` — a second TypeError that escaped the
+   * method (an unhandled rejection on the un-awaited S2s path). The
+   * security-settings route already rejects unknown authIds via its validator,
+   * so in practice this only hardens the S2s message path.
    */
-  getSetupFunction(authId) {
-    return this.setupFunction[authId];
-  }
+  async setupStrategyById(authId: string): Promise<void> {
+    if (!isStrategyId(authId)) {
+      logger.warn(`Unknown strategy id '${authId}'; skipping setup`);
+      return;
+    }
 
-  /**
-   * setup strategy by target name
-   */
-  async setupStrategyById(authId) {
-    const func = this.getSetupFunction(authId);
+    const { setup, reset } = this.strategySetups[authId];
 
     try {
-      await this[func.setup]();
+      await setup();
     } catch (err) {
       logger.debug(err);
-      this[func.reset]();
+      reset();
     }
 
     this.lastLoadedAt = new Date();
@@ -235,7 +271,7 @@ class PassportService implements S2sMessageHandlable {
    *
    * @memberof PassportService
    */
-  resetLocalStrategy() {
+  resetLocalStrategy(): void {
     logger.debug('LocalStrategy: reset');
     passport.unuse('local');
     this.isLocalStrategySetup = false;
@@ -246,7 +282,8 @@ class PassportService implements S2sMessageHandlable {
    *
    * @memberof PassportService
    */
-  setupLocalStrategy() {
+  // biome-ignore lint/suspicious/useAwait: async to satisfy the uniform StrategySetup dispatch contract; LocalStrategy is static so the body has no async work
+  async setupLocalStrategy(): Promise<void> {
     this.resetLocalStrategy();
 
     const { configManager } = this.crowi;
@@ -295,7 +332,7 @@ class PassportService implements S2sMessageHandlable {
    *
    * @memberof PassportService
    */
-  resetLdapStrategy() {
+  resetLdapStrategy(): void {
     logger.debug('LdapStrategy: reset');
     passport.unuse('ldapauth');
     this.isLdapStrategySetup = false;
@@ -567,7 +604,7 @@ class PassportService implements S2sMessageHandlable {
    *
    * @memberof PassportService
    */
-  resetGoogleStrategy() {
+  resetGoogleStrategy(): void {
     logger.debug('GoogleStrategy: reset');
     passport.unuse('google');
     this.isGoogleStrategySetup = false;
@@ -630,7 +667,7 @@ class PassportService implements S2sMessageHandlable {
    *
    * @memberof PassportService
    */
-  resetGitHubStrategy() {
+  resetGitHubStrategy(): void {
     logger.debug('GitHubStrategy: reset');
     passport.unuse('github');
     this.isGitHubStrategySetup = false;
@@ -789,7 +826,7 @@ class PassportService implements S2sMessageHandlable {
    *
    * @memberof PassportService
    */
-  resetOidcStrategy() {
+  resetOidcStrategy(): void {
     logger.debug('OidcStrategy: reset');
     passport.unuse('oidc');
     this.isOidcStrategySetup = false;
@@ -970,7 +1007,7 @@ class PassportService implements S2sMessageHandlable {
    *
    * @memberof PassportService
    */
-  resetSamlStrategy() {
+  resetSamlStrategy(): void {
     logger.debug('SamlStrategy: reset');
     passport.unuse('saml');
     this.isSamlStrategySetup = false;


### PR DESCRIPTION
## Problem

The passport service statically imported every strategy SDK at module top: `openid-client` (pulls jose, 84 files), `passport-ldapauth` (pulls ldapjs, **+18.4 MiB RSS** measured), `passport-saml` (pulls the xml-crypto/xml2js/xmlbuilder stack), `passport-github`, `passport-google-oauth20`. These loaded at every boot even for tenants using only local auth (the majority). ldapjs additionally had a second boot-reachable door: `crowi` → external-user-group's `ldap-user-group-sync` → `service/ldap.ts`.

## Changes

- `passport.ts`: each SDK is imported dynamically inside its setup method, **after** the existing enabled/cert guards, so disabled strategies never trigger the import. Four setup methods became async — `setupStrategyById` and every caller (crowi boot, security-settings admin route, S2s handler) already `await`, so no caller changes were needed. `passport` and `passport-local` stay static; all type-only imports unchanged.
- `service/ldap.ts`: ldapjs loaded lazily in `initClient()` / `search()` (all callers in ldap-user-group-sync already await).
- New drift spec (`no-eager-passport-strategy-imports.spec.ts`) with two roots — `passport.ts` itself and the shared `BOOT_ENTRYPOINTS` — banning the five SDKs and ldapjs from the static boot graph. Mutation-tested (including the `ldap.ts` chain and an `import type` → value-import mutation proving the walker distinguishes them).
- New contract tests: disabled-path for all 5 strategies; enabled-path runs the real dynamic `import()` and real strategy constructors (only `passport.use` is stubbed), so a wrong export shape (e.g. ldapauth's default export) fails the test.

## Measurements

See #11479 — measured stacked with it: installed-idle RSS **269 → 256 MiB (−13)**, boot peak **375 → 365 MiB (−10)**; ldapjs/@ldapjs/*, jose, openid-client, passport-saml + its XML stack, passport-github/google/oauth2 all verified absent from the runtime boot module log (−965 module files combined with #11479).

## Notes

- Stacked on #11479 (shares the extracted static-import-graph test util); retarget to `dev/8.0.x` after that merges
- Adversarially reviewed (opus): per-strategy option/guard equivalence, openid-client symbol identity across the two import sites (`custom.clock_tolerance` / `custom.http_options` computed keys), failure-path equivalence via `setupStrategyById`'s existing try/catch, S2s re-setup path
- Backport candidate for `master` (v7.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)