### PR TITLE
docs(vault): record the abandoned-run recovery in the resilience spec

### DIFF
--- a/.kiro/specs/growi-vault-resilience/design.md
+++ b/.kiro/specs/growi-vault-resilience/design.md
@@ -957,3 +957,90 @@ export interface DriftStatus {
 - Existing reference specs（cleanup 済み、編集禁止）:
   - [growi-vault-gateway/requirements.md](../growi-vault-gateway/requirements.md) Req 5 — 現行 bootstrap の挙動定義
   - [growi-vault-manager/requirements.md](../growi-vault-manager/requirements.md) Req 2.6 — 現行 `reset-all` op の挙動定義
+
+---
+
+## 追補 A: 実行が途絶えた bootstrap の復旧と、全 wipe 時の cursor 無効化（要件 7 — PR #11599）
+
+実装完了後の運用で、bootstrap の途中でプロセスが落ちた状態から、GROWI 自身の手段（サーバの再起動 / admin UI）では復帰できないことが判明した。原因は 1 つの実装ミスではなく、本 design が別々の箇所で決めた 3 つの判断が重なった結果である。
+
+**用語**: 以下では、bootstrap を実行していたプロセスが落ちたあと、状態だけが `running` / `verifying` のまま残っている状況を「実行が途絶えた bootstrap」と呼ぶ。プロセスがまだ動いているかどうかは `bootstrapHeartbeatAt`（実行中のプロセスが定期的に書き込む時刻）の新しさで見分ける。
+
+### 何が重なっていたか
+
+| 経路 | 本 design での決定 | 実行が途絶えた bootstrap に対して起きたこと |
+|---|---|---|
+| 起動時の正規化（tasks 1.4） | `running` かつ `bootstrapInstanceId` が null の doc を `failed` に書き換える | instanceId は bootstrap の開始時（`heartbeat.acquireInstance()`）に書かれるため、プロセスが落ちても残る。復旧させたい doc がちょうど条件から外れる |
+| `bootstrapHeartbeatAt` を見た resume（tasks 4.1 / BootstrapTriggerResolver） | `running` かつ heartbeat が古ければ `resumeFromCursor` | この行に到達するのは `VAULT_BOOTSTRAP_ON_START` が `true` / `force` のときだけ。既定の `false` では判定自体が呼ばれない |
+| admin UI（tasks 5.4） | 状態が `running` / `verifying` なら再構築ボタンを押せなくする（二重起動の抑止） | プロセスが動いているかを区別しないため、誰も処理していない状態でも押せない |
+
+`verifying` は `running` より深い行き止まりだった。BootstrapTriggerResolver は `verifying` を無条件で skip とし（進行中の completeness check を邪魔しないため）、起動時の正規化も対象にしていなかった。completeness の待機ループは同じプロセスの中で回っているので、その最中にプロセスが落ちれば誰も先に進められない。
+
+なお `POST /_api/v3/vault/wipe` は状態を検査しておらず、state machine の `forceOverride` はどの状態からでも有効なので、API を直接呼ぶ経路だけは生きていた。UI からは到達できない。
+
+### プロセスが動いているかの判断を 1 か所に置く
+
+判断を `runner-liveness.ts`（純関数のみ、I/O なし）にまとめ、起動時の正規化と `getStatus()` の双方がこれを使う。2 か所が「実行が途絶えた」の定義で食い違わないことが目的（要件 7.4）。
+
+```
+resilience/runner-liveness.ts
+  isBootstrapInFlight(state)            -- running / verifying かどうか
+  isStaleBootstrapRunner({ state, heartbeatAt, staleThresholdMs, now? })
+```
+
+判断の材料は `bootstrapHeartbeatAt` の新しさだけとする（要件 7.2）。`running` / `verifying` 以外の状態では、heartbeat がどれだけ古くても false を返す。`running` / `verifying` なのに heartbeat が一度も書かれていない場合は「途絶えた」と扱う（bootstrap はページの処理を始める前に必ず 1 つ書き込むので、無いということは誰も実行していない）。
+
+barrel（`resilience/index.ts`。この配下のモジュールを外部へ公開する唯一の入口）からこの関数を export する。起動時の正規化は `features/growi-vault/server/index.ts` にあって resilience layer の外側なので、barrel 以外から内部モジュールを直接 import しない原則（tasks 4.4）に従う。
+
+「古い」と判断する時間は `app:vaultBootstrapHeartbeatStaleMs`（既定 60 秒）を呼び出し側から渡す。`runVaultSyncStateMigration` が configManager を直接読まないので、テストから明示的な値を与えられる。
+
+### 起動時の正規化の変更
+
+対象を「`running` / `verifying` かつプロセスが動いていない」に広げ（`verifying` を含める）、`failed` に書き換える。`failed` は運用者と自動再試行のどちらからでも扱える状態である（要件 3.1）。
+
+`bootstrapCursor` はそのまま残す（要件 7.8）。wipe を伴わない bootstrap ではまだ有効な再開位置であり、消せば毎回全件をやり直すことになる。wipe の側の cursor は下記のとおり開始時に消えるので、両方あわせて「古い cursor が残る経路」が閉じる。
+
+書き換えるときは WARN ログに状態・heartbeat の時刻・instanceId を残す。運用者が「なぜ状態が変わったのか」を後から追えるようにするため。
+
+### 全 wipe 時の cursor 無効化
+
+`executeBootstrap` の forceWipe 分岐では、状態を `running` に変える `$set` に `bootstrapCursor: null` を含める（要件 7.9）。
+
+これまでは、処理を始めるときのローカル変数（`resumeCursor = forceWipe ? null : cursor`）でのみ cursor を無視しており、DB に保存された値は最初の 1 ページを処理した時点で初めて上書きされていた。その手前で落ちると前回の cursor が残る。残ったまま resume すると次のようになる。
+
+1. ページの取得条件が `_id > 残った cursor` になり、それより古いページを 1 件も処理しない
+2. しかし wipe の `reset-all` は既に vault-manager に届いており、repository は空
+3. completeness check は cursor が snapshotMaxId に届いたかだけを見るので、新しいページを処理し終えれば条件を満たし `done` になる
+
+結果として、中身が欠けた vault が `done` として公開される。要件 2 が解消したはずの「cursor より前のページが永久に取り込まれない」状態の再発であり、エラーも警告も出ないまま起きるので気付きにくい。
+
+### 状態の公開と admin UI
+
+`BootstrapStatus` に 2 つのフィールドを追加する。
+
+| フィールド | 意味 |
+|---|---|
+| `heartbeatAt` | 実行中のプロセスが最後に書いた時刻。運用者が古さを目で確認できる |
+| `isStaleRunner` | `running` / `verifying` なのにプロセスが動いていないとき true |
+
+判断はサーバ側で行い、結論だけを `GET /_api/v3/vault/status` に載せる（要件 7.5）。「古い」と判断する時間はサーバの設定値なので、client 側が `heartbeatAt` から同じ判断を組み立てる作りにすると、設定を変えても UI に伝わらず、判断基準が 2 か所に分かれてしまう。
+
+admin UI は再構築ボタンを押せるかどうかを `isStaleRunner` に従わせ、実行が途絶えているときは押せるようにする。あわせて警告文を表示する（要件 7.6）。状態が `running` と表示されたままデータを消すボタンが押せると、運用者には UI の不具合に見えて押せないため、「進捗が報告されていないので押せるようにしている」ことを文章で示す。文言は `growi-vault.admin-settings.kill-switch.abandoned-run-notice`（en_US / ja_JP）。
+
+ボタンを押した直後に画面側の状態を先に書き換える処理（optimistic update）では、`isStaleRunner: false` と現在時刻の `heartbeatAt` を入れる。押した直後は「たった今始まった bootstrap」なので、次のポーリングでサーバの判断が返るまでボタンを再び押せなくするのが正しい。
+
+### Requirements Traceability（追補分）
+
+| 要件 | 実装 | テスト |
+|---|---|---|
+| 7.1, 7.2, 7.3, 7.8 | `features/growi-vault/server/index.ts` の `runVaultSyncStateMigration`（step 3） | `server/index.spec.ts`「in-flight state with no live runner」 |
+| 7.2, 7.4 | `resilience/runner-liveness.ts` | `resilience/__tests__/runner-liveness.spec.ts`（「古い」と判断する時間の境界 / heartbeat が未記録 / `done` や `failed` など処理が終わっている状態） |
+| 7.5 | `bootstrap-runner.ts` の `getStatus()`、`routes/vault-admin.ts` の `GET /status` | `bootstrap-runner.spec.ts`「getStatus() — runner liveness」、`vault-admin.spec.ts` |
+| 7.6, 7.7 | `client/admin/VaultAdminSettings.tsx` | `VaultAdminSettings.spec.tsx`（ボタンを押せるかどうか / 警告文の有無） |
+| 7.9, 7.10 | `bootstrap-runner.ts` の `executeBootstrap` forceWipe 分岐 | `bootstrap-runner.spec.ts`「(c-2) force wipe invalidates the persisted cursor」（`onRunning` が呼ばれた時点の cursor を観測する = プロセスが落ちる窓そのもの） |
+
+### 残る論点
+
+- **`VAULT_BOOTSTRAP_ON_START` の既定値**: 既定 `false` のままとした。実行が途絶えた bootstrap は再起動で `failed` に落ち、そこから先は要件 1.5 のとおり admin の明示操作で進む。既定を `true` に変えると「env をつけっぱなしにしても安全」という判断（要件 1.3）と別の議論になるため、本追補では触らない。
+- **`verifying` からの自動 resume**: 起動時の正規化が `failed` に落とすため、`VAULT_BOOTSTRAP_ON_START=true` の環境では次の起動で resume される。BootstrapTriggerResolver の「`verifying` は skip」という行自体は変更していない（進行中の completeness check を邪魔しないという判断は維持する）。
+- **プロセスは動いているのに heartbeat の書き込みだけ止まる場合**: 起動時の正規化は再起動しないと走らないため、この状態では admin UI 側でボタンが押せることだけが救いになる。heartbeat の書き込み失敗を検知して自分で状態を `failed` に落とす仕組みは入れていない（`updateOne` の失敗を握り潰さない形にする話であり、別途検討する）。

--- a/.kiro/specs/growi-vault-resilience/requirements.md
+++ b/.kiro/specs/growi-vault-resilience/requirements.md
@@ -152,3 +152,32 @@ GROWI Vault の現行 bootstrap 機構は「完了状態の信頼性」を保証
 4. The GROWI Vault Resilience Layer shall 既存 op（upsert / bulk-upsert / remove / rename-prefix / grant-change-prefix）の挙動を変更しない（`reset-all` のみが再定義対象）
 5. The GROWI Vault Resilience Layer shall single-replica 運用を前提とする（マルチレプリカ対応は別 spec の責務）
 6. The GROWI Vault Resilience Layer shall 既存 sub-spec（`growi-vault-gateway` / `growi-vault-manager`）の cleanup 済み reference を再編集せず、本 spec が置き換え設計を提示する形を採る
+
+---
+
+### 要件 7: 実行が途絶えた bootstrap からの復旧と、全 wipe 時の cursor 無効化
+
+> 2026-07-28 追記（PR #11599）。実装完了後の運用で見つかった 2 件の不具合に対応する。要件 2 / 要件 3 / 要件 5 の受け入れ基準は変更せず、本要件がそれらを補う形を採る。
+>
+> **本要件で使う言い方**: bootstrap を実行していたプロセスが落ちたあと、状態だけが `running` / `verifying` のまま残っている状況を「**実行が途絶えた bootstrap**」と呼ぶ。`running` / `verifying` は「いま誰かが処理を進めている」ことを表す状態なので、進めるプロセスがいなくなると、他の何かがその状態を書き換えることはない。プロセスがまだ動いているかどうかは、`bootstrapHeartbeatAt`（実行中のプロセスが定期的に書き込む時刻）が最近更新されているかで見分ける。「正規化」は本 spec の既存の言い方で、状態を `failed` に書き換えて、運用者と自動再試行のどちらからでも扱える状態に戻すことを指す。
+
+**目的**: 運用担当者として、bootstrap の途中でプロセスが落ちた場合に、その状態を GROWI 自身の手段（サーバの再起動、または admin UI の操作）だけで必ず解消できるようにしたい。また、全 wipe を伴う bootstrap が最初のページを処理する前に落ちた場合でも、次の resume が古い cursor に引きずられて一部のページを取り込まないまま終わらないようにしたい。
+
+**実際に起きたこと**: dev 環境で、`bootstrapState` が `running`、`bootstrapHeartbeatAt` が 6 週間前、`bootstrapProcessed` が 0、`bootstrapCursor` は前回の bootstrap が最後に処理したページの `_id`、という doc が観測された。gateway は `done` 以外をすべて 503 で拒否するため、clone はいつまでも失敗し続ける。しかも次の 3 つが同時に成立していたため、GROWI の側からは直せなかった。
+
+- (a) 起動時の正規化は `bootstrapInstanceId` が null の doc しか対象にしない
+- (b) `bootstrapHeartbeatAt` を見て resume する判定は、`VAULT_BOOTSTRAP_ON_START` が `true` / `force` のときしか実行されない（既定は `false`）
+- (c) admin UI の再構築ボタンは、状態が `running` / `verifying` なら押せない
+
+#### 受け入れ基準
+
+1. When apps/app が起動し `bootstrapState` が `running` または `verifying` で、かつ `bootstrapHeartbeatAt` が「古い」と判断する時間（`VAULT_BOOTSTRAP_HEARTBEAT_STALE_MS`）より前のまま、あるいは一度も書かれていない場合, the GROWI Vault Resilience Layer shall `VAULT_BOOTSTRAP_ON_START` の値に関わらずその状態を `failed` に書き換え、`bootstrapLastError` に「実行していたプロセスがもう動いていない」旨を記録する（要件 3.3 の「`running` のまま停滞させない」を、env の値によらず必ず成り立つ条件にする。resume を実際に走らせるかどうかは、従来どおり要件 1.4 / 1.5 に従う）
+2. The GROWI Vault Resilience Layer shall bootstrap を実行しているプロセスがまだ動いているかどうかの判断を、`bootstrapHeartbeatAt` が最近更新されているかだけで行い、`bootstrapInstanceId` があるかないかを判断に使わない（instanceId は bootstrap の開始時に書かれるので、プロセスが落ちても残る。それを条件にすると、まさに復旧させたい doc が対象から外れる）
+3. When 別のインスタンスが bootstrap を実行中で、`bootstrapHeartbeatAt` が上記の時間内に更新されている場合, the GROWI Vault Resilience Layer shall その状態を書き換えず、進行中の処理を妨げない
+4. The GROWI Vault Resilience Layer shall 上記の判断を 1 つの純関数にまとめ、起動時の正規化と `getStatus()` の両方が同じ関数を使う（「実行が途絶えた」の定義が 2 か所に分かれて食い違わないようにする）
+5. The GROWI Vault Resilience Layer shall その判断の結果と `bootstrapHeartbeatAt` を `getStatus()` および `GET /_api/v3/vault/status` の応答に含める（`VAULT_BOOTSTRAP_HEARTBEAT_STALE_MS` はサーバ側の設定値なので、時刻から同じ判断を組み立てる処理を client 側に持たせない）
+6. When `bootstrapState` が `running` / `verifying` で、かつその bootstrap の実行が途絶えている場合, the GROWI Vault Resilience Layer shall admin UI の再構築ボタンを押せる状態にし、あわせて「進捗が報告されていないので押せるようにしている」旨を画面に表示する（要件 5 の表示項目に追加する。状態が `running` と表示されたままデータを消すボタンが押せる理由を、運用者が読んで分かるようにする）
+7. While `running` / `verifying` の bootstrap が実際に動いている（`bootstrapHeartbeatAt` が上記の時間内に更新されている）場合, the GROWI Vault Resilience Layer shall admin UI の再構築ボタンを従来どおり押せないままにする
+8. When 起動時の正規化が `failed` を書き込む場合, the GROWI Vault Resilience Layer shall `bootstrapCursor` をそのまま残す（wipe を伴わない bootstrap では、まだ有効な再開位置である。wipe の側は基準 9 で開始時に消す）
+9. When VaultBootstrapper が全 wipe を伴う bootstrap を開始する場合, the GROWI Vault Resilience Layer shall 状態を `running` に変える更新と同じ更新で、DB に保存された `bootstrapCursor` を null にする（メモリ上の変数だけで cursor を無視する作りでは、最初のページを処理する前に落ちたときに前回の cursor が残ってしまい、要件 2 が解消したはずの「cursor より前のページが永久に取り込まれない」状態が再発する）
+10. When 全 wipe を伴う bootstrap が最初のページを処理する前に落ちた場合, the GROWI Vault Resilience Layer shall 次の resume が全ページを先頭から処理する（completeness check は cursor が snapshotMaxId に届いたかだけを見るため、一部のページしか処理していない bootstrap でも `done` に到達しうる。その道筋を塞ぐ）

--- a/.kiro/specs/growi-vault-resilience/spec.json
+++ b/.kiro/specs/growi-vault-resilience/spec.json
@@ -1,7 +1,7 @@
 {
   "feature_name": "growi-vault-resilience",
   "created_at": "2026-05-20T00:00:00.000Z",
-  "updated_at": "2026-06-05T00:00:00.000Z",
+  "updated_at": "2026-07-28T00:00:00.000Z",
   "language": "ja",
   "phase": "implementation-complete",
   "approvals": {

--- a/.kiro/specs/growi-vault-resilience/tasks.md
+++ b/.kiro/specs/growi-vault-resilience/tasks.md
@@ -19,6 +19,7 @@
 
 - [x] 1.4 起動時 migration 処理（2 段階分離 + stale running 正規化）
   - WHY: `$setOnInsert` 単体では既存 doc に新フィールドが入らず、追加フィルタ + upsert は E11000 を招くため fresh install 用 upsert と既存 doc 用 no-upsert を分離する。`running` + null instanceId は stale 扱いに正規化（migration 前の crash 残骸を安全側で回収）
+  - NOTE: 正規化の条件は 7.2 で置き換え済み。instanceId は bootstrap の開始時に書かれるためプロセスが落ちても残り、この条件では復旧させたい doc をちょうど対象外にしていた（要件 7 / 追補 A 参照）
   - _Depends: 1.1_
   - _Requirements: 1.11, 3.3_
   - _Boundary: resilience layer init（features/growi-vault/server/index.ts の migration block、bootstrap 起動分岐より前）_
@@ -138,3 +139,24 @@
   - _Depends: 6.1_
   - _Requirements: 1.6, 1.8, 2.3, 3.1, 3.3, 3.6, 5.6, 6.1, 6.2_
   - _Boundary: resilience-flow integration (stale / abort / force)_
+
+## Phase 7: 追補（要件 7 — PR #11599）
+
+- [ ] 7. 実行が途絶えた bootstrap の復旧と、全 wipe 時の cursor 無効化
+
+- [x] 7.1 全 wipe の開始時に、DB に保存された bootstrapCursor を消す
+  - WHY: メモリ上の `resumeCursor` だけで cursor を無視する作りでは、最初のページを処理する前に落ちると前回の cursor が残る。残った cursor から resume すると、それより古いページを 1 件も処理しないまま completeness check を満たし、中身が欠けた vault が `done` になる
+  - _Requirements: 7.9, 7.10_
+  - _Boundary: bootstrap-runner（executeBootstrap の forceWipe 分岐）_
+
+- [x] 7.2 プロセスが動いているかの判断を 1 つの純関数にまとめ、起動時の正規化と getStatus の双方から使う
+  - WHY: 判断の材料は `bootstrapHeartbeatAt` の新しさだけとする（instanceId は bootstrap の開始時に書かれるためプロセスが落ちても残り、復旧させたい doc をちょうど対象外にしてしまう）。定義が 2 か所に分かれて食い違わないよう 1 つの関数に置き、barrel（外部への唯一の入口）から export する
+  - _Depends: 7.1_
+  - _Requirements: 7.1, 7.2, 7.3, 7.4, 7.8_
+  - _Boundary: resilience/runner-liveness.ts（新規）、resilience/index.ts barrel、features/growi-vault/server/index.ts の migration step 3_
+
+- [x] 7.3 判断の結果を status API に載せ、admin UI の再構築操作をそれに従わせる
+  - WHY: 「古い」と判断する時間はサーバの設定値なので、判断はサーバ側で行い結論だけを渡す。実行が途絶えているときは再構築を押せるようにし、状態が `running` と表示されたままデータを消す操作が有効になる理由を文章で示す
+  - _Depends: 7.2_
+  - _Requirements: 7.5, 7.6, 7.7_
+  - _Boundary: bootstrap-runner getStatus、vault-admin route GET /status、VaultAdminSettings UI、admin.json（en_US / ja_JP）_


### PR DESCRIPTION
Spec follow-up for #11599 (already merged). That PR fixed the code; this one records it in `.kiro/specs/growi-vault-resilience/` so the spec stops describing behaviour the implementation has moved away from.

## What is added

| File | Addition |
|---|---|
| `requirements.md` | **要件 7**: 放棄された bootstrap run からの復旧と全 wipe 時の cursor 無効化（受け入れ基準 10 件） |
| `design.md` | **追補 A**: なぜ行き止まりになったか（3 つの決定の重なり）、生存判定を 1 箇所に置いた理由、wipe 時の cursor 無効化、状態の公開と admin UI、追補分の traceability、残る論点 |
| `tasks.md` | **Phase 7**: 完了済みタスク 7.1 / 7.2 / 7.3。あわせて task 1.4 に NOTE を 1 行追加 |
| `spec.json` | `updated_at` を更新（`phase` は `implementation-complete` のまま） |

## Approved sections are left alone

要件 2 / 3 / 5 の受け入れ基準は書き換えていません。新しい要件から参照する形にしてあります — `ai-settings-model-picker` の Requirement 9 + 追補 R と同じやり方です。

ひとつだけ既存箇所に手を入れています: task 1.4 の WHY は「`running` + null instanceId は stale 扱いに正規化」と書いてあり、これは 7.2 で置き換わりました。元の WHY はそのまま残し、NOTE 行を足して 7.2 / 追補 A を指しています（タスク一覧が、コードがもう使っていない条件を説明したままになるのを避けるため）。

## Why the spec needed this

`#11599` で直した行き止まりは、実装ミス 1 つではなく本 design が別々の箇所で決めた 3 つの判断が重なって生じたものでした。

- 起動時正規化（task 1.4）は `bootstrapInstanceId` が null の doc だけを回収する — instanceId は run 開始時に書かれるため異常終了しても残り、回収対象がちょうど条件から外れる
- heartbeat 由来の resume（task 4.1 / BootstrapTriggerResolver）は `VAULT_BOOTSTRAP_ON_START` が `true` / `force` のときしか評価されない（既定は `false`）
- admin UI（task 5.4）は in-flight 状態なら生存の有無を問わず再構築ボタンを操作不可にする

どれも単体では妥当な判断です。追補 A はこの重なり方と、`verifying` が `running` より深い行き止まりだった理由（trigger resolver が無条件 skip、起動時正規化も対象外、completeness の待機は in-process）を記録しています。次に同じ場所を触る人が、3 つのうち 1 つだけを見て「これで十分」と判断しないようにするためです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)