### PR TITLE
imprv: Warm up Prisma connection at boot

### DIFF
--- a/apps/app/src/server/crowi/index.ts
+++ b/apps/app/src/server/crowi/index.ts
@@ -27,6 +27,7 @@ import { startCron as startAccessTokenCron } from '~/server/service/access-token
 import { projectRoot } from '~/server/util/project-dir-utils';
 import { getGrowiVersion } from '~/utils/growi-version';
 import loggerFactory from '~/utils/logger';
+import { connectPrismaAtBoot } from '~/utils/prisma-connect';
 
 import ActivityEvent from '../events/activity';
 import AdminEvent from '../events/admin';
@@ -262,6 +263,11 @@ class Crowi {
 
   async init(): Promise<void> {
     await this.setupDatabase();
+    // Warm up the Prisma connection right after mongoose connects, so a
+    // Prisma connection problem aborts boot the same way a mongoose failure
+    // does, and the native query engine's memory cost is paid at boot time
+    // instead of being invisible until the first request (see prisma-connect.ts).
+    await connectPrismaAtBoot();
     this.models = await setupModelsDependentOnCrowi(this);
     await this.setupConfigManager();
     await this.setupSessionConfig();

--- a/apps/app/src/utils/prisma-connect.spec.ts
+++ b/apps/app/src/utils/prisma-connect.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * Unit tests for utils/prisma-connect.ts — boot-time Prisma warmup helper
+ *
+ * Contract under test:
+ * - resolves and calls `$connect` exactly once on the injected client
+ * - when `$connect` rejects, the error is rethrown (so boot aborts, mirroring
+ *   how a mongoose connection failure aborts crowi `init()`)
+ *
+ * The client is always injected via `mock<...>()` — this spec never imports
+ * or touches a live Prisma connection.
+ */
+
+import { mock } from 'vitest-mock-extended';
+
+import type { PrismaClient } from './prisma';
+import { connectPrismaAtBoot } from './prisma-connect';
+
+describe('connectPrismaAtBoot', () => {
+  it('resolves and calls $connect exactly once', async () => {
+    const client = mock<Pick<PrismaClient, '$connect'>>();
+    client.$connect.mockResolvedValue(undefined);
+
+    await connectPrismaAtBoot(client);
+
+    expect(client.$connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows the error when $connect rejects', async () => {
+    const client = mock<Pick<PrismaClient, '$connect'>>();
+    const connectionError = new Error('connection refused');
+    client.$connect.mockRejectedValue(connectionError);
+
+    await expect(connectPrismaAtBoot(client)).rejects.toBe(connectionError);
+  });
+});

--- a/apps/app/src/utils/prisma-connect.ts
+++ b/apps/app/src/utils/prisma-connect.ts
@@ -1,0 +1,32 @@
+import loggerFactory from '~/utils/logger';
+
+import type { PrismaClient } from './prisma';
+import { prisma } from './prisma';
+
+const logger = loggerFactory('growi:utils:prisma-connect');
+
+/**
+ * Warm up the Prisma client at boot instead of deferring it to the first query.
+ *
+ * The Prisma JS client object is constructed at module scope (`prisma.ts`), but
+ * its native query engine (+12.5 MiB RSS) only loads lazily on first use. Left
+ * lazy, that cost is invisible to startup memory measurements used for capacity
+ * planning, and a broken Prisma connection would only surface on a user's first
+ * request instead of aborting boot -- unlike a mongoose connection failure.
+ * Calling this explicitly from crowi `init()` (right after `setupDatabase()`)
+ * makes both failure modes and memory costs visible at boot time.
+ *
+ * `client` is injectable for unit testing without a real database connection;
+ * it defaults to the real singleton for production use.
+ */
+export async function connectPrismaAtBoot(
+  client: Pick<PrismaClient, '$connect'> = prisma,
+): Promise<void> {
+  try {
+    await client.$connect();
+    logger.debug('Prisma client connected at boot');
+  } catch (err) {
+    logger.error('Failed to connect Prisma client at boot', err);
+    throw err;
+  }
+}


### PR DESCRIPTION
## Problem

The Prisma JS client is constructed at module scope and loads at boot, but the native query engine (**+12.5 MiB RSS** measured in isolation) only loaded on the first query. That deferral (1) skews capacity planning — infra sizes memory limits from startup measurements, which silently miss memory every real deployment pays (the same class of mistake behind the earlier 384Mi OOM sizing incident), (2) hides Prisma connection misconfiguration until the first user request, and (3) adds engine-load latency to that request.

## Changes

- New `utils/prisma-connect.ts`: `connectPrismaAtBoot(client = prisma)` — awaits `$connect()`, logs, rethrows on failure. Dependency-injected for unit testing without a DB; `utils/prisma.ts` stays side-effect-free on import.
- `crowi.init()`: `await connectPrismaAtBoot()` immediately after `setupDatabase()` (mongoose connect), so a Prisma connection failure aborts boot through the exact same path as a mongoose failure (`app.ts` top-level catch → `process.exit(1)`).

## Measurements (production build, same procedure as #11479)

Installed-idle RSS **269 → 274 MiB (+5)** — the engine cost is now paid at boot instead of invisibly at first request. Boot-phase peak **375 → 379 MiB (+4)**, i.e. within noise: warming up does not meaningfully raise the startup peak.

## Notes

- Adversarially reviewed: `--ci` boot mode exits via unconditional `process.exit()` (no drain-hang risk from the held connection); `PrismaClient` construction alone opens no connection (empirically confirmed — test suites importing the singleton run with no DB); only `$connect()` call site in the codebase
- Capacity-planning guidance: v8.0 plans should budget ~+25 MiB vs v7.5 for the Prisma runtime (JS client + engine), now fully visible in startup measurements

🤖 Generated with [Claude Code](https://claude.com/claude-code)