### PR TITLE
feat: rename "GROWI AI" to "GROWI AI Agent"

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -151,7 +151,7 @@
   "Page Tree": "Page Tree",
   "Bookmarks": "Bookmarks",
   "In-App Notification": "Notifications",
-  "GROWI AI": "GROWI AI",
+  "GROWI AI Agent": "GROWI AI Agent",
   "original_path": "Original path",
   "new_path": "New path",
   "duplicated_path": "Duplicated path",

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -153,7 +153,7 @@
   "Page Tree": "Arborescence",
   "Bookmarks": "Favoris",
   "In-App Notification": "Notifications",
-  "GROWI AI": "GROWI AI",
+  "GROWI AI Agent": "GROWI AI Agent",
   "original_path": "Chemin originel",
   "new_path": "Nouveau chemin",
   "duplicated_path": "Chemin dupliqué",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -153,7 +153,7 @@
   "Page Tree": "ページツリー",
   "Bookmarks": "ブックマーク",
   "In-App Notification": "通知",
-  "GROWI AI": "GROWI AI",
+  "GROWI AI Agent": "GROWI AI Agent",
   "original_path": "元のパス",
   "new_path": "新しいパス",
   "duplicated_path": "重複したパス",

--- a/apps/app/public/static/locales/ko_KR/translation.json
+++ b/apps/app/public/static/locales/ko_KR/translation.json
@@ -151,7 +151,7 @@
   "Page Tree": "페이지 트리",
   "Bookmarks": "북마크",
   "In-App Notification": "알림",
-  "GROWI AI": "GROWI AI",
+  "GROWI AI Agent": "GROWI AI Agent",
   "original_path": "원본 경로",
   "new_path": "새 경로",
   "duplicated_path": "중복된 경로",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -158,7 +158,7 @@
   "Page Tree": "页面树",
   "Bookmarks": "书签",
   "In-App Notification": "通知",
-  "GROWI AI": "GROWI AI",
+  "GROWI AI Agent": "GROWI AI Agent",
   "original_path": "Original path",
   "new_path": "New path",
   "duplicated_path": "Duplicated path",

--- a/apps/app/src/client/components/Sidebar/SidebarNav/PrimaryItem.tsx
+++ b/apps/app/src/client/components/Sidebar/SidebarNav/PrimaryItem.tsx
@@ -79,7 +79,7 @@ export const PrimaryItem = (props: PrimaryItemProps): JSX.Element => {
     onHover?.(contents);
   }, [contents, onHover, selectThisItem, sidebarMode]);
 
-  const labelForTestId = label.toLowerCase().replace(' ', '-');
+  const labelForTestId = label.toLowerCase().replaceAll(' ', '-');
 
   return (
     <>

--- a/apps/app/src/client/components/Sidebar/SidebarNav/PrimaryItems.tsx
+++ b/apps/app/src/client/components/Sidebar/SidebarNav/PrimaryItems.tsx
@@ -113,7 +113,7 @@ export const PrimaryItems = memo((props: Props) => {
         <PrimaryItem
           sidebarMode={sidebarMode}
           contents={SidebarContentsType.AI}
-          label="GROWI AI"
+          label="GROWI AI Agent"
           iconName="growi_ai"
           isCustomIcon
           onHover={onItemHover}

--- a/apps/app/src/features/mastra/client/components/Sidebar/AiSidebar.tsx
+++ b/apps/app/src/features/mastra/client/components/Sidebar/AiSidebar.tsx
@@ -17,7 +17,7 @@ export const AiSidebar = (): JSX.Element => {
   return (
     <div className="px-3">
       <div className="grw-sidebar-content-header py-4 d-flex">
-        <h3 className="fs-6 fw-bold mb-0">{t('GROWI AI')}</h3>
+        <h3 className="fs-6 fw-bold mb-0">{t('GROWI AI Agent')}</h3>
       </div>
 
       {isGuestUser ? (

--- a/apps/app/src/migrations/20260616120000-normalize-registration-whitelist.js
+++ b/apps/app/src/migrations/20260616120000-normalize-registration-whitelist.js
@@ -12,70 +12,61 @@ const logger = loggerFactory('growi:migrate:normalize-registration-whitelist');
 
 const KEY = 'security:registrationWhitelist';
 
-module.exports = {
-  async up() {
-    logger.info('Apply migration: Normalize registration whitelist entries');
-    await mongoose.connect(getMongoUri(), mongoOptions);
+export async function up() {
+  logger.info('Apply migration: Normalize registration whitelist entries');
+  await mongoose.connect(getMongoUri(), mongoOptions);
 
-    const config = await Config.findOne({ key: KEY });
-    if (config == null || config.value == null) {
-      logger.info(
-        'No registration whitelist config found - migration not needed',
-      );
-      return;
-    }
+  const config = await Config.findOne({ key: KEY });
+  if (config == null || config.value == null) {
+    logger.info('No registration whitelist config found - migration not needed');
+    return;
+  }
 
-    let entries;
-    try {
-      entries = JSON.parse(config.value);
-    } catch (err) {
-      logger.warn(
-        'Failed to parse registration whitelist value - skipping',
-        err,
-      );
-      return;
-    }
+  let entries;
+  try {
+    entries = JSON.parse(config.value);
+  } catch (err) {
+    logger.warn('Failed to parse registration whitelist value - skipping', err);
+    return;
+  }
 
-    if (!Array.isArray(entries) || entries.length === 0) {
-      logger.info('Registration whitelist is empty - migration not needed');
-      return;
-    }
+  if (!Array.isArray(entries) || entries.length === 0) {
+    logger.info('Registration whitelist is empty - migration not needed');
+    return;
+  }
 
-    const normalized = normalizeWhitelistEntries(entries);
+  const normalized = normalizeWhitelistEntries(entries);
 
-    // Surface entries that remain invalid even after normalization (e.g. legacy
-    // free-form values or regex patterns the old lax validator accepted). These
-    // are left untouched - deleting them would discard admin intent - but the
-    // new save validator will reject the whole list with a 400 once an admin
-    // edits the security settings. Warn here so operators can fix them at
-    // migration time instead of discovering it later on save.
-    const invalidEntries = normalized.filter(
-      (entry) => !isValidWhitelistEntry(entry),
+  // Surface entries that remain invalid even after normalization (e.g. legacy
+  // free-form values or regex patterns the old lax validator accepted). These
+  // are left untouched - deleting them would discard admin intent - but the
+  // new save validator will reject the whole list with a 400 once an admin
+  // edits the security settings. Warn here so operators can fix them at
+  // migration time instead of discovering it later on save.
+  const invalidEntries = normalized.filter(
+    (entry) => !isValidWhitelistEntry(entry),
+  );
+  if (invalidEntries.length > 0) {
+    logger.warn(
+      'The following registration whitelist entries are invalid and were left unchanged. ' +
+        'They will block saving security settings until corrected in Admin > Security: ' +
+        JSON.stringify(invalidEntries),
     );
-    if (invalidEntries.length > 0) {
-      logger.warn(
-        'The following registration whitelist entries are invalid and were left unchanged. ' +
-          'They will block saving security settings until corrected in Admin > Security: ' +
-          JSON.stringify(invalidEntries),
-      );
-    }
+  }
 
-    const isChanged = JSON.stringify(normalized) !== JSON.stringify(entries);
-    if (!isChanged) {
-      logger.info(
-        'No legacy whitelist entries to normalize - migration not needed',
-      );
-      return;
-    }
+  const isChanged = JSON.stringify(normalized) !== JSON.stringify(entries);
+  if (!isChanged) {
+    logger.info('No legacy whitelist entries to normalize - migration not needed');
+    return;
+  }
 
-    await Config.updateOne({ key: KEY }, { value: JSON.stringify(normalized) });
+  await Config.updateOne({ key: KEY }, { value: JSON.stringify(normalized) });
 
-    logger.info('Migration has successfully applied');
-  },
+  logger.info('Migration has successfully applied');
+}
 
-  async down() {
-    logger.info('Rollback migration: Normalize registration whitelist entries');
-    // No rollback action - normalization is a non-destructive, idempotent correction
-    logger.info('No rollback action needed');
-  },
-};
+export async function down() {
+  logger.info('Rollback migration: Normalize registration whitelist entries');
+  // No rollback action - normalization is a non-destructive, idempotent correction
+  logger.info('No rollback action needed');
+}

--- a/apps/app/src/server/routes/apiv3/users.integ.ts
+++ b/apps/app/src/server/routes/apiv3/users.integ.ts
@@ -127,15 +127,16 @@ describe('POST /invite', () => {
     vi.resetModules();
 
     // Import and mount the users router.
-    // users.js is an untyped CommonJS module (`module.exports = (crowi) => router`).
-    // TypeScript types the dynamic-import namespace without a call signature or a
-    // `.default`, so a cast to the real factory shape is required here — no usable
-    // type exists for the JS module. The cast still type-checks the call site:
-    // `crowiMock` is verified against `Crowi`.
+    // users.js is an untyped JS module exposing a named `setup` factory
+    // (`export const setup = (crowi) => router`). TypeScript types the
+    // dynamic-import namespace without a call signature, so a cast to the real
+    // factory shape is required here — no usable type exists for the JS module.
+    // The cast still type-checks the call site: `crowiMock` is verified against
+    // `Crowi`.
     const usersModule = (await import('./users')) as unknown as {
-      default: (crowi: Crowi) => express.Router;
+      setup: (crowi: Crowi) => express.Router;
     };
-    app.use('/', usersModule.default(crowiMock));
+    app.use('/', usersModule.setup(crowiMock));
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Task
https://redmine.weseek.co.jp/issues/187547

## 概要

サイドバーナビゲーションおよび AI サイドバー
で表示している「GROWI AI」という文言を「GROWI AI Agent」に変更します。

## 変更内容

### 文言変更（GROWI AI → GROWI AI Agent）

- **翻訳ファイル (全5ロケール)**: 既存の `"GROWI AI"` キーを削除し、`"GROWI AI Agent"` キーを新設
  - `en_US` / `ja_JP` / `ko_KR` / `zh_CN` / `fr_FR`
- **`PrimaryItems.tsx`**: サイドバーナビの `label` を `"GROWI AI"` → `"GROWI AI Agent"` に変更
- **`AiSidebar.tsx`**: AI サイドバーのヘッダー見出しを新キー `t('GROWI AI Agent')` に変更（削除した旧キーを参照していたため）
- **`PrimaryItem.tsx`**: `labelForTestId` 生成を `.replace(' ', '-')` → `.replaceAll(' ', '-')` に修正

`label` が「GROWI AI Agent」のようにスペースを2つ含む文字列になると、`.replace(' ', '-')` は最初のスペースしか置換しないため、生成される id / ツールチップの `target` に空白が残り、reactstrap の Tooltip が以下のエラーを投げていました。

```
The target 'growi-ai agent' could not be identified in the dom
```

`.replaceAll(' ', '-')` に修正することで全スペースが置換され、有効な id / セレクタになります。

### CI 修正（本 PR で顕在化した既存の ESM 移行漏れ）

- **`20260616120000-normalize-registration-whitelist.js`**: CommonJS の `module.exports` を ESM の名前付きエクスポート（`export async function up/down`）に変換
  - `apps/app` は `"type": "module"` のため `.js` は ESM 扱いとなり、このマイグレーションだけ `module.exports` で書かれていて `dev:migrate` が `module is not defined in ES module scope` で失敗していた
- **`users.integ.ts`**: users ルートを名前付き `setup` エクスポート経由で呼ぶよう修正
  - `users.js` は ESM 化で `export const setup = (crowi) => router` を公開する形（`apiv3/index.js` は `import { setup as setupUsers }` で利用）に変わっていたが、テストが旧 CommonJS の `.default` を参照したままだったため `usersModule.default is not a function` で全 `POST /invite` テストが失敗していた

いずれもロジック変更はなく、他ファイルと同じ ESM 形式に揃えるだけの修正です。

## 影響範囲

- サイドバーナビボタンの `data-testid` / `id` が `grw-sidebar-nav-primary-growi-ai` → `grw-sidebar-nav-primary-growi-ai-agent` に変わります。旧値を参照している箇所（src・playwright）は無いことを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
