### PR TITLE
fix(import): Derive export archive list from server state via SWR

### DIFF
--- a/apps/app/src/client/components/Admin/ExportArchiveDataPage.spec.tsx
+++ b/apps/app/src/client/components/Admin/ExportArchiveDataPage.spec.tsx
@@ -1,0 +1,188 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import type { Socket } from 'socket.io-client';
+import { SWRConfig } from 'swr';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import type { IExportStatus } from '~/stores/admin/export';
+
+import ExportArchiveDataPage from './ExportArchiveDataPage';
+
+// --- module mocks -----------------------------------------------------------
+
+const useAdminSocket = vi.hoisted(() => vi.fn());
+vi.mock('~/features/admin/states/socket-io', () => ({ useAdminSocket }));
+
+const apiv3Get = vi.hoisted(() => vi.fn());
+vi.mock('~/client/util/apiv3-client', () => ({ apiv3Get }));
+
+const apiDelete = vi.hoisted(() => vi.fn());
+const apiPost = vi.hoisted(() => vi.fn());
+vi.mock('~/client/util/apiv1-client', () => ({ apiDelete, apiPost }));
+
+const toastSuccess = vi.hoisted(() => vi.fn());
+const toastError = vi.hoisted(() => vi.fn());
+vi.mock('~/client/util/toastr', () => ({ toastSuccess, toastError }));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('next-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// --- helpers ----------------------------------------------------------------
+
+// The single source of truth the server would derive the archive list from
+// (its filesystem). Tests mutate this to simulate exports completing / files
+// being deleted, then let the component revalidate against it.
+let serverStatus: IExportStatus;
+
+const socketHandlers = new Map<string, (payload: unknown) => void>();
+
+const makeStat = (fileName: string) => ({
+  fileName,
+  meta: { version: '7.5.7', exportedAt: '2026-07-23T00:00:00.000Z' },
+  innerFileStats: [{ collectionName: 'pages' }],
+});
+
+const renderPage = () =>
+  render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <ExportArchiveDataPage />
+    </SWRConfig>,
+  );
+
+// Number of archive rows currently shown (total <tr> minus the header row).
+const archiveRowCount = () => screen.getAllByRole('row').length - 1;
+
+const fireSocketEvent = async (event: string, payload: unknown) => {
+  await act(async () => {
+    socketHandlers.get(event)?.(payload);
+  });
+};
+
+describe('ExportArchiveDataPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    socketHandlers.clear();
+
+    serverStatus = {
+      zipFileStats: [makeStat('growi-a.zip')],
+      isExporting: false,
+      progressList: null,
+    };
+
+    apiv3Get.mockImplementation((endpoint: string) => {
+      if (endpoint === '/mongo/collections') {
+        return Promise.resolve({ data: { collections: ['pages', 'users'] } });
+      }
+      if (endpoint === '/export/status') {
+        return Promise.resolve({ data: { status: serverStatus } });
+      }
+      return Promise.reject(new Error(`unexpected endpoint: ${endpoint}`));
+    });
+
+    const socket = mock<Socket>();
+    // socket.io's on() is heavily overloaded; a capturing implementation cannot
+    // be expressed through those overload types, so cast this single function.
+    socket.on.mockImplementation(((event: string, cb: (p: unknown) => void) => {
+      socketHandlers.set(event, cb);
+      return socket;
+    }) as unknown as typeof socket.on);
+    useAdminSocket.mockReturnValue(socket);
+  });
+
+  it('renders one row per archive reported by the server', async () => {
+    renderPage();
+
+    expect(await screen.findByText('growi-a.zip')).toBeInTheDocument();
+    expect(archiveRowCount()).toBe(1);
+  });
+
+  it('shows exactly one row per archive after a completion event, even if it is processed twice (#11509)', async () => {
+    // Contract: the displayed list always equals the server's archive list, so
+    // a completion event that is (re-)processed more than once can never
+    // produce duplicate rows. Regression guarded: the old handler appended the
+    // event payload to local state without dedup, so a re-subscribed / doubled
+    // event added the same archive twice, and deleting one row removed both.
+    renderPage();
+    await screen.findByText('growi-a.zip');
+
+    // a new export finishes and lands on the server
+    serverStatus = {
+      ...serverStatus,
+      zipFileStats: [makeStat('growi-a.zip'), makeStat('growi-b.zip')],
+    };
+
+    await fireSocketEvent('admin:onTerminateForExport', {
+      addedZipFileStat: makeStat('growi-b.zip'),
+    });
+    await waitFor(() =>
+      expect(screen.getByText('growi-b.zip')).toBeInTheDocument(),
+    );
+
+    // the same completion event is delivered again (double subscription)
+    await fireSocketEvent('admin:onTerminateForExport', {
+      addedZipFileStat: makeStat('growi-b.zip'),
+    });
+
+    await waitFor(() => expect(archiveRowCount()).toBe(2));
+    expect(screen.getAllByText('growi-b.zip')).toHaveLength(1);
+  });
+
+  it('does not crash when a completion event carries a null stat (broken zip)', async () => {
+    // The server emits a null stat for a broken zip; the listener must not
+    // dereference it. Regression guarded: reading addedZipFileStat.fileName
+    // threw inside the state updater / success toast.
+    renderPage();
+    await screen.findByText('growi-a.zip');
+
+    await fireSocketEvent('admin:onTerminateForExport', {
+      addedZipFileStat: null,
+    });
+
+    expect(screen.getByText('growi-a.zip')).toBeInTheDocument();
+    expect(archiveRowCount()).toBe(1);
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it('removes only the deleted archive by re-syncing with the server', async () => {
+    // Contract: deletion reflects the server's post-delete filesystem, not a
+    // client-side filter by fileName (which would drop every entry sharing the
+    // name). Here two distinct archives exist and deleting one leaves the other.
+    serverStatus = {
+      ...serverStatus,
+      zipFileStats: [makeStat('growi-a.zip'), makeStat('growi-b.zip')],
+    };
+    apiDelete.mockImplementation(() => {
+      serverStatus = {
+        ...serverStatus,
+        zipFileStats: [makeStat('growi-b.zip')],
+      };
+      return Promise.resolve();
+    });
+
+    renderPage();
+    await screen.findByText('growi-a.zip');
+
+    // the delete button of the first row (growi-a.zip)
+    fireEvent.click(
+      screen.getAllByRole('button', {
+        name: /export_management\.delete/,
+      })[0],
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByText('growi-a.zip')).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText('growi-b.zip')).toBeInTheDocument();
+    expect(apiDelete).toHaveBeenCalledWith('/v3/export/growi-a.zip', {});
+  });
+});

--- a/apps/app/src/client/components/Admin/ExportArchiveDataPage.tsx
+++ b/apps/app/src/client/components/Admin/ExportArchiveDataPage.tsx
@@ -2,67 +2,55 @@ import React, { type JSX, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { apiDelete } from '~/client/util/apiv1-client';
-import { apiv3Get } from '~/client/util/apiv3-client';
 import { toastError, toastSuccess } from '~/client/util/toastr';
 import { useAdminSocket } from '~/features/admin/states/socket-io';
+import {
+  useSWRxExportCollections,
+  useSWRxExportStatus,
+} from '~/stores/admin/export';
 
 import LabeledProgressBar from './Common/LabeledProgressBar';
 import ArchiveFilesTable from './ExportArchiveData/ArchiveFilesTable';
 import SelectCollectionsModal from './ExportArchiveData/SelectCollectionsModal';
 
-const IGNORED_COLLECTION_NAMES = [
-  'sessions',
-  'rlflx',
-  'yjs-writings',
-  'transferkeys',
-];
-
 const ExportArchiveDataPage = (): JSX.Element => {
   const socket = useAdminSocket();
   const { t } = useTranslation('admin');
 
-  const [collections, setCollections] = useState<any[]>([]);
-  const [zipFileStats, setZipFileStats] = useState<any[]>([]);
+  const { data: collections } = useSWRxExportCollections();
+  const { data: exportStatus, mutate: mutateExportStatus } =
+    useSWRxExportStatus();
+
+  // The exported-archive list is server state (derived from the filesystem by
+  // GET /export/status), so it is read straight from SWR — never mirrored or
+  // accumulated on the client. This is what makes duplicate rows impossible
+  // (#11509): a completion event only revalidates, and the server stays the
+  // single source of truth for how many archives exist.
+  const zipFileStats = exportStatus?.zipFileStats ?? [];
+
+  // Transient, high-frequency progress state driven by socket events. Seeded
+  // from the persisted status so an export already running when the page opens
+  // is reflected immediately.
   const [progressList, setProgressList] = useState<any[]>([]);
   const [isExportModalOpen, setExportModalOpen] = useState(false);
   const [isExporting, setExporting] = useState(false);
   const [isZipping, setZipping] = useState(false);
   const [isExported, setExported] = useState(false);
 
-  const fetchData = useCallback(async () => {
-    const [{ data: collectionsData }, { data: statusData }] = await Promise.all(
-      [
-        apiv3Get<{ collections: any[] }>('/mongo/collections', {}),
-        apiv3Get<{
-          status: {
-            zipFileStats: any[];
-            isExporting: boolean;
-            progressList: any[];
-          };
-        }>('/export/status', {}),
-      ],
-    );
-
-    // filter only not ignored collection names
-    const filteredCollections = collectionsData.collections.filter(
-      (collectionName) => {
-        return !IGNORED_COLLECTION_NAMES.includes(collectionName);
-      },
-    );
-
-    const { zipFileStats, isExporting, progressList } = statusData.status;
-    setCollections(filteredCollections);
-    setZipFileStats(zipFileStats);
-    setExporting(isExporting);
-    setProgressList(progressList);
-  }, []);
+  useEffect(() => {
+    if (exportStatus == null) {
+      return;
+    }
+    setExporting(exportStatus.isExporting);
+    setProgressList(exportStatus.progressList ?? []);
+  }, [exportStatus]);
 
   const setupWebsocketEventHandler = useCallback(() => {
     if (socket == null) {
       return () => {};
     }
 
-    const onProgress = ({ currentCount, totalCount, progressList }) => {
+    const onProgress = ({ progressList }) => {
       setExporting(true);
       setProgressList(progressList);
     };
@@ -75,9 +63,19 @@ const ExportArchiveDataPage = (): JSX.Element => {
       setExporting(false);
       setZipping(false);
       setExported(true);
-      setZipFileStats((prev) => prev.concat([addedZipFileStat]));
 
-      toastSuccess(`New Archive Data '${addedZipFileStat.fileName}' is added`);
+      // Revalidate against the server (the filesystem) instead of appending the
+      // event payload locally. mutate() is idempotent, so the same completion
+      // event processed more than once can never produce duplicate rows.
+      mutateExportStatus();
+
+      // A broken zip makes the server emit a null stat; guard the toast so the
+      // listener never throws on it.
+      if (addedZipFileStat != null) {
+        toastSuccess(
+          `New Archive Data '${addedZipFileStat.fileName}' is added`,
+        );
+      }
     };
 
     // Add listeners
@@ -91,21 +89,24 @@ const ExportArchiveDataPage = (): JSX.Element => {
       socket.off('admin:onStartZippingForExport', onStartZipping);
       socket.off('admin:onTerminateForExport', onTerminateForExport);
     };
-  }, [socket]);
+  }, [socket, mutateExportStatus]);
 
-  const onZipFileStatRemove = useCallback(async (fileName) => {
-    try {
-      await apiDelete(`/v3/export/${fileName}`, {});
+  const onZipFileStatRemove = useCallback(
+    async (fileName) => {
+      try {
+        await apiDelete(`/v3/export/${fileName}`, {});
 
-      setZipFileStats((prev) =>
-        prev.filter((stat) => stat.fileName !== fileName),
-      );
+        // Re-sync with the server rather than filtering the local list by
+        // fileName (which would drop every entry sharing that name).
+        await mutateExportStatus();
 
-      toastSuccess(`Deleted ${fileName}`);
-    } catch (err) {
-      toastError(err);
-    }
-  }, []);
+        toastSuccess(`Deleted ${fileName}`);
+      } catch (err) {
+        toastError(err);
+      }
+    },
+    [mutateExportStatus],
+  );
 
   const exportingRequestedHandler = useCallback(() => {}, []);
 
@@ -148,13 +149,12 @@ const ExportArchiveDataPage = (): JSX.Element => {
   }, [isExported, isZipping]);
 
   useEffect(() => {
-    fetchData();
     const cleanupWebsocket = setupWebsocketEventHandler();
 
     return () => {
       if (cleanupWebsocket) cleanupWebsocket();
     };
-  }, [fetchData, setupWebsocketEventHandler]);
+  }, [setupWebsocketEventHandler]);
 
   const showExportingData = (isExported || isExporting) && progressList != null;
 
@@ -191,7 +191,7 @@ const ExportArchiveDataPage = (): JSX.Element => {
         isOpen={isExportModalOpen}
         onExportingRequested={exportingRequestedHandler}
         onClose={() => setExportModalOpen(false)}
-        collections={collections}
+        collections={collections ?? []}
       />
     </div>
   );

--- a/apps/app/src/stores/admin/export.ts
+++ b/apps/app/src/stores/admin/export.ts
@@ -1,0 +1,44 @@
+import type { SWRResponse } from 'swr';
+import useSWRImmutable from 'swr/immutable';
+
+import { apiv3Get } from '~/client/util/apiv3-client';
+
+// Collections that must never be offered as export targets.
+const IGNORED_COLLECTION_NAMES = [
+  'sessions',
+  'rlflx',
+  'yjs-writings',
+  'transferkeys',
+];
+
+export interface IExportStatus {
+  zipFileStats: any[];
+  isExporting: boolean;
+  progressList: any[] | null;
+}
+
+/**
+ * Server-derived export status.
+ *
+ * `zipFileStats` (the exported-archive list) is derived from the filesystem by
+ * the server's `GET /export/status`, so it is server state and must be read
+ * through SWR — never mirrored or accumulated on the client. Callers revalidate
+ * with the returned `mutate` after an export completes or an archive is deleted,
+ * which keeps the displayed list equal to the single source of truth and makes
+ * duplicate rows impossible (see #11509).
+ */
+export const useSWRxExportStatus = (): SWRResponse<IExportStatus, Error> => {
+  return useSWRImmutable('/export/status', async (endpoint) => {
+    const { data } = await apiv3Get<{ status: IExportStatus }>(endpoint);
+    return data.status;
+  });
+};
+
+export const useSWRxExportCollections = (): SWRResponse<string[], Error> => {
+  return useSWRImmutable('/mongo/collections', async (endpoint) => {
+    const { data } = await apiv3Get<{ collections: string[] }>(endpoint);
+    return data.collections.filter(
+      (collectionName) => !IGNORED_COLLECTION_NAMES.includes(collectionName),
+    );
+  });
+};


### PR DESCRIPTION
## Summary

Fixes duplicate rows in the admin "Export Archive Data" list, where deleting one duplicate row removed both (#11509).

The first revision of this PR added a `fileName` dedup guard to the append. That fixed the reported symptom but left the underlying design in place. This revision instead removes the fragile client-side mirror altogether.

## Root Cause (design level)

The archive list is **server state derived from the filesystem** — `ExportService.getStatus()` reads the export directory and returns one `ZipFileStat` per `.zip`. But `ExportArchiveDataPage.tsx` kept a hand-maintained *mirror* of that list: it fetched once, then mutated local state on each socket event — `concat` on `admin:onTerminateForExport`, `filter` by `fileName` on delete.

```tsx
// before
setZipFileStats((prev) => prev.concat([addedZipFileStat]));   // terminate
setZipFileStats((prev) => prev.filter((s) => s.fileName !== fileName)); // delete
```

The terminate listener is re-subscribed whenever the `socket` reference changes identity (it starts `null` and becomes the connected instance, re-running the effect). If the completion event is processed more than once for the same export (that re-subscription, plus React StrictMode's double effect in development), the same stat is appended twice. Because the table keys on `fileName` and delete filters by `fileName`, the two rows share an identity, so removing either removed both — exactly the reported symptom.

## Change

Treat the list as server state instead of guarding the append:

- **`zipFileStats` is read through SWR** (`useSWRxExportStatus`), the single source of truth. The rendered list always equals the server's filesystem listing.
- **On completion and after delete, revalidate with `mutate()`** rather than mutating local state. `mutate()` is idempotent, so a completion event processed more than once can never produce duplicate rows — the fragile mirror that caused #11509 no longer exists.
- **Guard the `null` stat** a broken zip makes the server emit (`emitTerminateEvent(null)`), so the listener no longer throws while dereferencing `addedZipFileStat.fileName` (a latent crash present in both the original code and the first revision of this PR).

Transient, high-frequency progress state (`isExporting` / `progressList` / `isZipping`) stays socket-driven; only the persisted list moves to SWR.

### Files

- `apps/app/src/stores/admin/export.ts` (new): `useSWRxExportStatus` / `useSWRxExportCollections`.
- `apps/app/src/client/components/Admin/ExportArchiveDataPage.tsx`: read the list from SWR; revalidate on terminate/delete; null guard.
- `apps/app/src/client/components/Admin/ExportArchiveDataPage.spec.tsx` (new): see below.

## Test Plan

- [x] `pnpm run lint:typecheck` passes (verified locally; note: a fresh `@growi/core` build is required — a stale `packages/core/dist` produces unrelated `AI_ASSISTANT` scope errors)
- [x] `biome check --diagnostic-level=error` passes for the changed files
- [x] `pnpm vitest run ExportArchiveDataPage.spec` — 4 tests pass. Coverage:
  - renders one row per archive reported by the server;
  - shows exactly one row per archive after a completion event even if it is processed twice (**#11509 contract**);
  - does not crash when a completion event carries a `null` stat (broken zip) — mutation-checked (removing the guard turns this test RED);
  - removes only the deleted archive by re-syncing with the server.
- [ ] Manual: run a data export as admin, confirm one row per export and that deleting a row removes only that row.

Closes #11509

---
_Generated by [Claude Code](https://claude.com/claude-code)_
