### PR TITLE
fix(vault): Recover a bootstrap whose runner is gone

### DIFF
--- a/apps/app/public/static/locales/en_US/admin.json
+++ b/apps/app/public/static/locales/en_US/admin.json
@@ -1280,7 +1280,8 @@
         "confirm-question": "Are you sure you want to proceed?",
         "confirm-button": "Confirm",
         "cancel-button": "Cancel",
-        "started-toast": "Rebuild started. The Vault will return 503 until the data is rebuilt."
+        "started-toast": "Rebuild started. The Vault will return 503 until the data is rebuilt.",
+        "abandoned-run-notice": "The status says a rebuild is in progress, but no progress has been reported since {{heartbeatAt}} — the process that was running it is gone. Rebuild Vault stays available so you can start a new run."
       },
       "bootstrap-status": {
         "state": "Status",

--- a/apps/app/public/static/locales/ja_JP/admin.json
+++ b/apps/app/public/static/locales/ja_JP/admin.json
@@ -1279,7 +1279,8 @@
         "confirm-question": "本当に続行してよろしいですか？",
         "confirm-button": "確認",
         "cancel-button": "キャンセル",
-        "started-toast": "初期化を開始しました。データの再構築が完了するまで Vault は 503 を返します。"
+        "started-toast": "初期化を開始しました。データの再構築が完了するまで Vault は 503 を返します。",
+        "abandoned-run-notice": "ステータスは再構築中となっていますが、{{heartbeatAt}} 以降まったく進捗が報告されていません。実行していたプロセスが失われた状態です。やり直せるよう「Vault を初期化」は実行可能にしています。"
       },
       "bootstrap-status": {
         "state": "ステータス",

--- a/apps/app/src/features/growi-vault/client/admin/VaultAdminSettings.spec.tsx
+++ b/apps/app/src/features/growi-vault/client/admin/VaultAdminSettings.spec.tsx
@@ -179,7 +179,11 @@ const makeResilienceStatus = (
   forceWarningActive: overrides.forceWarningActive ?? false,
 });
 
-const makeVaultStatus = (state = 'done', vaultEnabled = true) => ({
+const makeVaultStatus = (
+  state = 'done',
+  vaultEnabled = true,
+  isStaleRunner = false,
+) => ({
   vaultEnabled,
   bootstrapState: state,
   processed: 100,
@@ -187,6 +191,8 @@ const makeVaultStatus = (state = 'done', vaultEnabled = true) => ({
   startedAt: '2026-01-01T00:00:00.000Z',
   completedAt: '2026-01-01T01:00:00.000Z',
   lastError: null,
+  heartbeatAt: '2026-01-01T00:30:00.000Z',
+  isStaleRunner,
   storageStats: null,
 });
 
@@ -202,6 +208,17 @@ function setup(
   mocks.swrData.status = makeVaultStatus(vaultState, vaultEnabled);
   mocks.swrData.resilience = resilience;
   mocks.globalState.siteUrl = siteUrl ?? undefined;
+  return render(<VaultAdminSettings />);
+}
+
+/** Render with an explicitly built /vault/status payload. */
+function setupWithStatus(
+  resilience: ResilienceStatusShape,
+  status: ReturnType<typeof makeVaultStatus>,
+): ReturnType<typeof render> {
+  mocks.swrData.status = status;
+  mocks.swrData.resilience = resilience;
+  mocks.globalState.siteUrl = 'https://example.com';
   return render(<VaultAdminSettings />);
 }
 
@@ -538,6 +555,66 @@ describe('VaultAdminSettings — Rebuild Vault (kill switch)', () => {
       name: /rebuild vault/i,
     }) as HTMLButtonElement;
     expect(wipeBtn.disabled).toBe(true);
+  });
+
+  // -- Recovery from an abandoned run ---------------------------------------
+  //
+  // Disabling the button for every 'running' / 'verifying' state assumes some
+  // process is still working. When the owning process died, that assumption
+  // strands the admin: the state never leaves 'running' on its own and the one
+  // control that could fix it is greyed out. The server reports that verdict
+  // as isStaleRunner, and the button must follow it.
+  // ------------------------------------------------------------------------
+
+  it('(f) enables "Rebuild Vault" when the running state has no live runner', () => {
+    setupWithStatus(
+      makeResilienceStatus({ bootstrap: { state: 'running' } }),
+      makeVaultStatus('running', true, true),
+    );
+    const wipeBtn = screen.getByRole('button', {
+      name: /rebuild vault/i,
+    }) as HTMLButtonElement;
+    expect(wipeBtn.disabled).toBe(false);
+  });
+
+  it('(f) enables "Rebuild Vault" when the verifying state has no live runner', () => {
+    setupWithStatus(
+      makeResilienceStatus({ bootstrap: { state: 'verifying' } }),
+      makeVaultStatus('verifying', true, true),
+    );
+    const wipeBtn = screen.getByRole('button', {
+      name: /rebuild vault/i,
+    }) as HTMLButtonElement;
+    expect(wipeBtn.disabled).toBe(false);
+  });
+
+  it('(f) keeps "Rebuild Vault" disabled while a verifying run is still alive', () => {
+    setupWithStatus(
+      makeResilienceStatus({ bootstrap: { state: 'verifying' } }),
+      makeVaultStatus('verifying', true, false),
+    );
+    const wipeBtn = screen.getByRole('button', {
+      name: /rebuild vault/i,
+    }) as HTMLButtonElement;
+    expect(wipeBtn.disabled).toBe(true);
+  });
+
+  it('(f) explains why the button is available when the runner is gone', () => {
+    setupWithStatus(
+      makeResilienceStatus({ bootstrap: { state: 'running' } }),
+      makeVaultStatus('running', true, true),
+    );
+    // Without this, an enabled destructive button next to state=running reads
+    // as a UI bug rather than a recovery path.
+    expect(screen.getByText(/no progress has been reported/i)).toBeTruthy();
+  });
+
+  it('(f) does not show the abandoned-run notice while a run is progressing', () => {
+    setupWithStatus(
+      makeResilienceStatus({ bootstrap: { state: 'running' } }),
+      makeVaultStatus('running', true, false),
+    );
+    expect(screen.queryByText(/no progress has been reported/i)).toBeNull();
   });
 });
 

--- a/apps/app/src/features/growi-vault/client/admin/VaultAdminSettings.tsx
+++ b/apps/app/src/features/growi-vault/client/admin/VaultAdminSettings.tsx
@@ -45,6 +45,14 @@ interface VaultStatusData {
   startedAt: string | null;
   completedAt: string | null;
   lastError: string | null;
+  /** Last liveness signal from the process that owns the run. */
+  heartbeatAt: string | null;
+  /**
+   * Server-side verdict: the state claims a run is in flight but nobody is
+   * working on it any more. Computed on the server because the staleness
+   * threshold is server configuration.
+   */
+  isStaleRunner: boolean;
   storageStats: StorageStatsResponse | null;
 }
 
@@ -341,8 +349,14 @@ const BootstrapStatusSection = ({
   const [isWipeModalOpen, setIsWipeModalOpen] = useState(false);
 
   const isRunning = data?.bootstrapState === 'running';
-  const isBootstrapRunning =
+  const isBootstrapInFlight =
     data?.bootstrapState === 'running' || data?.bootstrapState === 'verifying';
+  // An in-flight state whose runner is gone will never move on its own, and
+  // this button is the only way out of it — so it stays enabled in that case.
+  // Blocking it there is what strands an admin after a mid-bootstrap crash.
+  const isRunnerAbandoned =
+    isBootstrapInFlight && (data?.isStaleRunner ?? false);
+  const isBootstrapRunning = isBootstrapInFlight && !isRunnerAbandoned;
   const processed = data?.processed ?? 0;
   const totalEstimated = data?.totalEstimated ?? 0;
 
@@ -383,6 +397,17 @@ const BootstrapStatusSection = ({
                   ),
                 }}
               />
+
+              {/* Without this, an enabled destructive button next to a
+                  "running" status reads as a UI bug rather than a way out. */}
+              {isRunnerAbandoned && (
+                <Alert color="warning" className="mt-2">
+                  {t(
+                    'growi-vault.admin-settings.kill-switch.abandoned-run-notice',
+                    { heartbeatAt: formatDate(data?.heartbeatAt) },
+                  )}
+                </Alert>
+              )}
             </div>
           </div>
         </div>
@@ -924,6 +949,10 @@ export const VaultAdminSettings = (): JSX.Element => {
       startedAt: new Date().toISOString(),
       completedAt: null,
       lastError: null,
+      // A run has just been requested, so treat it as freshly alive: this
+      // re-disables the button until the next poll brings the server verdict.
+      heartbeatAt: new Date().toISOString(),
+      isStaleRunner: false,
       storageStats: current?.storageStats ?? null,
     }),
     [],

--- a/apps/app/src/features/growi-vault/server/index.spec.ts
+++ b/apps/app/src/features/growi-vault/server/index.spec.ts
@@ -851,7 +851,7 @@ describe('runVaultSyncStateMigration', () => {
         string,
         Record<string, unknown>
       >;
-      expect(upd.$set.bootstrapLastError).toMatch(/stale running/i);
+      expect(upd.$set.bootstrapLastError).toMatch(/no live runner/i);
     });
   });
 
@@ -894,65 +894,152 @@ describe('runVaultSyncStateMigration', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // (d) running + null instanceId — step 3 normalizes to failed
+  // (d) In-flight state with no live runner — step 3 normalizes to failed
+  //
+  // Contract: after a restart, a bootstrap state that claims to be in flight
+  // ('running' / 'verifying') is only left alone when some process is still
+  // refreshing the heartbeat. Otherwise the run died and the state must be
+  // normalized to 'failed', which is the state operators can act on (the
+  // admin UI offers a re-bootstrap, and auto-retry can pick it up).
+  //
+  // Liveness is decided by the heartbeat, not by the presence of an instance
+  // id: an id is written at the *start* of every run, so a crashed run leaves
+  // one behind and an id-based check would strand the state forever.
   // ---------------------------------------------------------------------------
-  describe('stale running state (no instanceId)', () => {
-    it('normalizes running + instanceId=null to failed with error message', async () => {
-      mockFindOneAndUpdateResult(null);
-      mockUpdateOneSuccess();
-      mockFindOneLean({
-        bootstrapState: 'running',
-        bootstrapInstanceId: null,
-      });
+  describe('in-flight state with no live runner', () => {
+    /** Heartbeat threshold used by these tests (ms). */
+    const STALE_MS = 60_000;
 
-      await runVaultSyncStateMigration();
+    function ageMs(ms: number): Date {
+      return new Date(Date.now() - ms);
+    }
 
-      expect(VaultSyncState.updateOne).toHaveBeenCalledWith(
-        { _id: 'singleton' },
-        {
-          $set: {
-            bootstrapState: 'failed',
-            bootstrapLastError:
-              'normalized stale running on first startup after schema migration',
-          },
-        },
-      );
-    });
-
-    it('does NOT normalize running when bootstrapInstanceId is set (live run)', async () => {
-      mockFindOneAndUpdateResult(null);
-      mockUpdateOneSuccess();
-      mockFindOneLean({
-        bootstrapState: 'running',
-        bootstrapInstanceId: 'live-instance-xyz',
-      });
-
-      await runVaultSyncStateMigration();
-
-      const updateOneCalls = vi.mocked(VaultSyncState.updateOne).mock.calls;
-      const normalizationCall = updateOneCalls.find((call) => {
+    /** Extract the step-3 normalization call, if any. */
+    function findNormalizationCall() {
+      return vi.mocked(VaultSyncState.updateOne).mock.calls.find((call) => {
         const upd = call[1] as Record<string, Record<string, unknown>>;
         return upd.$set?.bootstrapState === 'failed';
       });
-      expect(normalizationCall).toBeUndefined();
-    });
+    }
 
-    it('does NOT normalize when bootstrapState is not running', async () => {
+    beforeEach(() => {
       mockFindOneAndUpdateResult(null);
       mockUpdateOneSuccess();
+    });
+
+    it('normalizes running to failed when the heartbeat has expired, even though an instance id is present', async () => {
+      // The real-world case: a run started, wrote its instance id, then the
+      // process died. The heartbeat stops; nothing else ever moves the state.
+      mockFindOneLean({
+        bootstrapState: 'running',
+        bootstrapInstanceId: 'instance-of-a-dead-process',
+        bootstrapHeartbeatAt: ageMs(STALE_MS * 10),
+      });
+
+      await runVaultSyncStateMigration({ heartbeatStaleMs: STALE_MS });
+
+      const normalizationCall = findNormalizationCall();
+      expect(normalizationCall).toBeDefined();
+      if (normalizationCall == null) return;
+      const upd = normalizationCall[1] as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(upd.$set.bootstrapLastError).toMatch(/no live runner/i);
+    });
+
+    it('normalizes verifying to failed when the heartbeat has expired', async () => {
+      // The heartbeat keeps ticking through the completeness check, so an
+      // expired heartbeat in 'verifying' also means the runner is gone.
+      mockFindOneLean({
+        bootstrapState: 'verifying',
+        bootstrapInstanceId: 'instance-of-a-dead-process',
+        bootstrapHeartbeatAt: ageMs(STALE_MS * 10),
+      });
+
+      await runVaultSyncStateMigration({ heartbeatStaleMs: STALE_MS });
+
+      expect(findNormalizationCall()).toBeDefined();
+    });
+
+    it('normalizes running + instanceId=null to failed (pre-resilience document)', async () => {
+      mockFindOneLean({
+        bootstrapState: 'running',
+        bootstrapInstanceId: null,
+        bootstrapHeartbeatAt: null,
+      });
+
+      await runVaultSyncStateMigration({ heartbeatStaleMs: STALE_MS });
+
+      expect(findNormalizationCall()).toBeDefined();
+    });
+
+    it('normalizes running to failed when no heartbeat was ever written', async () => {
+      mockFindOneLean({
+        bootstrapState: 'running',
+        bootstrapInstanceId: 'instance-abc',
+        bootstrapHeartbeatAt: null,
+      });
+
+      await runVaultSyncStateMigration({ heartbeatStaleMs: STALE_MS });
+
+      expect(findNormalizationCall()).toBeDefined();
+    });
+
+    it('does NOT normalize running while the heartbeat is fresh (another instance owns the run)', async () => {
+      mockFindOneLean({
+        bootstrapState: 'running',
+        bootstrapInstanceId: 'instance-of-a-live-process',
+        bootstrapHeartbeatAt: ageMs(STALE_MS / 10),
+      });
+
+      await runVaultSyncStateMigration({ heartbeatStaleMs: STALE_MS });
+
+      expect(findNormalizationCall()).toBeUndefined();
+    });
+
+    it('does NOT normalize verifying while the heartbeat is fresh', async () => {
+      mockFindOneLean({
+        bootstrapState: 'verifying',
+        bootstrapInstanceId: 'instance-of-a-live-process',
+        bootstrapHeartbeatAt: ageMs(STALE_MS / 10),
+      });
+
+      await runVaultSyncStateMigration({ heartbeatStaleMs: STALE_MS });
+
+      expect(findNormalizationCall()).toBeUndefined();
+    });
+
+    it('does NOT normalize a state that is not in flight, whatever the heartbeat age', async () => {
       mockFindOneLean({
         bootstrapState: 'failed',
         bootstrapInstanceId: null,
+        bootstrapHeartbeatAt: ageMs(STALE_MS * 10),
       });
 
-      await runVaultSyncStateMigration();
+      await runVaultSyncStateMigration({ heartbeatStaleMs: STALE_MS });
 
-      const updateOneCalls = vi.mocked(VaultSyncState.updateOne).mock.calls;
-      const normalizationCall = updateOneCalls.find((call) => {
-        const upd = call[1] as Record<string, Record<string, unknown>>;
-        return upd.$set?.bootstrapState === 'failed';
+      expect(findNormalizationCall()).toBeUndefined();
+    });
+
+    it('does NOT touch the resume cursor when normalizing (the cursor stays a valid resume point)', async () => {
+      mockFindOneLean({
+        bootstrapState: 'running',
+        bootstrapInstanceId: 'instance-of-a-dead-process',
+        bootstrapHeartbeatAt: ageMs(STALE_MS * 10),
+        bootstrapCursor: 'aaaaaaaaaaaaaaaaaaaaaaaa',
       });
-      expect(normalizationCall).toBeUndefined();
+
+      await runVaultSyncStateMigration({ heartbeatStaleMs: STALE_MS });
+
+      const normalizationCall = findNormalizationCall();
+      expect(normalizationCall).toBeDefined();
+      if (normalizationCall == null) return;
+      const upd = normalizationCall[1] as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(upd.$set).not.toHaveProperty('bootstrapCursor');
     });
   });
 });

--- a/apps/app/src/features/growi-vault/server/index.ts
+++ b/apps/app/src/features/growi-vault/server/index.ts
@@ -15,6 +15,7 @@ import {
   type VaultReconcileService,
 } from './services/reconcile';
 import { createHistoryStore } from './services/reconcile/reconcile-history-store';
+import { isStaleBootstrapRunner } from './services/resilience';
 import { createVaultBootstrapper } from './services/vault-bootstrapper';
 import { createVaultDispatcher } from './services/vault-dispatcher';
 import { vaultNamespaceMapper } from './services/vault-namespace-mapper';
@@ -97,6 +98,13 @@ const logger = loggerFactory('growi:features:growi-vault:server');
 // ---------------------------------------------------------------------------
 
 /**
+ * Fallback heartbeat-staleness threshold for runVaultSyncStateMigration when
+ * the caller does not pass one. Mirrors the `app:vaultBootstrapHeartbeatStaleMs`
+ * default; production callers pass the configured value explicitly.
+ */
+const DEFAULT_HEARTBEAT_STALE_MS = 60_000;
+
+/**
  * Run the vault_sync_state startup migration.
  *
  * Idempotent — safe to call on every boot regardless of DB state.
@@ -109,14 +117,22 @@ const logger = loggerFactory('growi:features:growi-vault:server');
  *         one-time predicate — once migrated the update becomes a no-op.
  *         No upsert option to prevent E11000 on concurrent runs.
  *
- * Step 3: Normalize a stale 'running' state that has no instanceId.
- *         A running document without an instanceId means the previous process
- *         crashed before the resilience schema was applied; mark it 'failed'
- *         so the bootstrapper can decide whether to retry.
+ * Step 3: Normalize an in-flight state ('running' / 'verifying') that has no
+ *         live runner behind it — see the step 3 body for why the heartbeat,
+ *         not the instanceId, decides this.
  *
  * Requirements: 1.11, 3.3
  */
-export const runVaultSyncStateMigration = async (): Promise<void> => {
+export const runVaultSyncStateMigration = async (opts?: {
+  /**
+   * Heartbeat age beyond which an in-flight run counts as abandoned. Passed in
+   * by the caller (from `app:vaultBootstrapHeartbeatStaleMs`) so this function
+   * stays independent of configManager and testable with an explicit value.
+   */
+  heartbeatStaleMs?: number;
+}): Promise<void> => {
+  const heartbeatStaleMs = opts?.heartbeatStaleMs ?? DEFAULT_HEARTBEAT_STALE_MS;
+
   // Step 1: ensure singleton exists (fresh install)
   await VaultSyncState.findOneAndUpdate(
     { _id: 'singleton' },
@@ -175,16 +191,46 @@ export const runVaultSyncStateMigration = async (): Promise<void> => {
     },
   );
 
-  // Step 3: normalize stale 'running' with no instanceId to 'failed'.
+  // Step 3: normalize an in-flight state that has no live runner to 'failed'.
+  //
+  // 'running' / 'verifying' only move forward while the process that owns the
+  // run is alive, so after a crash or restart they would stay there forever:
+  // the gateway keeps answering 503, the trigger resolver skips 'running'
+  // unless VAULT_BOOTSTRAP_ON_START is set, and the admin UI hides its
+  // re-bootstrap control while a run looks active. 'failed' is the state
+  // operators (and auto-retry) can act on, so we land there.
+  //
+  // Liveness is decided by the heartbeat, NOT by the presence of an instance
+  // id: the id is written at the start of every run and therefore survives the
+  // crash, so an id-based check leaves exactly the abandoned runs it should be
+  // rescuing. A live peer instance mid-bootstrap keeps its heartbeat fresh and
+  // is left untouched.
+  //
+  // bootstrapCursor is deliberately preserved: for a non-wipe run it is still a
+  // valid resume point, and a wipe clears it when it starts.
   const doc = await VaultSyncState.findOne({ _id: 'singleton' }).lean();
-  if (doc?.bootstrapState === 'running' && doc?.bootstrapInstanceId == null) {
+  if (
+    doc != null &&
+    isStaleBootstrapRunner({
+      state: doc.bootstrapState,
+      heartbeatAt: doc.bootstrapHeartbeatAt,
+      staleThresholdMs: heartbeatStaleMs,
+    })
+  ) {
+    logger.warn(
+      {
+        bootstrapState: doc.bootstrapState,
+        bootstrapHeartbeatAt: doc.bootstrapHeartbeatAt,
+        bootstrapInstanceId: doc.bootstrapInstanceId,
+      },
+      `GROWI Vault: bootstrapState='${doc.bootstrapState}' has no live runner (heartbeat older than ${heartbeatStaleMs}ms); normalizing to 'failed'`,
+    );
     await VaultSyncState.updateOne(
       { _id: 'singleton' },
       {
         $set: {
           bootstrapState: 'failed',
-          bootstrapLastError:
-            'normalized stale running on first startup after schema migration',
+          bootstrapLastError: `normalized on startup: state was '${doc.bootstrapState}' with no live runner (heartbeat expired or never written)`,
         },
       },
     );
@@ -539,9 +585,13 @@ export const initializeVaultFeature = async (crowi: any): Promise<void> => {
   // This is idempotent and must execute on every boot so that:
   //   - fresh installs get a singleton doc with all required fields,
   //   - pre-resilience installs get the 14 new fields back-filled, and
-  //   - stale 'running' states (no instanceId) are normalized to 'failed'.
+  //   - in-flight states with no live runner are normalized to 'failed'.
   // ------------------------------------------------------------------
-  await runVaultSyncStateMigration();
+  await runVaultSyncStateMigration({
+    heartbeatStaleMs: configManager.getConfig(
+      'app:vaultBootstrapHeartbeatStaleMs',
+    ),
+  });
 
   // ------------------------------------------------------------------
   // Step 1.6: Reconcile history store — normalize stale lifecycle records.

--- a/apps/app/src/features/growi-vault/server/routes/vault-admin.spec.ts
+++ b/apps/app/src/features/growi-vault/server/routes/vault-admin.spec.ts
@@ -216,6 +216,46 @@ describe('VaultAdminRouter', () => {
       expect(res.status).toBe(500);
       expect(res.body.ok).toBe(false);
     });
+
+    // The admin UI decides whether a re-bootstrap may be started from this
+    // response, so the runner-liveness verdict has to travel with the state.
+    // The staleness threshold is server-side config — the UI must not have to
+    // re-derive it from a timestamp.
+    it('reports isStaleRunner=true when the in-flight run has no live runner', async () => {
+      mockBootstrapper.getStatus.mockResolvedValue({
+        ...doneStatus,
+        state: 'running',
+        completedAt: null,
+        heartbeatAt: new Date('2026-01-01T00:00:00Z'),
+        isStaleRunner: true,
+      });
+      mockManagerClient.getStorageStats.mockResolvedValue(storageStatsFixture);
+
+      const app = buildApp();
+      const res = await request(app).get('/_api/admin/vault/status');
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.bootstrapState).toBe('running');
+      expect(res.body.data.isStaleRunner).toBe(true);
+      expect(res.body.data.heartbeatAt).toBe('2026-01-01T00:00:00.000Z');
+    });
+
+    it('reports isStaleRunner=false while a run is progressing', async () => {
+      mockBootstrapper.getStatus.mockResolvedValue({
+        ...doneStatus,
+        state: 'running',
+        completedAt: null,
+        heartbeatAt: new Date('2026-01-01T00:00:00Z'),
+        isStaleRunner: false,
+      });
+      mockManagerClient.getStorageStats.mockResolvedValue(storageStatsFixture);
+
+      const app = buildApp();
+      const res = await request(app).get('/_api/admin/vault/status');
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.isStaleRunner).toBe(false);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/apps/app/src/features/growi-vault/server/routes/vault-admin.ts
+++ b/apps/app/src/features/growi-vault/server/routes/vault-admin.ts
@@ -127,6 +127,12 @@ export const createVaultAdminRouter = (
           startedAt: bootstrapStatus.startedAt,
           completedAt: bootstrapStatus.completedAt,
           lastError: bootstrapStatus.lastError,
+          heartbeatAt: bootstrapStatus.heartbeatAt,
+          // Whether an in-flight state still has a live runner. The admin UI
+          // gates its re-bootstrap control on this, so the verdict is computed
+          // server-side (the staleness threshold is server config, not
+          // something a client should re-derive from heartbeatAt).
+          isStaleRunner: bootstrapStatus.isStaleRunner,
           storageStats,
         },
       });

--- a/apps/app/src/features/growi-vault/server/services/resilience/__tests__/bootstrap-runner.spec.ts
+++ b/apps/app/src/features/growi-vault/server/services/resilience/__tests__/bootstrap-runner.spec.ts
@@ -416,6 +416,52 @@ describe('BootstrapRunner', () => {
   });
 
   // -------------------------------------------------------------------------
+  // (c-2) force wipe must invalidate the persisted resume cursor immediately
+  //
+  // A force wipe re-seeds the vault from the first page, so a cursor left over
+  // from an earlier run is not a valid resume point. If the wipe run dies
+  // before it streams its first page, that stale cursor would survive and the
+  // next resume would skip every page below it — leaving those pages missing
+  // from the freshly wiped repository while the completeness check still
+  // passes.
+  // -------------------------------------------------------------------------
+
+  describe('(c-2) force wipe invalidates the persisted cursor', () => {
+    it('has cleared the persisted cursor by the time the run is acknowledged as running', async () => {
+      const pages = [makePageDoc(FAKE_ID_B, '/page-b')];
+      const { state, runner } = createTestRunner(
+        { bootstrapState: 'done', bootstrapCursor: FAKE_ID_A },
+        pages,
+      );
+
+      // onRunning fires right after the state transition is committed and
+      // before any page is streamed — the exact window a crash would freeze.
+      let cursorWhenRunning: unknown = 'never-captured';
+      await runner.bootstrap({
+        triggerSource: 'env-force',
+        onRunning: () => {
+          cursorWhenRunning = state.bootstrapCursor;
+        },
+      });
+
+      expect(cursorWhenRunning).toBeNull();
+    });
+
+    it('does not carry a previous cursor into the page query of the wipe run', async () => {
+      const pages = [makePageDoc(FAKE_ID_B, '/page-b')];
+      const { mockPage, runner } = createTestRunner(
+        { bootstrapState: 'done', bootstrapCursor: FAKE_ID_A },
+        pages,
+      );
+
+      await runner.bootstrap({ triggerSource: 'env-force' });
+
+      // The stream query must be unfiltered: a wipe re-seeds from page one.
+      expect(mockPage.find).toHaveBeenCalledWith({});
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // (d) env=true + failed → resume (no reset-all)
   // -------------------------------------------------------------------------
 

--- a/apps/app/src/features/growi-vault/server/services/resilience/__tests__/bootstrap-runner.spec.ts
+++ b/apps/app/src/features/growi-vault/server/services/resilience/__tests__/bootstrap-runner.spec.ts
@@ -899,6 +899,105 @@ describe('BootstrapRunner', () => {
   });
 
   // -------------------------------------------------------------------------
+  // getStatus — runner liveness
+  //
+  // Contract: isStaleRunner answers "the state says a bootstrap is in flight,
+  // but is anyone still working on it?". Callers (the admin UI) use it to
+  // decide whether a re-bootstrap may be started, so it must be false while a
+  // real run is progressing and true once the owning process has gone away.
+  // The staleness threshold belongs to the server (heartbeatStaleMs = 120s in
+  // this fixture); callers must not have to re-derive it.
+  // -------------------------------------------------------------------------
+
+  describe('getStatus() — runner liveness (isStaleRunner)', () => {
+    it('is false while a running bootstrap keeps its heartbeat within the threshold', async () => {
+      const { runner } = createTestRunner({
+        bootstrapState: 'running',
+        bootstrapHeartbeatAt: new Date(Date.now() - 119_000),
+      });
+
+      const status = await runner.getStatus();
+
+      expect(status.bootstrap.isStaleRunner).toBe(false);
+    });
+
+    it('is true once a running bootstrap heartbeat is older than the threshold', async () => {
+      const { runner } = createTestRunner({
+        bootstrapState: 'running',
+        bootstrapHeartbeatAt: new Date(Date.now() - 121_000),
+      });
+
+      const status = await runner.getStatus();
+
+      expect(status.bootstrap.isStaleRunner).toBe(true);
+    });
+
+    it('is true for a verifying bootstrap whose heartbeat has expired', async () => {
+      // The heartbeat keeps ticking through the completeness check, so an
+      // expired heartbeat in 'verifying' means the owning process is gone.
+      const { runner } = createTestRunner({
+        bootstrapState: 'verifying',
+        bootstrapHeartbeatAt: new Date(Date.now() - 600_000),
+      });
+
+      const status = await runner.getStatus();
+
+      expect(status.bootstrap.isStaleRunner).toBe(true);
+    });
+
+    it('is true for a running bootstrap that never wrote a heartbeat', async () => {
+      const { runner } = createTestRunner({
+        bootstrapState: 'running',
+        bootstrapHeartbeatAt: null,
+      });
+
+      const status = await runner.getStatus();
+
+      expect(status.bootstrap.isStaleRunner).toBe(true);
+    });
+
+    it.each([
+      'done',
+      'failed',
+      'escalated',
+      'pending',
+    ] as const)('is false for the settled state %s even when the heartbeat is ancient', async (settledState) => {
+      const { runner } = createTestRunner({
+        bootstrapState: settledState,
+        bootstrapHeartbeatAt: new Date(Date.now() - 86_400_000),
+      });
+
+      const status = await runner.getStatus();
+
+      expect(status.bootstrap.isStaleRunner).toBe(false);
+    });
+
+    it('exposes the raw heartbeat timestamp so operators can see how old it is', async () => {
+      const heartbeatAt = new Date('2026-06-16T13:10:30.008Z');
+      const { runner } = createTestRunner({
+        bootstrapState: 'running',
+        bootstrapHeartbeatAt: heartbeatAt,
+      });
+
+      const status = await runner.getStatus();
+
+      expect(status.bootstrap.heartbeatAt).toEqual(heartbeatAt);
+    });
+
+    it('is false when no state document exists yet', async () => {
+      const { mockVaultSyncState, runner } = createTestRunner();
+      mockVaultSyncState.findOne.mockReturnValue({
+        lean: () => Promise.resolve(null),
+      });
+
+      const status = await runner.getStatus();
+
+      expect(status.bootstrap.isStaleRunner).toBe(false);
+      expect(status.bootstrap.heartbeatAt).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // stop()
   // -------------------------------------------------------------------------
 

--- a/apps/app/src/features/growi-vault/server/services/resilience/__tests__/runner-liveness.spec.ts
+++ b/apps/app/src/features/growi-vault/server/services/resilience/__tests__/runner-liveness.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * runner-liveness.spec.ts
+ *
+ * Unit tests for the pure runner-liveness predicates.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  isBootstrapInFlight,
+  isStaleBootstrapRunner,
+} from '../runner-liveness';
+
+const NOW = new Date('2026-07-28T12:00:00.000Z');
+const STALE_MS = 60_000;
+
+/** A heartbeat written `ms` before NOW. */
+const heartbeatAgedBy = (ms: number): Date => new Date(NOW.getTime() - ms);
+
+describe('isBootstrapInFlight', () => {
+  it.each([
+    'running',
+    'verifying',
+  ] as const)('treats %s as in flight', (state) => {
+    expect(isBootstrapInFlight(state)).toBe(true);
+  });
+
+  it.each([
+    'pending',
+    'done',
+    'failed',
+    'retrying',
+    'escalated',
+  ] as const)('treats %s as not in flight', (state) => {
+    expect(isBootstrapInFlight(state)).toBe(false);
+  });
+});
+
+describe('isStaleBootstrapRunner', () => {
+  it('is false at the moment the heartbeat is written', () => {
+    expect(
+      isStaleBootstrapRunner({
+        state: 'running',
+        heartbeatAt: NOW,
+        staleThresholdMs: STALE_MS,
+        now: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it('is false while the heartbeat age is still within the threshold', () => {
+    expect(
+      isStaleBootstrapRunner({
+        state: 'running',
+        heartbeatAt: heartbeatAgedBy(STALE_MS - 1),
+        staleThresholdMs: STALE_MS,
+        now: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it('is false exactly at the threshold (the threshold is the last live moment)', () => {
+    expect(
+      isStaleBootstrapRunner({
+        state: 'running',
+        heartbeatAt: heartbeatAgedBy(STALE_MS),
+        staleThresholdMs: STALE_MS,
+        now: NOW,
+      }),
+    ).toBe(false);
+  });
+
+  it('is true one millisecond past the threshold', () => {
+    expect(
+      isStaleBootstrapRunner({
+        state: 'running',
+        heartbeatAt: heartbeatAgedBy(STALE_MS + 1),
+        staleThresholdMs: STALE_MS,
+        now: NOW,
+      }),
+    ).toBe(true);
+  });
+
+  it('is true for a verifying run whose heartbeat expired', () => {
+    expect(
+      isStaleBootstrapRunner({
+        state: 'verifying',
+        heartbeatAt: heartbeatAgedBy(STALE_MS * 100),
+        staleThresholdMs: STALE_MS,
+        now: NOW,
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    null,
+    undefined,
+  ])('is true for an in-flight run with %s heartbeat', (heartbeatAt) => {
+    expect(
+      isStaleBootstrapRunner({
+        state: 'running',
+        heartbeatAt,
+        staleThresholdMs: STALE_MS,
+        now: NOW,
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    'pending',
+    'done',
+    'failed',
+    'retrying',
+    'escalated',
+  ] as const)('is false for the settled state %s no matter how old the heartbeat is', (state) => {
+    expect(
+      isStaleBootstrapRunner({
+        state,
+        heartbeatAt: heartbeatAgedBy(STALE_MS * 1000),
+        staleThresholdMs: STALE_MS,
+        now: NOW,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/app/src/features/growi-vault/server/services/resilience/bootstrap-runner.ts
+++ b/apps/app/src/features/growi-vault/server/services/resilience/bootstrap-runner.ts
@@ -438,6 +438,14 @@ export function createBootstrapRunner(
               bootstrapLastError: null,
               bootstrapLastTriggerSource: triggerSource,
               bootstrapRetryAttempts: currentRetryAttempts,
+              // A wipe re-seeds from the first page, so any cursor from an
+              // earlier run is not a valid resume point. Clear it here, not
+              // just in the local `resumeCursor` below: if this run dies before
+              // it streams its first page (which is what overwrites the field),
+              // the leftover cursor would make the next resume skip every page
+              // below it — leaving those pages missing from the wiped
+              // repository while the completeness check still passes.
+              bootstrapCursor: null,
             },
           },
           { upsert: true },

--- a/apps/app/src/features/growi-vault/server/services/resilience/bootstrap-runner.ts
+++ b/apps/app/src/features/growi-vault/server/services/resilience/bootstrap-runner.ts
@@ -19,6 +19,7 @@ import type { BootstrapEnvValue } from './bootstrap-trigger-resolver';
 import { resolveAction } from './bootstrap-trigger-resolver';
 import type { RetryConfig } from './retry-policy';
 import { decideRetry } from './retry-policy';
+import { isStaleBootstrapRunner } from './runner-liveness';
 
 const logger = loggerFactory(
   'growi:features:growi-vault:service:resilience:bootstrap-runner',
@@ -48,6 +49,17 @@ export interface BootstrapStatus {
   readonly totalEstimated: number | null;
   readonly processed: number;
   readonly lastError: string | null;
+  /** Last liveness signal written by the process that owns the run. */
+  readonly heartbeatAt: Date | null;
+  /**
+   * True when `state` claims a run is in flight ('running' / 'verifying') but
+   * no process has refreshed the heartbeat within the configured threshold —
+   * the run was abandoned and will not progress on its own.
+   *
+   * Derived here rather than by callers so the staleness threshold stays a
+   * server-side concern (see runner-liveness.ts).
+   */
+  readonly isStaleRunner: boolean;
 }
 
 export interface RetryStatus {
@@ -929,6 +941,8 @@ export function createBootstrapRunner(
             totalEstimated: null,
             processed: 0,
             lastError: null,
+            heartbeatAt: null,
+            isStaleRunner: false,
           },
           retry: null,
           drift: null,
@@ -945,6 +959,12 @@ export function createBootstrapRunner(
         totalEstimated: doc.bootstrapTotalEstimated,
         processed: doc.bootstrapProcessed,
         lastError: doc.bootstrapLastError,
+        heartbeatAt: doc.bootstrapHeartbeatAt,
+        isStaleRunner: isStaleBootstrapRunner({
+          state: doc.bootstrapState,
+          heartbeatAt: doc.bootstrapHeartbeatAt,
+          staleThresholdMs: heartbeatStaleMs,
+        }),
       };
 
       // RetryStatus: expose when retry attempts > 0 or state indicates retry

--- a/apps/app/src/features/growi-vault/server/services/resilience/index.ts
+++ b/apps/app/src/features/growi-vault/server/services/resilience/index.ts
@@ -35,6 +35,13 @@ export type {
   RetryStatus,
   VaultResilienceLayer,
 } from './bootstrap-runner';
+/**
+ * The runner-liveness rule is part of the public surface because the startup
+ * normalization (features/growi-vault/server/index.ts) has to apply the *same*
+ * definition of "abandoned run" that getStatus reports. Sharing the predicate
+ * keeps those two from drifting apart.
+ */
+export { isStaleBootstrapRunner } from './runner-liveness';
 
 // ---------------------------------------------------------------------------
 // Factory dependency interface

--- a/apps/app/src/features/growi-vault/server/services/resilience/runner-liveness.ts
+++ b/apps/app/src/features/growi-vault/server/services/resilience/runner-liveness.ts
@@ -1,0 +1,53 @@
+/**
+ * runner-liveness.ts — pure predicates about whether an in-flight bootstrap
+ * still has a live owner.
+ *
+ * No I/O: callers pass the persisted state plus the heartbeat timestamp they
+ * already read. Both the startup normalization (features/growi-vault/server/
+ * index.ts) and the status API (bootstrap-runner getStatus) decide liveness
+ * from this single rule, so the two can never disagree about what "abandoned"
+ * means.
+ */
+
+import type { BootstrapState } from './bootstrap-state-machine';
+
+/**
+ * States that assert a bootstrap run is in flight.
+ *
+ * Nothing moves them except the process that owns the run, so they are only
+ * trustworthy while that process keeps refreshing the heartbeat.
+ */
+const IN_FLIGHT_STATES: readonly BootstrapState[] = ['running', 'verifying'];
+
+/** True when the state claims a run is in flight ('running' / 'verifying'). */
+export const isBootstrapInFlight = (state: BootstrapState): boolean =>
+  IN_FLIGHT_STATES.includes(state);
+
+export interface RunnerLivenessInput {
+  readonly state: BootstrapState;
+  readonly heartbeatAt: Date | null | undefined;
+  /** Age beyond which a heartbeat no longer proves a live runner. */
+  readonly staleThresholdMs: number;
+  /** Injected by tests; defaults to the current time. */
+  readonly now?: Date;
+}
+
+/**
+ * True when the persisted state claims a run is in flight but no process has
+ * refreshed the heartbeat within the threshold — the run was abandoned (crash
+ * or restart) and will never progress on its own.
+ *
+ * A missing heartbeat on an in-flight state counts as abandoned: the runner
+ * writes one before it starts streaming, so its absence means no live owner.
+ * The instance id deliberately plays no part — it is written at the start of
+ * every run and therefore survives a crash, which is exactly why an id-based
+ * check strands an abandoned run forever.
+ */
+export const isStaleBootstrapRunner = (input: RunnerLivenessInput): boolean => {
+  const { state, heartbeatAt, staleThresholdMs, now = new Date() } = input;
+
+  if (!isBootstrapInFlight(state)) return false;
+  if (heartbeatAt == null) return true;
+
+  return heartbeatAt.getTime() < now.getTime() - staleThresholdMs;
+};


### PR DESCRIPTION
## What happened

A `git clone <site>/vault.git` against a dev instance returned 503:

```
WARN growi:features:growi-vault:routes:vault-gateway: Vault gateway rejected:
  bootstrap is not done (state=running). Responding 503.
```

`vault_sync_state` had been sitting like this for six weeks:

```
bootstrapState:       "running"
bootstrapStartedAt:   2026-06-16T13:10:30.011Z
bootstrapHeartbeatAt: 2026-06-16T13:10:30.008Z   # never refreshed again
bootstrapProcessed:   0
bootstrapCursor:      6a314b34b9e197c6eac2cd34   # left over from an earlier run
```

A rebuild had started and the process died before it streamed its first page. Nothing could move the state after that, and the gateway rejects anything other than `done`, so every clone failed — permanently.

## Two defects

### 1. An abandoned run has no way out (commit 2)

All three recovery paths were closed at once:

| Path | Why it did not fire |
|---|---|
| Startup normalization (`runVaultSyncStateMigration`) | Only rescued `running` documents with `bootstrapInstanceId == null`. The id is written at the *start* of every run, so it survives the crash — the check skipped exactly the documents it should have rescued. |
| Heartbeat-based resume (trigger resolver `running` + stale → resume) | Only evaluated when `VAULT_BOOTSTRAP_ON_START` is `true` / `force`. It defaults to `false`, so the stale-heartbeat row is unreachable in a default deployment. |
| Admin **Rebuild Vault** button | Disabled whenever the state looks in-flight (`running` / `verifying`). |

`POST /_api/v3/vault/status`'s sibling `POST /_api/v3/vault/wipe` *would* have worked (the state machine allows `forceOverride` from any state) — calling the API by hand was the only escape.

`verifying` was an even deeper dead end: the trigger resolver skips it unconditionally, and the startup normalization did not cover it at all.

**Fix**: decide liveness from the heartbeat, in one shared pure predicate (`isStaleBootstrapRunner`) that both the startup normalization and the status API apply, so the two cannot disagree about what "abandoned" means. `GET /_api/v3/vault/status` now reports the verdict as `isStaleRunner` — computed server-side, because the staleness threshold is server config (`VAULT_BOOTSTRAP_HEARTBEAT_STALE_MS`) and not something a client should re-derive from a timestamp — and the admin UI enables Rebuild Vault for an abandoned run, with a notice explaining why a destructive button sits next to a "running" status.

A live peer instance mid-bootstrap keeps its heartbeat fresh and is left untouched.

### 2. A rebuild left a stale resume cursor behind (commit 1)

A force wipe re-seeds from the first page, so an earlier run's cursor is not a valid resume point. The wipe path ignored it in memory (`resumeCursor`) but left the persisted field alone — and that field is not overwritten until the first page is streamed.

A wipe that died in that window left the old cursor behind. The next resume then queried `_id > <old cursor>` against a repository the wipe had already emptied, skipped every page below it, and still satisfied the completeness check (which only asks whether the cursor reached the snapshot max id) — reporting `done` for a vault missing most of its pages. `bootstrapProcessed: 0` with a far-ahead cursor in the report above is that state.

**Fix**: clear `bootstrapCursor` in the same update that transitions to running.

The two fixes compose: normalization deliberately preserves the cursor (for a non-wipe run it is still a valid resume point), and a wipe clears it when it starts.

## Verification

Red → green was measured for every test (21 failing before the implementation).

- `pnpm vitest run src/features/growi-vault` — **34 files / 737 tests pass**, including the two `*.integ.ts` suites that need `turbo run build --filter @growi/vault-manager` first.
- `lint:typecheck` — no growi-vault errors. `lint:biome`, `lint:route-guard`, `lint:import-convention` clean.
- **Confirmed against the real stuck document**: the dev server restarted onto this code and normalized the six-week-old state on boot, which is what an operator would see after deploying it:

```
state:     "failed"
lastError: "normalized on startup: state was 'running' with no live runner
            (heartbeat expired or never written)"
```

`failed` is the state operators can act on — the admin button is enabled, and auto-retry can pick it up when `VAULT_BOOTSTRAP_ON_START` is set.

New tests: `runner-liveness.spec.ts` (threshold boundaries — exactly at the threshold is still alive, +1 ms is not — null heartbeat, settled states), cursor-cleared-at-`onRunning` (the exact crash window), heartbeat-based normalization incl. `verifying`, `isStaleRunner` on the status API, and the button/notice states in the admin UI.

## Not included

- `VAULT_BOOTSTRAP_ON_START` behaviour is unchanged; a default deployment still does not bootstrap on boot.
- vault-manager is not started by `turbo run dev` (its script is `dev:vault-manager`, so the `dev` task does not pick it up). Unrelated to these defects, but it is why the instruction queue had drained nothing and the admin page reported `Failed to retrieve storage statistics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)