### PR TITLE
docs(vault-manager): fill in the Docker Hub overview for growilabs/vault-manager

### DIFF
--- a/apps/growi-vault-manager/README.md
+++ b/apps/growi-vault-manager/README.md
@@ -91,7 +91,7 @@ Highlights of the refactor:
 
 ### Cross-repository impact: `growi-docker-compose`
 
-The separate [`growi-docker-compose`](https://github.com/weseek/growi-docker-compose) repository may reference this `Dockerfile` (e.g. via an image-build target or a published image tag). When a new vault-manager image built from this refactored Dockerfile is published, the `growi-docker-compose` repository **must be checked separately** to confirm that its compose definitions still build / run against the new image. That cross-repository update is intentionally out of scope for this PR — it must land as a separate PR in `growi-docker-compose`.
+The separate [`growi-docker-compose`](https://github.com/growilabs/growi-docker-compose) repository consumes the published image, as an opt-in override in [`examples/growi-vault`](https://github.com/growilabs/growi-docker-compose/tree/master/examples/growi-vault). When the image is republished with a new major/minor, that override pins the tag and has to be updated there in a separate PR.
 
 ### CI compatibility: `.github/workflows/ci-vault.yml`
 

--- a/apps/growi-vault-manager/docker/Dockerfile
+++ b/apps/growi-vault-manager/docker/Dockerfile
@@ -118,7 +118,7 @@ USER root
 WORKDIR ${appDir}/apps/growi-vault-manager
 
 # OCI standard labels
-LABEL org.opencontainers.image.source="https://github.com/weseek/growi"
+LABEL org.opencontainers.image.source="https://github.com/growilabs/growi"
 LABEL org.opencontainers.image.title="GROWI Vault Manager"
 LABEL org.opencontainers.image.description="GROWI Vault internal execution engine: namespace tree builder + git upload-pack server"
 LABEL org.opencontainers.image.vendor="WESEEK, Inc."

--- a/apps/growi-vault-manager/docker/README.md
+++ b/apps/growi-vault-manager/docker/README.md
@@ -5,33 +5,128 @@ GROWI Vault Manager Official docker image
 [![Node CI for Vault Manager](https://github.com/growilabs/growi/actions/workflows/ci-vault.yml/badge.svg)](https://github.com/growilabs/growi/actions/workflows/ci-vault.yml) [![docker-pulls](https://img.shields.io/docker/pulls/growilabs/vault-manager.svg)](https://hub.docker.com/r/growilabs/vault-manager/)
 
 
-Dockerfile link
+Supported tags and respective Dockerfile links
 ------------------------------------------------
 
-https://github.com/growilabs/growi/blob/master/apps/growi-vault-manager/docker/Dockerfile
+* [`0.1.1`, `0.1`, `0`, `latest` (Dockerfile)](https://github.com/growilabs/growi/blob/vault-manager/v0.1.1/apps/growi-vault-manager/docker/Dockerfile)
 
 
-What is GROWI Vault Manager used for?
----------------------------------------
+What is GROWI Vault?
+-------------
 
-GROWI Vault Manager is the internal execution engine for GROWI Vault. It receives
-instructions written by the main GROWI app (`apps/app`) to the `vault_instructions`
-MongoDB collection via a change stream, and maintains a per-namespace git bare
-repository on a shared filesystem. It composes per-user view refs, serves clones
-over `git upload-pack`, and runs periodic squash and gc. It holds no GROWI domain
-knowledge (ACL evaluation, PAT authentication, group resolution) — that stays in
-the main app.
+GROWI Vault turns a [GROWI](https://github.com/growilabs/growi) wiki into a git
+repository. Users `git clone` it and get their pages as a tree of Markdown
+files, so the wiki can be searched with `grep`, opened in an editor, and handed
+to AI agents that work on files. `git pull` brings the working copy up to date.
 
-This image is deployed alongside the main GROWI application and shares the `/data`
-volume with it. The container starts as root only long enough to prepare the bare
-repository directory, then drops to the `node` user (uid/gid 1000) before running.
+Each clone contains exactly the pages that user is allowed to read — pages they
+have no access to are not merely hidden, they leave no trace in the tree or in
+the refs. The vault is read-only: `git push` is rejected, and attachments,
+comments, likes and tags are not exported.
+
+This image is the engine behind that feature. It is **not a standalone
+application** and it is not what users clone from: it runs beside the GROWI app
+container, maintains the bare git repository, and serves `git upload-pack` for
+clone traffic that the GROWI app proxies to it. All GROWI domain knowledge
+(access control, token authentication, group resolution) stays in the app — this
+container only knows about namespaces and the git protocol.
+
+see: [GROWI Docs: GROWI Vault](https://docs.growi.org/en/guide/features/vault.html)
 
 
-How to use
----------------------------------------
+Requirements
+-------------
 
-See the GROWI documentation and the `growi-docker-compose` repository for
-deployment configuration:
+* GROWI >= 8.0.0 (`growilabs/growi:8`), started with the Vault feature enabled
+* MongoDB (>= 6.0) running as a **replica set**
+    * The vault is kept up to date through a MongoDB change stream, which a standalone server does not provide. A single-node replica set is enough.
+* A persistent filesystem for the bare repository, shared with the GROWI app container
+    * This container starts as root only long enough to create and chown that directory, then drops to the `node` user (uid/gid 1000) — the same uid the GROWI app runs as — so both containers can use one volume.
 
-- https://docs.growi.org
-- https://github.com/weseek/growi-docker-compose
+
+Usage
+-----
+
+### docker-compose
+
+Using docker-compose is the fastest and the most convenient way to boot GROWI
+Vault, because the app, MongoDB and this container have to be wired together.
+
+see: [growilabs/growi-docker-compose — examples/growi-vault](https://github.com/growilabs/growi-docker-compose/tree/master/examples/growi-vault)
+
+### docker run
+
+Start this container against a MongoDB replica set:
+
+```bash
+docker run -d \
+    -e MONGO_URI=mongodb://MONGODB_HOST:MONGODB_PORT/growi?replicaSet=rs0 \
+    -e VAULT_MANAGER_INTERNAL_SECRET=CHANGE_THIS \
+    -e VAULT_REPO_PATH=/data/vault-repo.git \
+    -v growi_data:/data \
+    growilabs/vault-manager
+```
+
+and point the GROWI app at it, with the same secret:
+
+```bash
+docker run -d \
+    -e MONGO_URI=mongodb://MONGODB_HOST:MONGODB_PORT/growi?replicaSet=rs0 \
+    -e VAULT_ENABLED=true \
+    -e VAULT_MANAGER_ENDPOINT=http://VAULT_MANAGER_HOST:3001 \
+    -e VAULT_MANAGER_INTERNAL_SECRET=CHANGE_THIS \
+    -v growi_data:/data \
+    growilabs/growi:8
+```
+
+The vault starts out empty. Run the initial import once from the admin screen at
+`/admin/vault`; after that every page change is picked up automatically. Users
+then clone from the **GROWI app**, not from this container:
+
+```bash
+git clone https://your-growi.example.com/vault.git
+```
+
+see: [GROWI Docs: Setting up GROWI Vault](https://docs.growi.org/en/admin-guide/management-cookbook/setup-vault.html)
+
+
+Configuration
+-----------
+
+### Environment Variables
+
+Read by this container:
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `MONGO_URI` | yes | | Connection string of the same MongoDB the GROWI app uses. Must select a replica set |
+| `VAULT_MANAGER_INTERNAL_SECRET` | yes | | Shared secret that authenticates the GROWI app against this container. Must be identical on both sides |
+| `VAULT_REPO_PATH` | yes | `/data/vault-repo.git` | Path of the bare git repository. The default is what the entrypoint prepares, but the value must still be passed explicitly — the process refuses to start without it |
+| `PORT` | no | `3001` | Port this container listens on |
+
+Read by the GROWI app container, to reach this one:
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `VAULT_ENABLED` | yes | `false` | Enables the feature. Fixed at deploy time; it cannot be toggled from the admin UI |
+| `VAULT_MANAGER_ENDPOINT` | yes | | URL of this container, e.g. `http://vault-manager:3001` |
+| `VAULT_MANAGER_INTERNAL_SECRET` | yes | | Same value as above |
+
+The tuning variables for bootstrap retries, drift detection, reconcile and
+garbage collection are listed under "GROWI Vault options" in
+[GROWI Docs: Environment Variables](https://docs.growi.org/en/admin-guide/admin-cookbook/env-vars.html).
+
+Keep `VAULT_MANAGER_INTERNAL_SECRET` out of version control and out of your
+logs, and use a value that cannot be guessed.
+
+### Health check
+
+`GET /health` returns `200 {"status":"ok"}` once MongoDB is connected and the
+bare repository is accessible, and `503` with the failing check otherwise. It
+requires no credentials, so it can be used as a Kubernetes liveness probe.
+
+
+Issues
+------
+
+If you have any issues or questions about this image, please contact us through [GitHub issue](https://github.com/growilabs/growi/issues).


### PR DESCRIPTION
## Why

The overview of [growilabs/vault-manager](https://hub.docker.com/r/growilabs/vault-manager) on Docker Hub is empty.

The cause is not a missing README: `apps/growi-vault-manager/docker/README.md` exists and has content. It is that `release-vault.yml` — whose last step syncs that file to Docker Hub via `peter-evans/dockerhub-description` — has never run. The four tags currently published there (`latest` / `0` / `0.1` / `0.1.0`) were pushed by hand on 2026-06-15, so neither the tag nor the description step ever happened.

Reading the existing README, its content was also the wrong fit for the page: it explained the service's internal architecture, which is not what an administrator opening Docker Hub is looking for.

## What

**`docker/README.md` — rewritten.** Restructured to follow `apps/app/docker/README.md` (Supported tags → What is → Requirements → Usage → Configuration → Issues), and rewritten around what it takes to run the image:

- GROWI Vault is introduced from the user's point of view first (`git clone` the wiki, per-user visibility, read-only)
- Makes explicit that this image is **not a standalone application**, and that users clone from the GROWI app — not from this container
- Requirements: GROWI >= 8.0.0, MongoDB as a replica set (with the reason: change streams), and the filesystem shared with `apps/app` (with the reason: both run as uid/gid 1000)
- Usage via docker-compose (pointing at the new `examples/growi-vault` in growi-docker-compose) and via `docker run`, including the variables the **app** side needs
- Environment variables split into two tables — read by this container vs. read by the GROWI app
- `/health` documented

**OCI label and links — corrected to `growilabs`.** `org.opencontainers.image.source` and the growi-docker-compose link in the package README still pointed at the `weseek` org. The cross-repository note in the package README is also refreshed: the compose side is now covered by `examples/growi-vault`, so it is no longer a pending separate PR.

## How this reaches Docker Hub

This PR does not publish anything by itself. The overview is updated by the `Update Docker Hub Description` step in `release-vault.yml`, which fires when a PR into `release/vault-manager/**` is merged. So this needs to land first, and the overview appears with the next vault-manager release (0.1.1).

**No changeset is included on purpose.** The Dockerfile label change does alter the image, but 0.1.1 has not been published yet — folding it into that release is correct, and adding a changeset here would bump to 0.1.2 for a label-only change.

## Related

- growi-docker-compose: v8 support (MongoDB replica set) and the opt-in `examples/growi-vault`
- growi-docs: `VAULT_REPO_PATH` corrected — the docs listed a default, but `src/preflight.ts` treats it as required and the process exits when it is unset

## Not verified

Docs-only apart from the label, so there is nothing to run here. For the record, the compose definitions referenced from this README have not been booted yet (no Docker available in the environment they were written in): the MongoDB healthcheck that calls `rs.initiate()`, the standalone → single-node replica set conversion, and the `node -e "fetch(...)"` healthcheck against the DHI dev image are all still unexercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
