### PR TITLE
support: release vault-manager v1.0.0

### DIFF
--- a/apps/growi-vault-manager/CHANGELOG.md
+++ b/apps/growi-vault-manager/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @growi/vault-manager
 
+## 1.0.0
+
+### Major Changes
+
+- First stable release, published alongside GROWI v8.0.0. GROWI Vault is generally available: users can `git clone` a GROWI wiki and receive the pages they are allowed to read as a tree of Markdown files. The vault stays read-only in this release — `git push` is rejected, and attachments, per-page metadata and history from before the feature was enabled are not exported.
+
 ## 0.1.1
 
 ### Patch Changes

--- a/apps/growi-vault-manager/docker/README.md
+++ b/apps/growi-vault-manager/docker/README.md
@@ -8,7 +8,7 @@ GROWI Vault Manager Official docker image
 Supported tags and respective Dockerfile links
 ------------------------------------------------
 
-* [`0.1.1`, `0.1`, `0`, `latest` (Dockerfile)](https://github.com/growilabs/growi/blob/vault-manager/v0.1.1/apps/growi-vault-manager/docker/Dockerfile)
+* [`1.0.0`, `1.0`, `1`, `latest` (Dockerfile)](https://github.com/growilabs/growi/blob/vault-manager/v1.0.0/apps/growi-vault-manager/docker/Dockerfile)
 
 
 What is GROWI Vault?

--- a/apps/growi-vault-manager/package.json
+++ b/apps/growi-vault-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/vault-manager",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
Releases `growilabs/vault-manager` **1.0.0**, the first stable release of the GROWI Vault execution engine, alongside GROWI v8.0.0.

Follows the same flow as pdf-converter ([#10524](https://github.com/growilabs/growi/pull/10524)): the version is fixed on this branch and merging into `release/vault-manager/current` triggers `release-vault.yml`. `release/vault-manager/current` was created from master at `d9e595f4`, so this PR contains only the release changes.

## Changes

- `package.json`: `0.1.1` → `1.0.0`
- `CHANGELOG.md`: entry for 1.0.0
- `docker/README.md`: supported-tags line now points at `1.0.0` / `1.0` / `1` / `latest` and the `vault-manager/v1.0.0` tag

## Why 1.0.0 rather than 0.1.2

0.1.0 was pushed to Docker Hub by hand and never went through this workflow, so nothing has been released through the regular path yet. GROWI Vault ships as a user-facing feature in GROWI v8.0.0, so the engine behind it goes out as a stable 1.0.0 rather than continuing the 0.x line.

Note that the 0.1.1 currently on master was not a deliberate release: changesets bumped it while following `@growi/core@2.5.0`, because `@growi/vault-manager` is not listed in the `ignore` section of `.changeset/config.json`. Worth deciding separately whether it should be, since this package is released by hand like pdf-converter.

## What happens on merge

`release-vault.yml` runs and:

1. builds and pushes the image for linux/amd64 and linux/arm64 as `1.0.0`, `1.0`, `1`, `latest`
2. creates the git tag `vault-manager/v1.0.0`
3. **fills in the Docker Hub overview**, which is currently empty — the description step has never run, which was the whole reason [#11586](https://github.com/growilabs/growi/pull/11586) rewrote `docker/README.md`
4. opens a follow-up PR against master bumping to `1.0.1-RC.0`

## Follow-up

`examples/growi-vault` in growi-docker-compose currently pins `growilabs/vault-manager:0.1`. It needs a separate PR to move to `1` once this release is out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
