### PR TITLE
fix(vault): Shrink the clone transfer and fix the sparse-checkout recipe

### DIFF
--- a/.kiro/specs/growi-vault-manager/design.md
+++ b/.kiro/specs/growi-vault-manager/design.md
@@ -61,7 +61,8 @@ Ts.ED v7.x ベースのマイクロサービスとして、`apps/pdf-converter` 
 - git binary が container image から外れる事態
 - GROWI Revision モデルの `body` フィールド形式変更
 - ページパスエンコーディング規則の変更（既存 clone 履歴との互換破壊）
-- `uploadpack.allowFilter` を有効化して partial clone を通す場合（ビュー外 object の要求の検査が、ファイル単体の要求を拒否するため。research.md の Decision A 参照）
+- 公開する sparse-checkout パターン集合（`PUBLISHED_SPARSE_FILTERS`）を変更する場合（object の ID が内容から決まるため、README に載せた clone コマンドと既存クライアントに残る `remote.origin.partialclonefilter` が無効になる。README との突き合わせは単体テストで固定済み）
+- `uploadpack.allowReachableSHA1InWant` を有効にする場合（クライアントが object を ID で名指しできるようになるため、要件 5.6 の検査を blob / tree の到達性まで拡張することが前提になる。research.md の Decision D 参照）
 - gateway がクライアントの `Git-Protocol` ヘッダを転送し、upload-pack が protocol v2 を使うようになる場合（同検査が v0 の形式のみ解釈するため）
 
 ---
@@ -182,6 +183,7 @@ apps/growi-vault-manager/
 │   │   ├── vault-blob-hasher.ts             # isomorphic-git hashObject
 │   │   ├── vault-pkt-line.ts                # want 区間の pkt-line 解析（純関数）
 │   │   ├── vault-want-guard.ts              # 本文先頭の peek + ビュー ref からの到達性確認
+│   │   ├── vault-sparse-filter.ts           # 公開する sparse filter 集合と絞り込み指定の判定
 │   │   ├── vault-upload-pack-spawner.ts     # git upload-pack 子プロセス起動
 │   │   └── vault-maintenance-scheduler.ts  # squash + 周期 gc 自走スケジューラ
 │   ├── models/
@@ -219,6 +221,7 @@ vault-manager は `VaultUploadPackSpawner` が `git upload-pack` を spawn す�
 | 4.1–4.12 | per-user view 合成・キャッシュ・tree 正規化 | ComposeViewController, VaultViewComposer, VaultTreeNormalizer |
 | 5.1–5.5 | git smart HTTP lower-half | GitProxyController, VaultUploadPackSpawner |
 | 5.6–5.8 | ビュー外 object の要求の拒否・解析範囲と作業量の制限 | GitProxyController, VaultWantGuard, VaultPktLine |
+| 5.9–5.11 | 配信する partial clone の絞り込み指定の限定と公開 | GitProxyController, VaultSparseFilter, VaultUploadPackSpawner |
 | 6.1–6.7 | メンテナンス自走スケジューリング | VaultMaintenanceScheduler |
 | 7.1–7.5 | shared secret 認証 | SharedSecretAuth |
 | 8.1–8.4 | health endpoint | HealthController |
@@ -248,6 +251,7 @@ vault-manager は `VaultUploadPackSpawner` が `git upload-pack` を spawn す�
 | VaultUploadPackSpawner | Service | git upload-pack 子プロセス起動（検査済み本文の先頭を書き戻す） | 5.1–5.5 |
 | VaultPktLine | Service | want 区間の pkt-line 解析（純関数） | 5.6, 5.7 |
 | VaultWantGuard | Service | 本文先頭の peek + ビュー ref からの到達性確認 | 5.6–5.8 |
+| VaultSparseFilter | Service | 公開する sparse-checkout パターン集合・その object ID の算出・絞り込み指定の判定・repo への設置 | 5.9–5.11 |
 | VaultMaintenanceScheduler | Service | squash + gc 自走スケジューラ | 6.1–6.7 |
 | SharedSecretAuth | Middleware | Bearer token constant-time 検証 | 7.1–7.5 |
 
@@ -823,18 +827,42 @@ git binary が pack 生成・delta 圧縮・転送を担当するため、vault-
 
 `GitProxyController.uploadPack()` が upload-pack を起動する **前に** 実施する。
 
-1. **要求の先頭だけを解析する** — リクエスト本文の先頭は要求する object を並べた区間（want 区間）で、終わりは flush（`0000`）。この区間のみを読み取り、要求された object の ID を取り出す（`vault-pkt-line.ts` の `parseWantSection`、純関数）。flush が来ないまま 64 KiB を超えた場合と、protocol v0 の形式として解釈できない場合は拒否する。要件 5.3（pack をメモリに溜めず一定量のメモリで転送する）は、解析対象を先頭に限ることで保たれる
+1. **要求の先頭だけを解析する** — リクエスト本文の先頭は要求する object を並べた区間（want 区間）で、終わりは flush（`0000`）。この区間のみを読み取り、要求された object の ID と絞り込み指定（`filter` 行）を取り出す（`vault-pkt-line.ts` の `parseWantSection`、純関数）。flush が来ないまま 64 KiB を超えた場合と、protocol v0 の形式として解釈できない場合は拒否する。要件 5.3（pack をメモリに溜めず一定量のメモリで転送する）は、解析対象を先頭に限ることで保たれる
 2. **読み取った先頭を upload-pack に書き戻す** — 本文は upload-pack にそのまま全部渡す必要がある。`peekWantSection` はストリームを閉じずに `pause()` で止め、読み取った先頭は `spawnUploadPack({ stdinPrefix })` で書き戻してから残りを pipe する（`vault-want-guard.ts`）
-3. **ビュー ref からの到達性を確認する** — 要求 1 件ごとに `git merge-base --is-ancestor <要求された ID> refs/namespaces/<viewRef>/refs/heads/main` を実行し、非ゼロ終了なら拒否する（`findWantsOutsideView`）。commit でないもの・他ビューの commit・存在しない ID・ビュー ref 自体が無い場合のすべてが拒否側に落ちる（閉じる方向に倒れる）
-4. **作業量を縛る** — 同一 ID の重複を排除し、異なる ID が 64 件を超えるリクエストは 1 件も確認せず拒否し、残りは直列に確認する。要求 1 件ごとに git プロセスが必要なため、件数をクライアントが決められる状態を残さない
-5. **拒否の返し方** — HTTP 200 と pkt-line 1 本の `ERR vault: requested object is not available in this view`。upload-pack 自身が拒否時に返す形と同じなので、git クライアントは `fatal: remote error: ...` と表示する。「ビューに無い」と「そもそも存在しない」で文言を変えず、リポジトリの保持内容を応答から推測させない（要件 2.3）。拒否はログに記録する
+3. **絞り込み指定を判定する** — 公開したパターン集合を指す `sparse:oid` 以外が含まれていれば、到達性の確認に進まず拒否する（`vault-sparse-filter.ts` の `findUnsupportedFilters`、要件 5.9。「転送量を絞る手段」参照）
+4. **ビュー ref からの到達性を確認する** — 要求 1 件ごとに `git merge-base --is-ancestor <要求された ID> refs/namespaces/<viewRef>/refs/heads/main` を実行し、非ゼロ終了なら拒否する（`findWantsOutsideView`）。commit でないもの・他ビューの commit・存在しない ID・ビュー ref 自体が無い場合のすべてが拒否側に落ちる（閉じる方向に倒れる）
+5. **作業量を縛る** — 同一 ID の重複を排除し、異なる ID が 64 件を超えるリクエストは 1 件も確認せず拒否し、残りは直列に確認する。要求 1 件ごとに git プロセスが必要なため、件数をクライアントが決められる状態を残さない
+6. **拒否の返し方** — HTTP 200 と pkt-line 1 本の `ERR vault: requested object is not available in this view`。upload-pack 自身が拒否時に返す形と同じなので、git クライアントは `fatal: remote error: ...` と表示する。「ビューに無い」と「そもそも存在しない」で文言を変えず、リポジトリの保持内容を応答から推測させない（要件 2.3）。拒否はログに記録する
 
 ### この検査が拒否する正当な用途（既知の制約）
 
-- **partial clone の遅延取得** — `--filter=blob:none` を有効にしたクライアントはファイル単体を要求するため拒否される。`uploadpack.allowFilter` を有効にするなら本検査の拡張が前提（#11595）
+- **公開していない絞り込み指定** — `blob:none` などはファイルの中身を後から ID で名指しして取り直す方式なので拒否される（要件 5.9）。転送量を絞る用途は公開済みの `sparse:oid` で満たす（次節）
 - **protocol v2 の本文** — 現在 gateway はクライアントの `Git-Protocol` ヘッダを転送しないため upload-pack は v0 でしか動かず、本検査も v0 の形式のみ解釈する。v2 を通すなら本検査の拡張が前提
 
 いずれも Revalidation Triggers に登録済み。
+
+---
+
+## 転送量を絞る手段（要件 5.9–5.11）
+
+clone はビューに含まれる object を全量転送する。`git sparse-checkout` は作業ツリーに書き出すファイルを選ぶだけで転送量は変わらず、shallow clone が省ける履歴も squash（要件 6）で既に短い。残る手段は partial clone の絞り込み指定だけである。
+
+git の絞り込み指定のうち、**除外をサーバ側で適用して 1 リクエストで完結するのは `sparse:oid=<blob>` だけ**である。sparse-checkout 形式のパターンを書いた blob を指定する形式で、upload-pack がそのパターンで除外されるファイルの中身を pack に入れない。クライアントは最初の応答で checkout に必要なものを受け取り、以後 object を個別に要求しない。したがって要求は commit 1 件のままで、要件 5.6–5.8 の検査を変更なしで通る（実測: 本文 252 バイト・要求 1 件）。
+
+他の指定（`blob:none` / `blob:limit` / `tree:<n>` / `object:type` / `combine:`）はいずれもファイルの中身を後から ID で名指しして取り直す方式なので、要件 5.6 の検査に必ず拒否される。`uploadpack.allowFilter` は指定の種類ごとに分けられないため、受理してしまう分をこの検査で拒否する（要件 5.9）。拒否しない場合、`git clone --filter=blob:none` は clone だけ成功して checkout が object ごとのエラーの列とともに失敗し、作業ツリーが空のまま残る（実測）。
+
+### 公開するパターン集合
+
+| name | パターン | object ID |
+|---|---|---|
+| `exclude-user-pages` | `/*` と `!/user` | `ab678fd8055db49e954e61acfdb76add2a6291b9` |
+
+- object ID は内容から決まるため、パターンを変えると ID も変わる（Revalidation Trigger）。ID は計算して求め、repo の状態に依存させない（判定に使う集合が解決できない状態を作らない）
+- `refs/vault/sparse-filters/<name>` から参照させ、gc で消えないようにする（要件 5.10）。この ref は `refs/namespaces/` の外なので、どのビューにも広告されない
+- 公開した集合以外の `sparse:oid` は拒否する（要件 5.9）。任意の object を指定できると、返ってくるパスの集合からその object の内容を推し量る余地が生じる（実測で応答サイズに差が出た）
+- クライアントは同じパターンをローカルの sparse-checkout にも設定する必要がある。設定しないと checkout がサーバの除外したファイルを要求し、要件 5.6 の検査に拒否される
+
+削減幅の実測（20,000 ページ・うち 5,000 が `user/` 配下）: 6,269,214 → 4,815,099 バイト（23.2%）。詳細と他案との比較は [`research.md`](./research.md)。
 
 ## 参考情報
 

--- a/.kiro/specs/growi-vault-manager/design.md
+++ b/.kiro/specs/growi-vault-manager/design.md
@@ -572,7 +572,7 @@ interface VaultUploadPackSpawner {
 - `mode: 'advertise'` → `git upload-pack --stateless-rpc --advertise-refs <repoPath>`
 - `mode: 'rpc'` → `git upload-pack --stateless-rpc <repoPath>`（stdin: request body）
 - env: `GIT_NAMESPACE=<viewRef>`
-- `uploadpack.allowAnySHA1InWant=false`（git デフォルト）を維持する。ただしこれで防げるのは commit の直接取得だけなので、要求された object がビューからたどれるかの検査を upload-pack 起動前に GitProxyController が行う（要件 5.6・5.7、「追補 A」参照）
+- `uploadpack.allowAnySHA1InWant=false`（git デフォルト）を維持する。ただしこれで防げるのは commit の直接取得だけなので、要求された object がビューからたどれるかの検査を upload-pack 起動前に GitProxyController が行う（要件 5.6・5.7、本書「ビュー外 object の要求の拒否」参照）
 - クライアント切断時・タイムアウト時はプロセスを kill
 
 ---
@@ -777,7 +777,7 @@ refs/namespaces/anonymous-view/refs/heads/main          # 匿名 view ref
 - **single security perimeter**: vault-manager は外部から到達不可（k8s NetworkPolicy で apps/app からのみ許可）。Ingress には登録しない
 - **shared secret**: env var only（`VAULT_MANAGER_INTERNAL_SECRET`）、DB に保存しない。k8s Secret で両 pod に注入
 - **constant-time 比較**: `crypto.timingSafeEqual` で timing attack を防止（要件 7.5）
-- **ビュー外 object の取得禁止**: `uploadpack.allowAnySHA1InWant=false`（git デフォルト）だけでは commit の直接取得しか防げない（ファイルの中身とディレクトリ一覧はビューを越えて取得できた。git 2.49.0 で実測）。そのため GitProxyController が upload-pack 起動前にクライアントの要求を検査し、ビュー ref からたどれない object の要求を拒否する（要件 5.6・5.7、「追補 A」）
+- **ビュー外 object の取得禁止**: `uploadpack.allowAnySHA1InWant=false`（git デフォルト）だけでは commit の直接取得しか防げない（ファイルの中身とディレクトリ一覧はビューを越えて取得できた。git 2.49.0 で実測）。そのため GitProxyController が upload-pack 起動前にクライアントの要求を検査し、ビュー ref からたどれない object の要求を拒否する（要件 5.6・5.7、本書「ビュー外 object の要求の拒否」）
 - **pages コレクション非アクセス**: vault-manager は `revisions` のみ ID 指定 body lookup（namespace 判定は apps/app に集約済み）
 - **情報漏洩防止**: namespace 集合は apps/app が ACL 評価済みで渡す。vault-manager は受け取った namespace をそのまま処理するのみ
 
@@ -838,7 +838,7 @@ git binary が pack 生成・delta 圧縮・転送を担当するため、vault-
 
 ## 参考情報
 
-- [git namespaces](https://git-scm.com/docs/gitnamespaces) — `GIT_NAMESPACE` 環境変数の仕様。読み取りのアクセス制御には使えないことも明記されている（「追補 A」参照）
+- [git namespaces](https://git-scm.com/docs/gitnamespaces) — `GIT_NAMESPACE` 環境変数の仕様。読み取りのアクセス制御には使えないことも明記されている（[research.md](./research.md) 参照）
 - [git smart HTTP protocol](https://git-scm.com/docs/http-protocol) — upload-pack wire format
 - [isomorphic-git GitHub](https://github.com/isomorphic-git/isomorphic-git) — v1.37.x API リファレンス
 - [MongoDB change streams](https://www.mongodb.com/docs/manual/changeStreams/) — resume token の挙動

--- a/.kiro/specs/growi-vault-manager/requirements.md
+++ b/.kiro/specs/growi-vault-manager/requirements.md
@@ -97,6 +97,11 @@
 6. `POST /internal/git/git-upload-pack` を受信したとき、GitProxyController は upload-pack を起動する前にクライアントが要求した object の ID を取り出し、`refs/namespaces/<viewRef>/refs/heads/main` からたどれない ID が 1 つでも含まれる場合は、リクエストを upload-pack に渡さず pkt-line 1 本の `ERR` を返して拒否し、拒否をログに記録する。「ビューに無い」場合と「そもそも存在しない」場合で応答の文言は変えない
 7. 上記 6 の解析はリクエスト本文の先頭（want 区間）のみを対象とし、読み取った先頭は upload-pack の標準入力にそのまま書き戻す。want 区間が終わらないまま 64 KiB を超えた場合、または protocol v0 の形式として解釈できない場合、GitProxyController はリクエストを拒否する
 8. 上記 6 の確認を行うとき、GitProxyController は同一 ID の重複を排除し、異なる ID が 64 件を超えるリクエストは確認せずに拒否し、残った確認は直列に実行する。これによりクライアントが要求件数を増やして vault-manager の処理量を増幅させられないようにする
+9. `POST /internal/git/git-upload-pack` を受信したとき、GitProxyController は want 区間から partial clone の絞り込み指定（`filter` 行）を取り出し、サーバが公開した sparse-checkout パターン集合を指す `sparse:oid=<ID>` 以外の指定が 1 つでも含まれる場合は、リクエストを upload-pack に渡さず pkt-line 1 本の `ERR` で拒否し、拒否をログに記録する。この応答には、対応している指定の形を含める
+10. vault-manager が起動したとき、公開する sparse-checkout パターン集合を bare repo の blob として書き込み、`refs/vault/sparse-filters/<name>` から参照させる。これにより gc（受け入れ基準 6.4）で削除されず、公開した object の ID が常に解決できる。この ref は `refs/namespaces/` の外に置き、どのビューにも広告されない
+11. git upload-pack を spawn するとき、GitProxyController は `uploadpack.allowFilter=true` を設定し、`uploadpack.allowReachableSHA1InWant` は設定しない（git 既定の false を維持する）。これによりクライアントが object を ID で名指しして取得する経路は開かず、絞り込みはサーバ側で完結する方式に限られる
+
+> **注記（2026-07-29）**: 受け入れ基準 9–11 は #11595（clone の転送量を絞る手段が README 通りに動かない）への対応。git の絞り込み指定のうち、除外をサーバ側で適用して 1 リクエストで完結するのは `sparse:oid` だけで、他（`blob:none` 等）はクライアントがファイルの中身を後から ID で名指しして取り直すため、上記 6 の検査と両立しない。実測と案の比較は [`research.md`](./research.md)（Research Log と Decision D・E）、設計は [`design.md`](./design.md) の「転送量を絞る手段」に記録する。
 
 > **注記（2026-07-28）**: 上記 4 の保証は、実際には commit にしか効いていない。ファイル 1 個の中身とディレクトリ 1 個分の一覧は、ビューを越えて取得できる（git 2.49.0 で実測）。承認済みの受け入れ基準 4 はそのまま残し、これを補う検査として 6–8 を追加した。実測結果と設計判断は [`research.md`](./research.md)、検査の位置と内容および残る制約は [`design.md`](./design.md) の「ビュー外 object の要求の拒否」に記録する。
 

--- a/.kiro/specs/growi-vault-manager/research.md
+++ b/.kiro/specs/growi-vault-manager/research.md
@@ -6,6 +6,8 @@
 
 実装後の調査で、要件 5.4 が前提にしていた「`uploadpack.allowAnySHA1InWant=false`（git の既定値）を維持すればビューに広告していない object は取得できない」が **commit にしか当てはまらない**ことが実測で判明した。umbrella の Decision 3（namespace モデル採用）が「namespace 分離で per-user の可視範囲を表現する」としていた前提のうち、**読み取りの遮断は git 側が提供していない**部分に相当する。対策として、upload-pack を起動する前に要求された object を検査する層を GitProxyController に置いた（要件 5.6–5.8）。
 
+あわせて #11595（clone の転送量を絞る手段が README 通りに動かない）の残件として、転送量を絞る方式を決めた。git の絞り込み指定のうち `sparse:oid` だけが除外をサーバ側で適用して 1 リクエストで完結するため、上記の検査を無変更で通る。他の指定は object を ID で名指しする経路を必要とするため通らず、`uploadpack.allowFilter` が種類ごとに分けられないことから、受理してしまう分は同じ検査で拒否する（要件 5.9–5.11）。
+
 ---
 
 ## Research Log
@@ -66,6 +68,31 @@
 | 異なる ID を 1,310 件 | 0 ms（検査せず拒否） | 0 |
 | 異なる ID を 64 件（上限ぎりぎり） | 141 ms | 1 |
 
+### 転送量を絞る手段 — git の絞り込み指定の比較（2026-07-29 実測 / git 2.49.0）
+
+**調べた動機**: #11595 の残件。README が案内していた 2 つの手段（`--filter=blob:none` と cone mode の sparse-checkout）がどちらも動かず、長く運用した wiki の clone を小さくする手段が実質存在しなかった。
+
+**方法**: `wiki/` 配下 15,000 ページ ＋ `user/` 配下 5,000 ページを持つビュー（squash 後と同じ親なし commit 1 個）の bare repo を作り、GitProxyController と同じ形（`GIT_NAMESPACE` を設定した `git upload-pack --stateless-rpc`）で起動する最小の HTTP サーバに実際の `git clone` を当てて、サーバが書き出したバイト数・クライアントが送った本文・要求された object の件数を数えた。
+
+| 手段 | HTTP のやりとり | クライアントが送る本文 | 要求 object 件数 | 転送量 | 削減 |
+|---|---|---|---|---|---|
+| 通常の clone | 1 回 | 183 B | 1 | 6,269,214 | — |
+| `--filter=blob:none` ＋ sparse-checkout | 2 回 | 210 B → **359,260 B（圧縮済み）** | 1 → **15,000** | 4,815,233 | 23.2% |
+| **`--filter=sparse:oid=<blob>` ＋ sparse-checkout** | **1 回** | **252 B** | **1** | 4,815,099 | 23.2% |
+| `user/` を外したビュー用ブランチを配る（採用せず） | 1 回 | 195 B | 1 | 4,690,525 | 25.2% |
+| `--depth=1` | 1 回 | — | — | 削減なし | — |
+
+**分かったこと 3 点**:
+
+1. **`blob:none` の 2 回目のリクエストは圧縮されて届く。** git クライアントは HTTP リクエスト本文が大きいと `Content-Encoding: gzip` を付ける（750,160 B → 359,260 B）。マージ済みの `parseWantSection` に実物を通すと、圧縮された形は `malformed pkt-line length prefix`、展開した形も `want section exceeds the size a git client would send`（64 KiB 上限）で拒否される。`upload-pack` 自身も圧縮された本文は読めず `fatal: protocol error: bad line length character` で落ちるため、通すなら proxy 側での展開が前提になる。
+2. **`sparse:oid` は遅延取得を発生させない。** 除外がサーバ側で適用されるため、クライアントは 1 回目の応答で checkout に必要なものを全部受け取る。要求は commit 1 件で、マージ済みの検査をそのまま通る（実物の本文 252 バイトを `parseWantSection` に通して `complete` / want 1 件を確認）。必要なサーバ設定は `uploadpack.allowFilter=true` のみで、`allowReachableSHA1InWant` は不要。
+3. **`allowFilter` を有効にすると `blob:none` の失敗の仕方が悪化する。** 有効化前は `warning: filtering not recognized by server, ignoring` で全量転送になり、clone は使える状態で終わる。有効化後（かつ object を ID で名指しする経路を許さない状態）では `error: Server does not allow request for unadvertised object <ID>` が数千行続いたのち `warning: Clone succeeded, but checkout failed.` で終了コード 128・作業ツリー 0 件になる。
+
+**副産物 2 点**:
+
+- `--filter=sparse:oid` に他人のページの blob を指定すると応答サイズが変わる（正規のパターン 4,815,099 B / 他人のページを指定 488,217 B / 何にも一致しないパターン 488,167 B）。object の ID を知っている相手に、その内容についてのわずかな手がかりを与える。
+- `sparse:path`（サーバ上のパスをクライアントが指定する形式）は git 側で削除済み（`fatal: sparse:path filters support has been dropped`）。同じ理由（クライアントがサーバ上の任意のファイルを名指しできる）による。
+
 ---
 
 ## Design Decisions
@@ -103,6 +130,28 @@
 - **Rationale**: ビューが広告するのは commit 1 個（と HEAD）で、full clone / shallow clone / 差分 fetch はいずれも実測で要求 1 件。64 は実用の 30 倍以上の余裕。直列にすれば同時に走る git プロセスは 1 個に収まり、並列度の調整パラメータも増えない
 - **Trade-offs**: 上限内の最悪ケース（異なる ID 64 件）は直列で 141 ms かかる。正当な利用では起こらない形
 
+### Decision D: 転送量削減は `sparse:oid` で行う
+
+- **Context**: #11595。転送量を絞る手段が実質存在しない状態で、方式の選択が未決だった
+- **Alternatives Considered**:
+  1. `blob:none` を通す — 検査に 3 つの拡張が必要（本文の展開、want 区間 64 KiB と異なる ID 64 件の上限引き上げ、到達性の確認を「そのビューから使われている object を全列挙して照合する」形へ差し替え）。除外パスをクライアントが自由に選べる利点はあるが、マージ直後のセキュリティ経路に手を入れることになり、要件 5.3 の「一定量のメモリ」がビュー規模に比例する形（1 リクエスト 1 MB 前後）に変わる
+  2. **`sparse:oid` を通す** — サーバ設定 1 行（`allowFilter`）とパターン集合の公開のみ。要件 5.6–5.8 の検査は無変更で通る
+  3. `user/` を外したビュー用ブランチを配る — 削減幅は最大（25.2%）でクライアントの手順も最短（`--single-branch --branch <名前>`）だが、git の標準の仕組みではなく VaultViewComposer にブランチ生成を足す必要があり、検査も「ビュー内のどのブランチからたどれるか」に広げる必要がある
+  4. 何もせず README に非対応と明記する（#11605 の当初案）
+- **Selected Approach**: 案 2
+- **Rationale**: git の標準の仕組みのまま成立し、セキュリティ経路（要件 5.6–5.8）に一切手を入れずに済むことを実物のリクエスト本文で確認できた。削減幅は案 3 と 2 ポイント差で、案 1 と同等
+- **Trade-offs**: 除外できるのはサーバが公開したパターン集合だけ（現在 1 つ）。filter を付けた clone は partial clone として記録され、除外したページを後から取得することはできない（`allowReachableSHA1InWant` を有効にしないため、クライアントの手前で止まる）
+
+### Decision E: 公開していない絞り込み指定は clone の時点で拒否する
+
+- **Context**: `uploadpack.allowFilter` は指定の種類ごとに分けられないため、有効にすると `blob:none` も受理される
+- **Alternatives Considered**:
+  1. 放置する — clone は成功し checkout が失敗、作業ツリーは空（Research Log の 3 点目）。有効化前の「無視されるが動く」より悪化する
+  2. **want 区間の `filter` 行を検査し、公開した `sparse:oid` 以外を拒否する**
+- **Selected Approach**: 案 2。既存の検査と同じ場所（upload-pack 起動前）で判定し、pkt-line 1 本の `ERR` に対応している指定の形を書いて返す
+- **Rationale**: clone の時点で 1 行で止まり、次に何をすればよいかが分かる。同じ判定が、公開していない object を `sparse:oid` に指定して応答サイズの差から内容を推し量る余地も塞ぐ
+- **Trade-offs**: 応答の文言がサーバの対応状況を明かす。ただしこれはリポジトリの保持内容ではないため要件 2.3 には触れない
+
 ---
 
 ## 実装知見（Post-Implementation Discoveries）
@@ -124,7 +173,9 @@ upload-pack 自身が拒否時に返す形と同じなので、git クライア�
 | Risk | Mitigation |
 |---|---|
 | 検査を通さず `spawnUploadPack` を 'rpc' で呼ぶ実装が将来追加される | spawner の冒頭コメントで検査必須を明示。要件 5.6 として受け入れ基準化 |
-| `uploadpack.allowFilter` を有効化して partial clone を通そうとする | design.md の Revalidation Triggers に登録。検査の拡張が前提であることを #11595 側にも記録 |
+| `uploadpack.allowReachableSHA1InWant` を有効化して object を ID で名指しできるようにする | design.md の Revalidation Triggers に登録。要件 5.6 の検査を blob / tree の到達性まで拡張することが前提（Decision D の案 1） |
+| 公開する sparse filter のパターンを変えて README を直し忘れる | パターンから object ID を計算する単体テストが README を突き合わせる（`vault-sparse-filter.spec.ts`） |
+| gc が公開した filter の blob を消し、README の clone コマンドが解決できなくなる | `refs/vault/sparse-filters/<name>` から参照させ、起動ごとに再設置する。ref 経由の blob が `gc --prune=now` を越えて残ることを単体テストで固定 |
 | protocol v2 を通すと本文が解釈できず全拒否になる | 同上。gateway が `Git-Protocol` を転送しない現状が前提条件であることを明記 |
 | git の内部挙動（commit の到達性判定）に依存している | 到達性判定は自前の `merge-base` で行い、git 側の暗黙の挙動には依存しない。他ビューの commit 拒否は結合試験で固定 |
 

--- a/.kiro/specs/growi-vault-manager/spec.json
+++ b/.kiro/specs/growi-vault-manager/spec.json
@@ -1,11 +1,11 @@
 {
   "feature_name": "growi-vault-manager",
   "created_at": "2026-05-07T00:00:00.000Z",
-  "updated_at": "2026-07-28T18:54:00.000Z",
+  "updated_at": "2026-07-29T09:00:00.000Z",
   "language": "ja",
   "phase": "implementation-complete",
   "cleaned_up_at": "2026-07-28T18:54:00.000Z",
-  "revision_note": "2026-07-28: 実装後の調査で要件 5.4 の前提（uploadpack.allowAnySHA1InWant=false でビュー外 OID を取得できない）が commit にしか当てはまらないと実測判明。ファイルの中身（blob）とディレクトリの一覧（tree）はビューを越えて取得できた（git 2.49.0）。gitnamespaces(7) が namespace は読み取りのアクセス制御に使えないと明記しており git の設定では解決できないため、GitProxyController が upload-pack 起動前に要求 object のビュー ref からの到達性を検査する層を追加（要件 5.6–5.8、PR #11604）。cc-sdd の流儀に合わせ、調査結果・3 案比較・性能実測・実装知見は新設した research.md に、検査の位置と内容および既知の制約は design.md に、受け入れ基準は requirements.md に分離。承認済みの受け入れ基準 5.4 は据え置き。umbrella spec（growi-vault）側は Decision 3 に Follow-up 1 項と Risks に 1 行のみ追記。前回の revision_note（2026-06-05 の integ 並行実行 timeout の調査と per-worker 分離による解決）は解決済みのため要約: integ テストは setupFile で worker ごとに独立 DB / 独立 bare repo / 独立 port の vault-manager を in-process 起動する方式に変更済み。",
+  "revision_note": "2026-07-29: #11595（clone の転送量を絞る手段が README 通りに動かない）の残件を解決。git の絞り込み指定のうち sparse:oid だけが除外をサーバ側で適用して 1 リクエストで完結し、要件 5.6–5.8 の検査を無変更で通ることを実測で確認（20,000 ページのビューで 23.2% 削減、要求は commit 1 件・本文 252 バイト）。uploadpack.allowFilter を有効化し、公開する sparse-checkout パターン集合を refs/vault/sparse-filters/<name> から参照させ、公開していない指定は upload-pack 起動前に拒否する（要件 5.9–5.11、Phase 21）。allowFilter は指定の種類ごとに分けられないため、拒否しないと blob:none が「clone だけ成功して checkout が空のまま失敗する」状態になる（実測）。allowReachableSHA1InWant は据え置き（有効化は Revalidation Trigger）。あわせて #11604 の spec 整頓で参照先が切れていた「追補 A」8 箇所を修正。 / 2026-07-28: 実装後の調査で要件 5.4 の前提（uploadpack.allowAnySHA1InWant=false でビュー外 OID を取得できない）が commit にしか当てはまらないと実測判明。ファイルの中身（blob）とディレクトリの一覧（tree）はビューを越えて取得できた（git 2.49.0）。gitnamespaces(7) が namespace は読み取りのアクセス制御に使えないと明記しており git の設定では解決できないため、GitProxyController が upload-pack 起動前に要求 object のビュー ref からの到達性を検査する層を追加（要件 5.6–5.8、PR #11604）。cc-sdd の流儀に合わせ、調査結果・3 案比較・性能実測・実装知見は新設した research.md に、検査の位置と内容および既知の制約は design.md に、受け入れ基準は requirements.md に分離。承認済みの受け入れ基準 5.4 は据え置き。umbrella spec（growi-vault）側は Decision 3 に Follow-up 1 項と Risks に 1 行のみ追記。前回の revision_note（2026-06-05 の integ 並行実行 timeout の調査と per-worker 分離による解決）は解決済みのため要約: integ テストは setupFile で worker ごとに独立 DB / 独立 bare repo / 独立 port の vault-manager を in-process 起動する方式に変更済み。",
   "approvals": {
     "requirements": {
       "generated": true,

--- a/.kiro/specs/growi-vault-manager/tasks.md
+++ b/.kiro/specs/growi-vault-manager/tasks.md
@@ -376,6 +376,41 @@
 
 ---
 
+- [x] 21. 転送量を絞る手段（**要件 5.9–5.11 の追加** — #11595）
+
+  clone はビューに含まれる object を全量転送し、sparse-checkout も shallow clone も転送量を実質減らせない。git の絞り込み指定のうち、除外をサーバ側で適用して 1 リクエストで完結するのは `sparse:oid` だけで、これは要件 5.6–5.8 の検査を無変更で通る。他の指定は object を ID で名指しする経路を必要とするため必ず拒否されるが、`uploadpack.allowFilter` を種類ごとに分けられない以上、受理してしまう分は明示的に拒否しないと「clone だけ成功して checkout が失敗する」状態になる。実測と案の比較は research.md、設計は design.md「転送量を絞る手段」を参照。
+
+- [x] 21.1 (P) 公開するパターン集合と絞り込み指定の判定を実装（TDD）
+  - パターン集合を単一の宣言として持ち、object ID は内容から計算する（repo の状態に依存させない）。判定は公開した `sparse:oid` 以外をすべて拒否側に落とす。README に載せた ID との突き合わせをドリフト検出テストで固定する。
+  - _Requirements: 5.9, 5.10_
+  - _Boundary: apps/growi-vault-manager/src/services/vault-sparse-filter.ts, vault-sparse-filter.spec.ts_
+
+- [x] 21.2 want 区間の解析に `filter` 行の収集を足す（TDD）
+  - `want` の capability 列に現れる `filter` という語（能力の宣言）と、`filter <指定>` 行（実際の要求）を混同しないこと。本文は一切書き換えずに upload-pack へ渡す性質を保つ。
+  - _Depends: 21.1_
+  - _Requirements: 5.9_
+  - _Boundary: apps/growi-vault-manager/src/services/vault-pkt-line.ts, vault-want-guard.ts, および各 spec_
+
+- [x] 21.3 GitProxyController に判定を配線し、`allowFilter` を有効化して起動時にパターン集合を設置
+  - 判定は到達性の確認より前に置く（安く済み、`blob:none` を渡した利用者に最も有用な文言を返せる）。拒否応答には対応している指定の形を含める。パターン集合は `refs/vault/sparse-filters/<name>` から参照させ、起動ごとに再設置する。
+  - _Depends: 21.2_
+  - _Requirements: 5.9, 5.10, 5.11_
+  - _Boundary: apps/growi-vault-manager/src/controllers/git-proxy-controller.ts, vault-upload-pack-spawner.ts, server-runtime.ts_
+
+- [x] 21.4 clone の end-to-end を結合テストで固定
+  - `--filter=sparse:oid=<公開 ID>` ＋ sparse-checkout で `user/` 配下が作業ツリーに現れず、その中身が clone の object 置き場にも存在しないこと（＝転送されていないこと）を確認する。`--filter=blob:none` が clone の時点で拒否されることも同時に固定する。
+  - _Depends: 21.3_
+  - _Requirements: 5.9_
+  - _Boundary: apps/growi-vault-manager/src/__tests__/clone-e2e.integ.ts_
+
+- [x] 21.5 README を実際に動く手順に直す
+  - `--no-cone` ＋ `--stdin` の sparse-checkout 手順、`--filter=sparse:oid=<公開 ID>` の手順、filter 付き clone の以後の制約（除外したページは取得できない）、他の指定が拒否されること、`--depth=1` の削減幅が小さい理由を書く。
+  - _Depends: 21.4_
+  - _Requirements: 5.9, 5.11_
+  - _Boundary: apps/growi-vault-manager/README.md_
+
+---
+
 ## Implementation Notes
 
 実装を経て判明した、refactor 時に押さえるべき設計上の課題・教訓を記録する。
@@ -451,6 +486,10 @@ want の検査には本文の先頭が必要だが、本文は upload-pack に�
 ### 検査の作業量はクライアントに決めさせない
 
 要求 1 件ごとに git プロセスが必要なため、`Promise.all` で素朴に並列化すると 1 リクエストで大量のプロセスを起動できる（want 区間 64 KiB に want 行は約 1,310 行入り、実測で同時 1,310 プロセス・1.3 秒）。重複 ID の排除・異なる ID 64 件の上限・直列実行の 3 点で縛っている。外部が件数を決められる入力に対してプロセスを起動する実装を足すときは同じ縛りを検討すること。
+
+### 絞り込み指定は種類ごとに有効化できない
+
+`uploadpack.allowFilter` は「絞り込みに対応している」という 1 つの合図で、指定の種類を選べない。したがって「1 種類だけ対応する」は、サーバ設定ではなく**リクエストの検査**で実現するしかない。有効化しただけの状態は、対応していない指定を渡した利用者にとって有効化前より悪い（clone は成功し checkout が空のまま失敗する）ので、有効化と検査は必ず同じ変更で入れる。
 
 ### Test mock の partial mock パターン採用
 

--- a/apps/growi-vault-manager/README.md
+++ b/apps/growi-vault-manager/README.md
@@ -55,28 +55,57 @@ These rules are versioned (v1) and are **immutable after the first release**.
 
 ---
 
-## Excluding `/user` pages with git sparse-checkout
+## Excluding `/user` pages from a clone
 
-To clone a vault while excluding all personal pages stored under `user/`, use git sparse-checkout in **non-cone** mode:
+To clone a vault without the personal pages stored under `user/`:
 
 ```bash
-git clone --no-checkout <url> my-growi-vault
+git clone --filter=sparse:oid=ab678fd8055db49e954e61acfdb76add2a6291b9 --no-checkout <url> my-growi-vault
 cd my-growi-vault
 git sparse-checkout init --no-cone
 printf '/*\n!/user\n' | git sparse-checkout set --stdin
 git checkout HEAD
 ```
 
-Two details are easy to get wrong:
+Both halves are needed, and they do different jobs:
+
+- **`--filter=sparse:oid=<object name>` is what shrinks the transfer.** It names a blob in the repository holding the pattern set `/*` and `!/user`, and the server applies those patterns before building the pack — the excluded page bodies are never sent. Measured on a 20,000-page view with a quarter of the pages under `user/`: 6.3 MB → 4.8 MB, in a single request.
+- **`git sparse-checkout` decides what lands in your working tree.** On its own it transfers nothing less; combined with the filter it also has to be set to the *same* patterns, so your checkout never asks for a page body the server left out.
+
+The object name is fixed: it is the content address of those exact patterns, so it only changes if the published pattern set does. The server keeps the blob anchored to a ref of its own so garbage collection cannot remove it.
+
+Two details of the sparse-checkout call are easy to get wrong:
 
 - **`--no-cone` is required.** Cone mode cannot express an exclusion, so `git sparse-checkout set '/*' '!/user'` fails with `fatal: specify directories rather than patterns (no leading slash)`, and the `git checkout` that follows then leaves you with an *empty* working tree rather than one without `user/`.
 - **Pass the patterns on stdin.** On Git Bash (MSYS) an argument that looks like an absolute path is rewritten before git ever sees it, which mangles `!/user`. Reading from `--stdin` sidesteps that, and also avoids per-shell quoting differences.
 
-> **Important**: sparse-checkout only controls which files are materialized in your **working tree**. Every object in your view is still transferred from the server, so the clone itself is not any smaller.
->
-> A partial-clone filter (`--filter=blob:none`) is what would shrink the transfer, but **this server does not enable it**: `git clone --filter=blob:none` just prints `warning: filtering not recognized by server, ignoring` and fetches everything. Passing the flag anyway is worse than useless — git still records `remote.origin.promisor=true` and `remote.origin.partialclonefilter=blob:none` locally, leaving the clone marked as a partial clone that the server will not serve as one. Whether to enable the filter is an open decision; see "追補 A" in `.kiro/specs/growi-vault-manager/design.md`.
->
-> `--depth=1` (shallow clone) does work, but saves little: each view's history is squashed to a single parentless commit whenever it exceeds `VAULT_SQUASH_COMMIT_THRESHOLD` commits (default 1000) or `VAULT_SQUASH_AGE_HOURS` (default 1), so there is not much history to omit in the first place. What dominates the transfer is the current snapshot, not the history.
+### What the filtered clone can and cannot do afterwards
+
+The clone is a partial clone: git records `remote.origin.promisor=true` and `remote.origin.partialclonefilter` locally. Ordinary work inside it (`git status`, `git log`, `git pull`, grepping the checked-out files) behaves normally.
+
+What it cannot do is obtain the excluded pages later. The server never lets a client ask for an object by name, so a command that needs one of those bodies stops at:
+
+```console
+error: Server does not allow request for unadvertised object <object name>
+fatal: could not fetch <object name> from promisor remote
+```
+
+If you need the personal pages, take a fresh clone without the filter.
+
+### Other filters are refused
+
+`sparse:oid` with a published pattern set is the only filter this server serves. Anything else — `blob:none`, `blob:limit`, `tree:<n>`, `object:type`, `combine:`, or a `sparse:oid` naming some other object — is refused when the clone starts:
+
+```console
+$ git clone --filter=blob:none <url> my-growi-vault
+fatal: remote error: vault: unsupported partial-clone filter; this server serves only --filter=sparse:oid=<published spec> (see the vault-manager README)
+```
+
+Those filters all work the same way: the server sends a pack with the file bodies left out, and the client then fetches each missing object **by name** as it needs it. Naming objects is exactly what a client is not allowed to do here (a view scopes which refs it can see, not which objects exist), so such a clone would break at its first checkout rather than at the clone. It is refused up front instead.
+
+### `--depth=1`
+
+A shallow clone works but saves little: each view's history is squashed to a single parentless commit whenever it exceeds `VAULT_SQUASH_COMMIT_THRESHOLD` commits (default 1000) or `VAULT_SQUASH_AGE_HOURS` (default 1), so there is not much history to omit in the first place. What dominates the transfer is the current snapshot, not the history.
 
 ---
 
@@ -89,7 +118,9 @@ The following items are **not supported** in the current MVP:
 - **Per-page metadata** — comments, likes, bookmarks, tags, and similar social/annotation metadata are not exported.
 - **Revision history before feature activation** — only revisions created after the vault feature is enabled are captured; pre-existing history is not back-filled.
 - **Drafts and unpublished pages** — only published pages are exported to the vault.
-- **Partial clone (`--filter=...`)** — the server does not advertise the filter capability, so a clone always transfers every object in your view. `git sparse-checkout` still limits what is written to your working tree (see above), but it does not reduce the transfer.
+- **Partial-clone filters other than the published `sparse:oid` specs** — `blob:none`, `blob:limit`, `tree:<n>`, `object:type` and `combine:` are refused when the clone starts, because each of them leaves the client to fetch objects by name afterwards and the server does not serve those requests (see above).
+- **Client-chosen exclusion patterns** — the transfer can only be narrowed by a pattern set the server publishes; there is currently one (`user/` excluded).
+- **Fetching an excluded page into a filtered clone** — the server never serves a request for an object by name, so the pages a filter left out cannot be obtained later. Take a fresh clone without the filter instead.
 
 ### Known limitation: long paths on Windows
 

--- a/apps/growi-vault-manager/README.md
+++ b/apps/growi-vault-manager/README.md
@@ -57,17 +57,26 @@ These rules are versioned (v1) and are **immutable after the first release**.
 
 ## Excluding `/user` pages with git sparse-checkout
 
-To clone a vault while excluding all personal pages stored under `user/`, use git sparse-checkout:
+To clone a vault while excluding all personal pages stored under `user/`, use git sparse-checkout in **non-cone** mode:
 
 ```bash
 git clone --no-checkout <url> my-growi-vault
 cd my-growi-vault
-git sparse-checkout init --cone
-git sparse-checkout set '/*' '!/user'
+git sparse-checkout init --no-cone
+printf '/*\n!/user\n' | git sparse-checkout set --stdin
 git checkout HEAD
 ```
 
-> **Important**: sparse-checkout only controls which files are materialized in your **working tree**. It does not affect the objects transferred from the server — the full history is still fetched. To limit server-side object delivery, a partial-clone filter (e.g. `--filter=blob:none`) is needed in addition to sparse-checkout.
+Two details are easy to get wrong:
+
+- **`--no-cone` is required.** Cone mode cannot express an exclusion, so `git sparse-checkout set '/*' '!/user'` fails with `fatal: specify directories rather than patterns (no leading slash)`, and the `git checkout` that follows then leaves you with an *empty* working tree rather than one without `user/`.
+- **Pass the patterns on stdin.** On Git Bash (MSYS) an argument that looks like an absolute path is rewritten before git ever sees it, which mangles `!/user`. Reading from `--stdin` sidesteps that, and also avoids per-shell quoting differences.
+
+> **Important**: sparse-checkout only controls which files are materialized in your **working tree**. Every object in your view is still transferred from the server, so the clone itself is not any smaller.
+>
+> A partial-clone filter (`--filter=blob:none`) is what would shrink the transfer, but **this server does not enable it**: `git clone --filter=blob:none` just prints `warning: filtering not recognized by server, ignoring` and fetches everything. Passing the flag anyway is worse than useless — git still records `remote.origin.promisor=true` and `remote.origin.partialclonefilter=blob:none` locally, leaving the clone marked as a partial clone that the server will not serve as one. Whether to enable the filter is an open decision; see "追補 A" in `.kiro/specs/growi-vault-manager/design.md`.
+>
+> `--depth=1` (shallow clone) does work, but saves little: each view's history is squashed to a single parentless commit whenever it exceeds `VAULT_SQUASH_COMMIT_THRESHOLD` commits (default 1000) or `VAULT_SQUASH_AGE_HOURS` (default 1), so there is not much history to omit in the first place. What dominates the transfer is the current snapshot, not the history.
 
 ---
 
@@ -80,6 +89,7 @@ The following items are **not supported** in the current MVP:
 - **Per-page metadata** — comments, likes, bookmarks, tags, and similar social/annotation metadata are not exported.
 - **Revision history before feature activation** — only revisions created after the vault feature is enabled are captured; pre-existing history is not back-filled.
 - **Drafts and unpublished pages** — only published pages are exported to the vault.
+- **Partial clone (`--filter=...`)** — the server does not advertise the filter capability, so a clone always transfers every object in your view. `git sparse-checkout` still limits what is written to your working tree (see above), but it does not reduce the transfer.
 
 ### Known limitation: long paths on Windows
 

--- a/apps/growi-vault-manager/src/__tests__/clone-e2e.integ.ts
+++ b/apps/growi-vault-manager/src/__tests__/clone-e2e.integ.ts
@@ -465,7 +465,7 @@ async function callComposeView(
     // -------------------------------------------------------------------------
 
     // -------------------------------------------------------------------------
-    // Objects outside the requester's view must not be served (req 5.4 / 追補 A)
+    // Objects outside the requester's view must not be served (req 5.4 / 5.6)
     // -------------------------------------------------------------------------
 
     describe('Objects outside the view (req 5.4)', () => {

--- a/apps/growi-vault-manager/src/__tests__/clone-e2e.integ.ts
+++ b/apps/growi-vault-manager/src/__tests__/clone-e2e.integ.ts
@@ -11,13 +11,19 @@
  *   pnpm vitest run clone-e2e.integ
  */
 
-import { execFile } from 'node:child_process';
+import { execFile, execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  PUBLISHED_SPARSE_FILTERS,
+  sparseFilterOid,
+  sparseFilterRefPath,
+} from '../services/vault-sparse-filter.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -828,6 +834,178 @@ async function callComposeView(
           '--porcelain',
         ]);
         expect(stdout.trim()).toBe('');
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // Partial clone: only a published sparse filter is served (req 5.9, 5.10)
+    // -------------------------------------------------------------------------
+
+    describe('Partial clone with a published sparse filter', () => {
+      const spec = PUBLISHED_SPARSE_FILTERS[0];
+      if (spec == null) {
+        throw new Error('no sparse filter is published');
+      }
+      const publishedOid = sparseFilterOid(spec);
+
+      let sparseCloneDir: string;
+
+      beforeAll(async () => {
+        await connectMongo();
+        sparseCloneDir = await fs.promises.mkdtemp(
+          path.join(os.tmpdir(), 'vault-sparse-clone-'),
+        );
+      });
+
+      afterAll(async () => {
+        await disconnectMongo();
+        if (sparseCloneDir != null) {
+          await fs.promises.rm(sparseCloneDir, {
+            recursive: true,
+            force: true,
+          });
+        }
+      });
+
+      /** Runs git against the bare repository the manager maintains. */
+      const gitInRepo = async (...args: string[]): Promise<string> => {
+        const repoPath = process.env.VAULT_REPO_PATH;
+        if (repoPath == null || !fs.existsSync(repoPath)) {
+          throw new Error('VAULT_REPO_PATH is not a local directory');
+        }
+        const { stdout } = await execFileAsync('git', [
+          '-C',
+          repoPath,
+          ...args,
+        ]);
+        return stdout.trim();
+      };
+
+      it('anchors the filter spec at the object name clients are told to pass', async () => {
+        // The README publishes this object name; if the ref held anything else,
+        // every documented clone command would name an object git cannot find.
+        expect(
+          await gitInRepo('rev-parse', sparseFilterRefPath(spec.name)),
+        ).toBe(publishedOid);
+        const stored = await execFileAsync('git', [
+          '-C',
+          process.env.VAULT_REPO_PATH ?? '',
+          'cat-file',
+          '-p',
+          publishedOid,
+        ]);
+        expect(stored.stdout).toBe(spec.patterns);
+      });
+
+      it('serves a clone that excludes user pages, without sending their file bodies', {
+        timeout: 120_000,
+      }, async () => {
+        if (mongoose == null) {
+          throw new Error('Mongoose not connected');
+        }
+        const { ObjectId } = mongoose.mongo;
+        const userId = 'aabbccddeeff00112233ff01';
+        const ns = 'public';
+
+        await upsertPageAndWait({
+          namespace: ns,
+          pageId: new ObjectId().toHexString(),
+          pagePath: '/user/someone/private-memo',
+          revisionId: new ObjectId().toHexString(),
+          bodyText: 'a personal page body that must not be transferred\n',
+        });
+        await upsertPageAndWait({
+          namespace: ns,
+          pageId: new ObjectId().toHexString(),
+          pagePath: '/sparse-probe/kept',
+          revisionId: new ObjectId().toHexString(),
+          bodyText: '# Kept\nAn ordinary wiki page.\n',
+        });
+
+        const { viewRef } = await callComposeView(userId, [ns]);
+        const viewRefPath = `refs/namespaces/${viewRef}/refs/heads/main`;
+
+        // The object name of the excluded page's body, read from the bare repo.
+        const excludedBlob = await gitInRepo(
+          'rev-parse',
+          `${viewRefPath}:user/someone/private-memo.md`,
+        );
+
+        const cloneTarget = path.join(sparseCloneDir, 'filtered-clone');
+        await execFileAsync('git', [
+          'clone',
+          '--config',
+          `http.extraheader=Authorization: ${AUTH_HEADER}`,
+          '--config',
+          `http.extraheader=x-vault-view-ref: ${viewRef}`,
+          `--filter=sparse:oid=${publishedOid}`,
+          '--no-checkout',
+          `${BASE_URL}/internal/git`,
+          cloneTarget,
+        ]);
+
+        // The client applies the same patterns locally, so its checkout asks
+        // for nothing the server left out.
+        await execFileAsync('git', ['sparse-checkout', 'init', '--no-cone'], {
+          cwd: cloneTarget,
+        });
+        execFileSync('git', ['sparse-checkout', 'set', '--stdin'], {
+          cwd: cloneTarget,
+          input: spec.patterns,
+        });
+        await execFileAsync('git', ['checkout', 'HEAD'], { cwd: cloneTarget });
+
+        const files = await listFilesRecursive(cloneTarget);
+
+        // The checkout ran to completion for everything outside user/.
+        expect(files).toContain('sparse-probe/kept.md');
+        expect(files.some((p) => p.startsWith('user/'))).toBe(false);
+
+        // The point of the filter: the excluded body was never transferred, so
+        // it is not in the clone's object store either.
+        await expect(
+          execFileAsync('git', ['cat-file', '-e', excludedBlob], {
+            cwd: cloneTarget,
+          }),
+        ).rejects.toThrow();
+
+        // git considers the working tree clean, i.e. the checkout was not left
+        // half-applied by a rejected object request.
+        const { stdout: status } = await execFileAsync(
+          'git',
+          ['status', '--porcelain'],
+          { cwd: cloneTarget },
+        );
+        expect(status.trim()).toBe('');
+      });
+
+      it('refuses a filter it does not serve at clone time, instead of failing the checkout later', {
+        timeout: 60_000,
+      }, async () => {
+        // With the filter capability advertised, git accepts --filter=blob:none
+        // and defers every file body — which it would then fetch one object at a
+        // time, and the want guard refuses those. Left unchecked, this exact
+        // command reports "Clone succeeded, but checkout failed" after a wall of
+        // per-object errors and leaves an empty working tree. Written the way a
+        // user would type it, so that outcome is what the test rules out.
+        const { viewRef } = await callComposeView(
+          TEST_USER_ID,
+          TEST_NAMESPACES,
+        );
+        const cloneTarget = path.join(sparseCloneDir, 'blobless-clone');
+
+        await expect(
+          execFileAsync('git', [
+            'clone',
+            '--config',
+            `http.extraheader=Authorization: ${AUTH_HEADER}`,
+            '--config',
+            `http.extraheader=x-vault-view-ref: ${viewRef}`,
+            '--filter=blob:none',
+            `${BASE_URL}/internal/git`,
+            cloneTarget,
+          ]),
+        ).rejects.toThrow(/unsupported partial-clone filter/);
       });
     });
   },

--- a/apps/growi-vault-manager/src/controllers/git-proxy-controller.ts
+++ b/apps/growi-vault-manager/src/controllers/git-proxy-controller.ts
@@ -166,7 +166,7 @@ export class GitProxyController {
 
     // Authorise the client's wants before upload-pack runs (requirement 5.4).
     // git would serve any blob or tree in the shared object store here, whether
-    // or not this view reaches it — see 追補 A in the vault-manager design.
+    // or not this view reaches it — see the vault-manager research.md.
     const peeked = await peekWantSection(req);
     if (peeked.status === 'invalid') {
       process.stderr.write(

--- a/apps/growi-vault-manager/src/controllers/git-proxy-controller.ts
+++ b/apps/growi-vault-manager/src/controllers/git-proxy-controller.ts
@@ -29,6 +29,10 @@ import type { Request, Response } from 'express';
 import { SharedSecretAuth } from '../middlewares/shared-secret-auth.js';
 import { encodePktLine } from '../services/vault-pkt-line.js';
 import { getRepoPath } from '../services/vault-repo-storage.js';
+import {
+  findUnsupportedFilters,
+  PUBLISHED_SPARSE_FILTERS,
+} from '../services/vault-sparse-filter.js';
 import { spawnUploadPack } from '../services/vault-upload-pack-spawner.js';
 import {
   findWantsOutsideView,
@@ -73,6 +77,19 @@ const REFUSAL_RESPONSE = encodePktLine(
 /** Response sent when the request head is not a protocol v0 want section. */
 const MALFORMED_REQUEST_RESPONSE = encodePktLine(
   'ERR vault: malformed upload-pack request\n',
+);
+
+/**
+ * Response sent when the client asks for a partial-clone filter this server does
+ * not serve (requirement 5.9).
+ *
+ * Unlike the refusal above, this message is deliberately specific: it describes
+ * what this server offers, not what the repository holds, and a client that is
+ * told nothing here would instead see its clone succeed and its checkout fail
+ * with a wall of per-object errors.
+ */
+const UNSUPPORTED_FILTER_RESPONSE = encodePktLine(
+  'ERR vault: unsupported partial-clone filter; this server serves only --filter=sparse:oid=<published spec> (see the vault-manager README)\n',
 );
 
 @Controller('/internal/git')
@@ -173,6 +190,21 @@ export class GitProxyController {
         `[git-proxy upload-pack] refused a request that is not a v0 want section (view=${viewRef}): ${peeked.reason}\n`,
       );
       res.end(MALFORMED_REQUEST_RESPONSE);
+      req.destroy();
+      return;
+    }
+
+    // A filter this server does not serve is refused here rather than left to
+    // fail the client's checkout later (requirement 5.9).
+    const unsupportedFilters = findUnsupportedFilters(
+      peeked.filters,
+      PUBLISHED_SPARSE_FILTERS,
+    );
+    if (unsupportedFilters.length > 0) {
+      process.stderr.write(
+        `[git-proxy upload-pack] refused an unsupported filter (view=${viewRef}): ${unsupportedFilters.join(', ')}\n`,
+      );
+      res.end(UNSUPPORTED_FILTER_RESPONSE);
       req.destroy();
       return;
     }

--- a/apps/growi-vault-manager/src/server-runtime.ts
+++ b/apps/growi-vault-manager/src/server-runtime.ts
@@ -6,6 +6,10 @@ import { Server } from './server.js';
 import { createVaultInstructionWatcher } from './services/vault-instruction-watcher.js';
 import { getSchedulerInstance } from './services/vault-maintenance-scheduler-instance.js';
 import { init as initRepo } from './services/vault-repo-storage.js';
+import {
+  installSparseFilters,
+  PUBLISHED_SPARSE_FILTERS,
+} from './services/vault-sparse-filter.js';
 
 /**
  * Handle for a running vault-manager runtime. `stop()` tears everything down
@@ -33,6 +37,11 @@ export async function startServer(): Promise<VaultManagerServer> {
 
   // Bare repo path is derived from VAULT_REPO_PATH at first call.
   await initRepo();
+
+  // The published partial-clone filter specs have to be present before the
+  // first clone can name one, and re-anchored on every boot so a gc between
+  // boots cannot leave a published object name unresolvable.
+  await installSparseFilters(PUBLISHED_SPARSE_FILTERS);
 
   const watcher = createVaultInstructionWatcher();
   await watcher.start();

--- a/apps/growi-vault-manager/src/services/vault-pkt-line.spec.ts
+++ b/apps/growi-vault-manager/src/services/vault-pkt-line.spec.ts
@@ -30,6 +30,7 @@ describe('parseWantSection', () => {
       expect(parseWantSection(buf)).toEqual({
         status: 'complete',
         wants: [OID_A],
+        filters: [],
       });
     });
 
@@ -44,6 +45,7 @@ describe('parseWantSection', () => {
       expect(parseWantSection(buf)).toEqual({
         status: 'complete',
         wants: [OID_A],
+        filters: [],
       });
     });
 
@@ -57,14 +59,30 @@ describe('parseWantSection', () => {
       expect(parseWantSection(buf)).toEqual({
         status: 'complete',
         wants: [OID_A, OID_B],
+        filters: [],
       });
     });
 
-    it('skips lines that are not wants (shallow / deepen / filter)', () => {
+    it('skips lines that carry no decision for the guard (shallow / deepen)', () => {
       const buf = Buffer.concat([
         pkt(`want ${OID_A} side-band-64k\n`),
         pkt(`shallow ${OID_B}\n`),
         pkt('deepen 1\n'),
+        FLUSH,
+      ]);
+
+      expect(parseWantSection(buf)).toEqual({
+        status: 'complete',
+        wants: [OID_A],
+        filters: [],
+      });
+    });
+
+    it('returns the partial-clone filter the client asked for', () => {
+      // The guard has to decide on the filter too: an unserved one is refused
+      // before upload-pack runs, rather than failing the client's checkout later.
+      const buf = Buffer.concat([
+        pkt(`want ${OID_A} side-band-64k filter\n`),
         pkt('filter blob:none\n'),
         FLUSH,
       ]);
@@ -72,13 +90,48 @@ describe('parseWantSection', () => {
       expect(parseWantSection(buf)).toEqual({
         status: 'complete',
         wants: [OID_A],
+        filters: ['blob:none'],
+      });
+    });
+
+    it('returns each filter when the client sends more than one line', () => {
+      const buf = Buffer.concat([
+        pkt(`want ${OID_A}\n`),
+        pkt(`filter sparse:oid=${OID_B}\n`),
+        pkt('filter tree:0\n'),
+        FLUSH,
+      ]);
+
+      expect(parseWantSection(buf)).toEqual({
+        status: 'complete',
+        wants: [OID_A],
+        filters: [`sparse:oid=${OID_B}`, 'tree:0'],
+      });
+    });
+
+    it('does not mistake the `filter` capability on the first want for a filter line', () => {
+      // git announces the capability in the want line whenever it *could* use a
+      // filter; only a `filter <spec>` line actually asks for one.
+      const buf = Buffer.concat([
+        pkt(`want ${OID_A} multi_ack_detailed filter\n`),
+        FLUSH,
+      ]);
+
+      expect(parseWantSection(buf)).toEqual({
+        status: 'complete',
+        wants: [OID_A],
+        filters: [],
       });
     });
 
     it('accepts a section that carries no want at all', () => {
       const buf = Buffer.concat([pkt('deepen 1\n'), FLUSH]);
 
-      expect(parseWantSection(buf)).toEqual({ status: 'complete', wants: [] });
+      expect(parseWantSection(buf)).toEqual({
+        status: 'complete',
+        wants: [],
+        filters: [],
+      });
     });
 
     it('stops at the first flush and ignores whatever follows it', () => {
@@ -92,6 +145,7 @@ describe('parseWantSection', () => {
       expect(parseWantSection(buf)).toEqual({
         status: 'complete',
         wants: [OID_A],
+        filters: [],
       });
     });
 
@@ -102,6 +156,7 @@ describe('parseWantSection', () => {
       expect(parseWantSection(buf)).toEqual({
         status: 'complete',
         wants: [sha256],
+        filters: [],
       });
     });
   });

--- a/apps/growi-vault-manager/src/services/vault-pkt-line.ts
+++ b/apps/growi-vault-manager/src/services/vault-pkt-line.ts
@@ -12,13 +12,13 @@
  *
  * `parseWantSection` reads only up to the first flush packet, which is all the
  * guard in vault-want-guard.ts needs in order to decide whether the request may
- * reach upload-pack (requirement 5.4 / 追補 A). Everything here is pure so the
+ * reach upload-pack (requirement 5.4 / 5.6). Everything here is pure so the
  * parsing can be tested without a stream or a git process.
  *
  * Only protocol v0 is covered, which is the only version reachable today: the
  * gateway does not forward the client's `Git-Protocol` header, so upload-pack
  * never negotiates v2. A v2 body is reported as invalid rather than guessed at
- * — see the note on the same subject in design.md 追補 A.
+ * — see the note on the same subject in the vault-manager research.md.
  */
 
 /** Largest want section the parser will buffer before giving up (bytes). */

--- a/apps/growi-vault-manager/src/services/vault-pkt-line.ts
+++ b/apps/growi-vault-manager/src/services/vault-pkt-line.ts
@@ -26,8 +26,15 @@ export const MAX_WANT_SECTION_BYTES = 64 * 1024;
 
 /** Outcome of parsing the head of an upload-pack request body. */
 export type WantSectionParseResult =
-  /** The flush packet was reached; `wants` lists every OID the client asked for. */
-  | { readonly status: 'complete'; readonly wants: readonly string[] }
+  /**
+   * The flush packet was reached; `wants` lists every OID the client asked for
+   * and `filters` every partial-clone filter spec it asked to be applied.
+   */
+  | {
+      readonly status: 'complete';
+      readonly wants: readonly string[];
+      readonly filters: readonly string[];
+    }
   /** More bytes are needed before the section can be judged. */
   | { readonly status: 'need-more' }
   /** The bytes cannot be a v0 want section; the request must not be forwarded. */
@@ -58,14 +65,16 @@ export function encodePktLine(payload: string): Buffer {
 /**
  * Reads the want section at the head of an upload-pack request body.
  *
- * Lines other than `want` (`shallow`, `deepen`, `filter`, …) are skipped: they
- * carry no OID the guard has to authorise, and they must survive untouched.
+ * `want` and `filter` lines are collected because the guard decides on both.
+ * Everything else (`shallow`, `deepen`, …) is skipped: those carry nothing to
+ * authorise. No line is altered — the body is handed to upload-pack unchanged.
  *
  * @param buf - Bytes received so far, from the start of the request body.
- * @returns Whether the section is complete, and the OIDs it requests.
+ * @returns Whether the section is complete, and what it requests.
  */
 export function parseWantSection(buf: Buffer): WantSectionParseResult {
   const wants: string[] = [];
+  const filters: string[] = [];
   let offset = 0;
 
   for (;;) {
@@ -90,7 +99,7 @@ export function parseWantSection(buf: Buffer): WantSectionParseResult {
 
     // Flush packet: the want section ends here.
     if (length === 0) {
-      return { status: 'complete', wants };
+      return { status: 'complete', wants, filters };
     }
     // 0001 (delim) and 0002 (response-end) only appear in protocol v2.
     if (length < LENGTH_PREFIX_BYTES) {
@@ -117,6 +126,8 @@ export function parseWantSection(buf: Buffer): WantSectionParseResult {
         };
       }
       wants.push(oid);
+    } else if (line.startsWith('filter ')) {
+      filters.push(line.slice('filter '.length).trim());
     }
 
     offset += length;

--- a/apps/growi-vault-manager/src/services/vault-sparse-filter.spec.ts
+++ b/apps/growi-vault-manager/src/services/vault-sparse-filter.spec.ts
@@ -1,0 +1,183 @@
+import { execFile, execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  findUnsupportedFilters,
+  installSparseFilters,
+  PUBLISHED_SPARSE_FILTERS,
+  sparseFilterOid,
+  sparseFilterRefPath,
+} from './vault-sparse-filter.js';
+
+const execFileAsync = promisify(execFile);
+
+const EXCLUDE_USER_PAGES = PUBLISHED_SPARSE_FILTERS[0];
+if (EXCLUDE_USER_PAGES == null) {
+  throw new Error('no sparse filter is published');
+}
+
+// ---------------------------------------------------------------------------
+// sparseFilterOid
+// ---------------------------------------------------------------------------
+
+describe('sparseFilterOid', () => {
+  /**
+   * The object name is what the client puts in `--filter=sparse:oid=<oid>`, so
+   * it has to be the name git itself gives those bytes — anything else and the
+   * filter names an object the repository does not hold. Compared against real
+   * git rather than a golden constant, since git is the definition here.
+   */
+  it('gives the patterns the same object name git does', () => {
+    // execFileSync, because only the sync form can feed stdin in one call.
+    const fromGit = execFileSync(
+      'git',
+      ['hash-object', '-t', 'blob', '--stdin'],
+      {
+        input: EXCLUDE_USER_PAGES.patterns,
+        encoding: 'utf8',
+      },
+    );
+
+    expect(sparseFilterOid(EXCLUDE_USER_PAGES)).toBe(fromGit.trim());
+  });
+
+  it('gives different patterns different names', () => {
+    expect(sparseFilterOid({ name: 'a', patterns: '/*\n' })).not.toBe(
+      sparseFilterOid({ name: 'a', patterns: '/*\n!/user\n' }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findUnsupportedFilters
+// ---------------------------------------------------------------------------
+
+describe('findUnsupportedFilters', () => {
+  const publishedOid = sparseFilterOid(EXCLUDE_USER_PAGES);
+  const find = (filters: readonly string[]): readonly string[] =>
+    findUnsupportedFilters(filters, PUBLISHED_SPARSE_FILTERS);
+
+  it('has nothing to refuse when the request carries no filter', () => {
+    expect(find([])).toEqual([]);
+  });
+
+  it('serves a filter that names a published spec', () => {
+    expect(find([`sparse:oid=${publishedOid}`])).toEqual([]);
+  });
+
+  it('refuses blob:none, whose deferred file bodies are fetched one object at a time later', () => {
+    // The clone itself would succeed and the checkout would then fail, which is
+    // a worse outcome than refusing the filter up front.
+    expect(find(['blob:none'])).toEqual(['blob:none']);
+  });
+
+  it('refuses blob:limit, tree and object:type filters for the same reason', () => {
+    expect(find(['blob:limit=1k'])).toEqual(['blob:limit=1k']);
+    expect(find(['tree:0'])).toEqual(['tree:0']);
+    expect(find(['object:type=blob'])).toEqual(['object:type=blob']);
+  });
+
+  it('refuses a combined filter even when one half names a published spec', () => {
+    const combined = `combine:sparse:oid=${publishedOid}+blob:none`;
+
+    expect(find([combined])).toEqual([combined]);
+  });
+
+  it('refuses a sparse:oid that names an object the server did not publish', () => {
+    // Otherwise a client could point the filter at any object it knows the name
+    // of, and read something back out of which paths the server then serves.
+    const foreign = `sparse:oid=${'a'.repeat(40)}`;
+
+    expect(find([foreign])).toEqual([foreign]);
+  });
+
+  it('refuses a sparse:path filter, which git dropped and this server never served', () => {
+    expect(find(['sparse:path=/etc/passwd'])).toEqual([
+      'sparse:path=/etc/passwd',
+    ]);
+  });
+
+  it('reports every offending filter when a request carries several', () => {
+    expect(find([`sparse:oid=${publishedOid}`, 'blob:none', 'tree:0'])).toEqual(
+      ['blob:none', 'tree:0'],
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// installSparseFilters
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs against a real bare repository: what has to hold is that upload-pack can
+ * still resolve the published object name after a pruning gc, and only git can
+ * answer that.
+ */
+describe('installSparseFilters', () => {
+  let root: string;
+  let repoPath: string;
+
+  const gitInRepo = async (...args: string[]): Promise<string> => {
+    const { stdout } = await execFileAsync('git', ['-C', repoPath, ...args]);
+    return stdout.trim();
+  };
+
+  beforeAll(async () => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'vault-sparse-filter-'));
+    repoPath = path.join(root, 'repo.git');
+    await execFileAsync('git', ['init', '--bare', '-q', repoPath]);
+    // vault-repo-storage resolves the repo path from the environment on first
+    // use, so this has to be set before any of its functions run.
+    process.env.VAULT_REPO_PATH = repoPath;
+  }, 30_000);
+
+  afterAll(() => {
+    if (root != null) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('stores each published spec under its own ref, holding the patterns git will read', async () => {
+    await installSparseFilters(PUBLISHED_SPARSE_FILTERS);
+
+    for (const spec of PUBLISHED_SPARSE_FILTERS) {
+      // biome-ignore lint/performance/noAwaitInLoops: each spec is checked against the same repository, one git call at a time
+      const oid = await gitInRepo('rev-parse', sparseFilterRefPath(spec.name));
+      expect(oid).toBe(sparseFilterOid(spec));
+
+      const stored = await execFileAsync('git', [
+        '-C',
+        repoPath,
+        'cat-file',
+        '-p',
+        oid,
+      ]);
+      expect(stored.stdout).toBe(spec.patterns);
+    }
+  }, 30_000);
+
+  it('keeps the spec reachable through a pruning gc, so the published object name stays resolvable', async () => {
+    await installSparseFilters(PUBLISHED_SPARSE_FILTERS);
+    const oid = sparseFilterOid(EXCLUDE_USER_PAGES);
+
+    await gitInRepo('gc', '--prune=now', '-q');
+
+    expect(await gitInRepo('cat-file', '-t', oid)).toBe('blob');
+  }, 60_000);
+
+  it('can be run again on a repository that already has the specs', async () => {
+    await installSparseFilters(PUBLISHED_SPARSE_FILTERS);
+    await installSparseFilters(PUBLISHED_SPARSE_FILTERS);
+
+    expect(
+      await gitInRepo(
+        'rev-parse',
+        sparseFilterRefPath(EXCLUDE_USER_PAGES.name),
+      ),
+    ).toBe(sparseFilterOid(EXCLUDE_USER_PAGES));
+  }, 30_000);
+});

--- a/apps/growi-vault-manager/src/services/vault-sparse-filter.spec.ts
+++ b/apps/growi-vault-manager/src/services/vault-sparse-filter.spec.ts
@@ -45,6 +45,20 @@ describe('sparseFilterOid', () => {
     expect(sparseFilterOid(EXCLUDE_USER_PAGES)).toBe(fromGit.trim());
   });
 
+  it('is the object name the README tells clients to pass', () => {
+    // The object name is content-addressed, so editing a spec's patterns
+    // silently invalidates every documented clone command. This is the drift
+    // check for that: change the patterns and the README has to change too.
+    const readme = fs.readFileSync(
+      path.join(import.meta.dirname, '../../README.md'),
+      'utf8',
+    );
+
+    expect(readme).toContain(
+      `--filter=sparse:oid=${sparseFilterOid(EXCLUDE_USER_PAGES)}`,
+    );
+  });
+
   it('gives different patterns different names', () => {
     expect(sparseFilterOid({ name: 'a', patterns: '/*\n' })).not.toBe(
       sparseFilterOid({ name: 'a', patterns: '/*\n!/user\n' }),

--- a/apps/growi-vault-manager/src/services/vault-sparse-filter.ts
+++ b/apps/growi-vault-manager/src/services/vault-sparse-filter.ts
@@ -1,0 +1,149 @@
+/**
+ * The partial-clone filters this server serves.
+ *
+ * A clone transfers every object in the requester's view, which for a long-lived
+ * wiki is dominated by the current snapshot rather than by history (each view's
+ * history is squashed to a parentless commit — requirement 6). `git
+ * sparse-checkout` alone does not help: it only decides what is written into the
+ * working tree, not what the server sends.
+ *
+ * What does shrink the transfer is a partial-clone filter, and of git's filters
+ * only `sparse:oid=<blob>` applies the exclusion **on the server**: it names a
+ * blob holding sparse-checkout patterns, and upload-pack leaves out the file
+ * bodies those patterns exclude. The client therefore receives everything it
+ * needs in one response and never asks for a single object afterwards, which is
+ * what keeps the request compatible with the want guard (requirements 5.6–5.8):
+ * one want, a few hundred bytes, no per-object follow-up.
+ *
+ * The other filters (`blob:none`, `blob:limit`, `tree:<n>`, `object:type`,
+ * `combine:`) all defer objects for the client to fetch by name later, which the
+ * want guard refuses — so they are refused up front instead, with a message that
+ * says what to use (requirement 5.9). `sparse:path` is not a choice at all: git
+ * dropped it because it let a client name any path on the server.
+ *
+ * A spec is only served when the server published it (requirement 5.10). Without
+ * that, a client could point the filter at any object whose name it knows and
+ * learn something from which paths came back.
+ */
+
+import { createHash } from 'node:crypto';
+
+import { updateRef, writeBlob } from './vault-repo-storage.js';
+
+// ---------------------------------------------------------------------------
+// Published specs
+// ---------------------------------------------------------------------------
+
+/** A sparse-checkout pattern set the server offers as a partial-clone filter. */
+export interface SparseFilterSpec {
+  /** Ref name segment the spec is anchored under; also its public name. */
+  readonly name: string;
+  /**
+   * The patterns, byte for byte as git will read them. Changing these changes
+   * the object name clients pass, so they are effectively part of the public
+   * interface — see the README.
+   */
+  readonly patterns: string;
+}
+
+/**
+ * Every spec clients may name in `--filter=sparse:oid=<oid>`.
+ *
+ * Non-cone patterns, because an exclusion cannot be expressed in cone mode.
+ * The client sets the same patterns locally with `git sparse-checkout`, so that
+ * its checkout asks for nothing the server left out.
+ */
+export const PUBLISHED_SPARSE_FILTERS: readonly SparseFilterSpec[] = [
+  { name: 'exclude-user-pages', patterns: '/*\n!/user\n' },
+];
+
+/** Ref namespace the published specs are anchored under. */
+const SPARSE_FILTER_REF_PREFIX = 'refs/vault/sparse-filters';
+
+/** Prefix of a filter that names a blob of sparse-checkout patterns. */
+const SPARSE_OID_PREFIX = 'sparse:oid=';
+
+// ---------------------------------------------------------------------------
+// Public functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Ref a published spec is anchored under.
+ *
+ * The ref exists so the blob stays reachable: an unreferenced object is removed
+ * by the maintenance gc (requirement 6.4), and the object name published in the
+ * README would then stop resolving. It lives outside `refs/namespaces/`, so no
+ * view advertises it.
+ *
+ * @param name - Spec name.
+ * @returns Ref path relative to the git directory.
+ */
+export function sparseFilterRefPath(name: string): string {
+  return `${SPARSE_FILTER_REF_PREFIX}/${name}`;
+}
+
+/**
+ * Object name git gives a spec's patterns.
+ *
+ * Computed rather than read back from the repository, so the value a request is
+ * checked against never depends on the repository being in any particular state
+ * (a check that cannot resolve its allowed set would have to refuse everything).
+ * `installSparseFilters` asserts that git agrees.
+ *
+ * @param spec - The spec whose object name is wanted.
+ * @returns 40-character SHA-1 object name.
+ */
+export function sparseFilterOid(spec: SparseFilterSpec): string {
+  const body = Buffer.from(spec.patterns, 'utf8');
+  const header = Buffer.from(`blob ${body.length}\0`, 'utf8');
+  return createHash('sha1')
+    .update(Buffer.concat([header, body]))
+    .digest('hex');
+}
+
+/**
+ * Returns the filters in a request that this server does not serve.
+ *
+ * @param filters - Filter specs taken from the request's want section.
+ * @param specs - Specs the server publishes.
+ * @returns The offending filter specs. Empty when every one may be served.
+ */
+export function findUnsupportedFilters(
+  filters: readonly string[],
+  specs: readonly SparseFilterSpec[],
+): readonly string[] {
+  const served = new Set(specs.map((spec) => sparseFilterOid(spec)));
+
+  return filters.filter((filter) => {
+    if (!filter.startsWith(SPARSE_OID_PREFIX)) {
+      return true;
+    }
+    return !served.has(filter.slice(SPARSE_OID_PREFIX.length).trim());
+  });
+}
+
+/**
+ * Writes every published spec into the bare repository and anchors it to a ref.
+ *
+ * Idempotent: the blob is content-addressed and the ref write is a replace, so
+ * running this at every boot costs one object write per spec.
+ *
+ * @param specs - Specs to publish.
+ * @throws When git names a spec's patterns differently than `sparseFilterOid`
+ *   does, which would leave the published object name unresolvable.
+ */
+export async function installSparseFilters(
+  specs: readonly SparseFilterSpec[],
+): Promise<void> {
+  for (const spec of specs) {
+    // biome-ignore lint/performance/noAwaitInLoops: a handful of specs, written once at boot; sequential keeps the failure attributable to one spec
+    const oid = await writeBlob(Buffer.from(spec.patterns, 'utf8'));
+    const expected = sparseFilterOid(spec);
+    if (oid !== expected) {
+      throw new Error(
+        `Sparse filter '${spec.name}' was stored as ${oid} but is published as ${expected}`,
+      );
+    }
+    await updateRef(sparseFilterRefPath(spec.name), oid);
+  }
+}

--- a/apps/growi-vault-manager/src/services/vault-upload-pack-spawner.ts
+++ b/apps/growi-vault-manager/src/services/vault-upload-pack-spawner.ts
@@ -30,8 +30,8 @@
  * The gap is therefore closed before this spawner runs: GitProxyController
  * authorises every want against the view ref via vault-want-guard.ts, and hands
  * the already-inspected head of the request body back through `stdinPrefix`. Do
- * not call this in 'rpc' mode without that check. See "追補 A" in
- * .kiro/specs/growi-vault-manager/design.md.
+ * not call this in 'rpc' mode without that check. See
+ * .kiro/specs/growi-vault-manager/research.md.
  */
 
 import type { ChildProcess } from 'node:child_process';

--- a/apps/growi-vault-manager/src/services/vault-upload-pack-spawner.ts
+++ b/apps/growi-vault-manager/src/services/vault-upload-pack-spawner.ts
@@ -32,6 +32,15 @@
  * the already-inspected head of the request body back through `stdinPrefix`. Do
  * not call this in 'rpc' mode without that check. See
  * .kiro/specs/growi-vault-manager/research.md.
+ *
+ * `uploadpack.allowFilter=true` is set so that a client can shrink its clone
+ * with `--filter=sparse:oid=<published spec>` (requirement 5.9). The setting is
+ * all-or-nothing — git cannot advertise one kind of filter and not another — so
+ * the filters this server does not serve are refused by the same guard, which
+ * inspects the `filter` line before this spawner runs. Note that
+ * `uploadpack.allowReachableSHA1InWant` stays off: a client is never allowed to
+ * ask for an object by name, which is why `sparse:oid` (applied entirely on the
+ * server, one want, no follow-up request) is the only filter that fits.
  */
 
 import type { ChildProcess } from 'node:child_process';
@@ -99,11 +108,21 @@ export function spawnUploadPack(opts: SpawnOptions): SpawnResult {
   const { mode, viewRef, stdin, stdinPrefix } = opts;
   const repoPath = getRepoPath();
 
+  // Both modes carry the config: 'advertise' is where the filter capability is
+  // announced, 'rpc' is where the filter is applied.
+  const config = ['-c', 'uploadpack.allowFilter=true'];
+
   // Build the argument list based on mode.
   const args =
     mode === 'advertise'
-      ? ['upload-pack', '--stateless-rpc', '--advertise-refs', repoPath]
-      : ['upload-pack', '--stateless-rpc', repoPath];
+      ? [
+          ...config,
+          'upload-pack',
+          '--stateless-rpc',
+          '--advertise-refs',
+          repoPath,
+        ]
+      : [...config, 'upload-pack', '--stateless-rpc', repoPath];
 
   // Spawn the process with GIT_NAMESPACE so git only sees the view ref's
   // namespace (gitnamespaces(7): refs are rewritten to refs/namespaces/<ns>/).

--- a/apps/growi-vault-manager/src/services/vault-want-guard.spec.ts
+++ b/apps/growi-vault-manager/src/services/vault-want-guard.spec.ts
@@ -74,6 +74,23 @@ describe('peekWantSection', () => {
     expect(Buffer.concat([result.prefix, rest])).toEqual(body);
   });
 
+  it('reports the partial-clone filter alongside the wants', async () => {
+    const filtered = Buffer.concat([
+      encodePktLine(`want ${OID} side-band-64k filter\n`),
+      encodePktLine('filter blob:none\n'),
+      FLUSH,
+    ]);
+    const stream = Readable.from([filtered, remainder]);
+
+    const result = await peekWantSection(stream);
+
+    expect(result).toMatchObject({
+      status: 'complete',
+      wants: [OID],
+      filters: ['blob:none'],
+    });
+  });
+
   it('reports the request as invalid when it ends before the want section does', async () => {
     const stream = Readable.from([encodePktLine(`want ${OID}\n`)]);
 

--- a/apps/growi-vault-manager/src/services/vault-want-guard.ts
+++ b/apps/growi-vault-manager/src/services/vault-want-guard.ts
@@ -5,7 +5,7 @@
  * reachability check for an unadvertised want assumes the want is a commit. A
  * client that asks for a blob or a tree by object name therefore receives it
  * even when nothing in its own view reaches that object — measured on git
- * 2.49.0, see 追補 A in `.kiro/specs/growi-vault-manager/design.md`. Since
+ * 2.49.0, see `.kiro/specs/growi-vault-manager/research.md`. Since
  * gitnamespaces(7) states outright that namespaces are not a read
  * access-control boundary, the check has to happen before upload-pack runs.
  *

--- a/apps/growi-vault-manager/src/services/vault-want-guard.ts
+++ b/apps/growi-vault-manager/src/services/vault-want-guard.ts
@@ -38,6 +38,12 @@ export interface PeekWantSectionResult {
   /** OIDs the client asked for; empty when `status` is 'invalid'. */
   readonly wants: readonly string[];
   /**
+   * Partial-clone filter specs the client asked to be applied; empty when
+   * `status` is 'invalid' or the request carries no filter. Judged by
+   * `findUnsupportedFilters` in vault-sparse-filter.ts.
+   */
+  readonly filters: readonly string[];
+  /**
    * The bytes already taken off the stream. The caller must write these to
    * upload-pack's stdin before piping the remainder, or the request body would
    * arrive truncated.
@@ -119,11 +125,13 @@ export function peekWantSection(
           ? {
               status: 'complete',
               wants: parsed.wants,
+              filters: parsed.filters,
               prefix: Buffer.concat(chunks),
             }
           : {
               status: 'invalid',
               wants: [],
+              filters: [],
               prefix: Buffer.concat(chunks),
               reason: parsed.reason,
             },
@@ -136,6 +144,7 @@ export function peekWantSection(
       resolve({
         status: 'invalid',
         wants: [],
+        filters: [],
         prefix,
         reason:
           parsed.status === 'need-more'


### PR DESCRIPTION
Fixes #11595

## 何をした PR か

GROWI Vault のクローンを小さくする手段が、README に書かれた通りにはどちらも動きませんでした。**転送量を実際に減らせるようにし**、README を動く手順に直します。

調査の途中で見つかった読み取りの隔離の問題（#11604）と、長いページ名でチェックアウトが失敗する問題（#11603）は先に別 PR でマージ済みです。本 PR は #11595 の残件（転送量削減）と、#11604 の spec 整頓で参照先が切れた箇所の修正です。

## 直した 2 点

### 1. sparse-checkout の手順が git に拒否されていた

```console
$ git sparse-checkout init --cone
$ git sparse-checkout set '/*' '!/user'
fatal: specify directories rather than patterns (no leading slash)
```

cone mode は「これは除く」という指定ができないため `set` が失敗します。パターンが 1 件も書き込まれないまま次の `git checkout` が走るので、結果は「`user/` が除かれた作業ツリー」ではなく **空の作業ツリー**になります。`--no-cone` に変え、パターンは `--stdin` で渡す形にしました（Git Bash では `!/user` が引数だと Windows のパスに書き換えられてしまうため）。

### 2. `--filter=blob:none` は無視されていた（→ 別の絞り方で転送量を減らせるようにした）

README は「サーバから送られる量を絞るには partial clone filter が必要」と案内していましたが、`uploadpack.allowFilter` を有効にしていないため git は指定を捨て、全量転送していました。

**git の絞り方のうち、`sparse:oid=<blob>` だけがこの設計に合います。** これは sparse-checkout 形式のパターンを書いた blob を指定する形式で、**除外をサーバ側で適用**します。クライアントは 1 回目の応答で必要なものを全部受け取り、以後 object を個別に要求しません。

そのため、#11604 で入れた検査（upload-pack を起動する前にクライアントの要求を読み、ビューから届かない object の要求を断る処理）に**手を入れずに通ります**。要求されるのはビューが広告している commit 1 件だけなので、どの object を許すかの判定ロジックは変更していません。実物のリクエスト本文をマージ済みの `parseWantSection` に通して確認しました。

なお、絞り方そのものを見る処理は同じ場所に**新しく足しています**（後述の「公開していない絞り方は clone の時点で断ります」）。無変更なのは object の要求に対する判定です。

```
通常の clone の本文（183 B）              → complete、want 1 件
--filter=sparse:oid の本文（252 B）        → complete、want 1 件（ビューが広告している commit そのもの）
--filter=blob:none の 2 回目（359,260 B）  → invalid: malformed pkt-line length prefix
```

## 実測（`wiki/` 15,000 ページ ＋ `user/` 5,000 ページ）

サーバが実際に書き出したバイト数です。

| 手段 | HTTP のやりとり | クライアントが送る本文 | 要求 object 件数 | 転送量 | 削減 |
|---|---|---|---|---|---|
| 通常の clone | 1 回 | 183 B | 1 | 6,269,214 | — |
| `--filter=blob:none` ＋ sparse-checkout | 2 回 | 210 B → **359,260 B（圧縮済み）** | 1 → **15,000** | 4,815,233 | 23.2% |
| **`--filter=sparse:oid` ＋ sparse-checkout（採用）** | **1 回** | **252 B** | **1** | 4,815,099 | 23.2% |
| `user/` を外したビュー用ブランチを配る（採用せず） | 1 回 | 195 B | 1 | 4,690,525 | 25.2% |
| `--depth=1` | 1 回 | — | — | 削減なし | — |

`blob:none` を採用しなかった理由は、検査に 3 つの拡張が必要になるためです。

1. **2 回目のリクエストの本文が圧縮されて届く。** git クライアントは本文が大きいと `Content-Encoding: gzip` を付けます（750,160 B → 359,260 B）。`upload-pack` 自身も圧縮された本文は読めず `fatal: protocol error: bad line length character` で落ちるので、proxy 側での展開が前提になります。
2. **要求する object の件数がページ数と同じになる**（15,000 件・展開後 750 KB）。要件 5.7 の 64 KiB 上限と要件 5.8 の 64 件上限の両方を超えます。上限を上げるとメモリがビュー規模に比例します（1 リクエスト 1 MB 前後）。
3. **1 件ごとに git を 1 プロセス起動する方式が破綻する**（15,000 件 × 2 ms ≈ 30 秒）。object を全列挙して照合する形（20,000 ページで 10 ms）への差し替えが必要です。

`user/` を外したブランチを配る案は削減幅が最大でしたが、git の標準の仕組みではなく composer にブランチ生成を足す必要があり、検査も広げる必要があるため採用しませんでした（`research.md` の Decision D に 4 案の比較を記録）。

## 公開していない絞り方は clone の時点で断ります

`uploadpack.allowFilter` は**絞り方の種類ごとに分けられません**。有効にすると `blob:none` も受理されてしまい、遅延取得を許していないので次のようになります（実測）。

```console
$ git clone --filter=blob:none <url>
error: Server does not allow request for unadvertised object fff7046598...
（同じ行が数千行続く）
warning: Clone succeeded, but checkout failed.
（終了コード 128、作業ツリーは 0 件）
```

これは有効化前の「無視されるが全量転送で動く」より**悪化**します。そのため、同じ検査で `filter` 行も読み、公開した `sparse:oid` 以外は upload-pack を起動せずに断ります。

```console
$ git clone --filter=blob:none <url>
fatal: remote error: vault: unsupported partial-clone filter; this server serves only --filter=sparse:oid=<published spec> (see the vault-manager README)
```

この判定は副産物として、**公開していない object を `sparse:oid` に指定して応答サイズの差から中身を推し量る余地**も塞ぎます（実測: 正規のパターン 4,815,099 B / 他人のページを指定 488,217 B / 何にも一致しないパターン 488,167 B）。なお `sparse:path`（サーバ上のパスをクライアントが指定する形式）は git 側で削除済みです（`fatal: sparse:path filters support has been dropped`）。

## 検証

**まず落ちることを確認しました。** 各部分を壊して、対応するテストが落ちることを実測しています。

| 壊した箇所 | 結果 |
|---|---|
| `uploadpack.allowFilter` を外す | 結合テスト 2 件が落ちる（filter が黙って無視され、除外したはずのページ本文が届く） |
| filter の検査を外す | 結合テスト 1 件が落ちる。`git clone --filter=blob:none` が `warning: Clone succeeded, but checkout failed.` を再現 |
| object ID の算出を壊す | 単体 4 件が落ちる（git の `hash-object` と一致しない、README の ID と一致しない） |
| ref での保持をやめる | 単体 3 件が落ちる（`gc --prune=now` で blob が消える） |
| `filter` 行の収集をやめる | 単体 2 件が落ちる |

- 単体: **249 passed**（新規 27 件。`vault-sparse-filter.spec.ts` 14 / `vault-pkt-line.spec.ts` と `vault-want-guard.spec.ts` に追加）
- 結合（CI と同じ形 `pnpm --filter @growi/vault-manager test:integ`）: **3 files / 22 tests passed**。実際の `git clone --filter=sparse:oid=...` で `user/` 配下が作業ツリーに現れず、その中身が clone の object 置き場にも存在しない（＝転送されていない）ことを確認しています
- `turbo run build test lint --filter @growi/vault-manager` — pass

現時点の HEAD（`40ab374304`）で再実測し、上の件数（単体 249 / 結合 3 files・22 tests）が変わっていないことを確認しています。ブランチは #11604 と #11603 を含む master に rebase 済みで、その後 master に入った 25 コミットは vault 配下を触っていません（`MERGEABLE` / `CLEAN`）。

README に載せた object ID がパターンとずれないよう、**README を突き合わせるドリフト検出テスト**を入れました（パターンを変えると落ちます）。

## gateway（apps/app）側は変更なし

gateway はリクエスト本文と応答をそのまま素通しするだけで（[vault-gateway.ts](https://github.com/growilabs/growi/blob/master/apps/app/src/features/growi-vault/server/routes/vault-gateway.ts) の `requestBody: req` と `pipeline(proxyResult.body, res)`）、filter の指定は本文の中を通るため変更は要りません。`info/refs` で広告される filter の capability も同じ経路で素通しされます。

## 残る制約（README と spec に記録）

- **除外したページは、その clone では以後も取得できません。** `remote.origin.promisor=true` は残りますが、`allowReachableSHA1InWant` を有効にしないので、後から要求しようとすると git クライアントの手前で止まります（サーバには要求が届かないため漏えいにはなりません）。必要なら filter なしで clone し直します
- **除外できるパターンはサーバが公開したものだけ**（現在 1 つ: `user/` を除く）
- **protocol v2 の本文**は従来どおり拒否（gateway が `Git-Protocol` ヘッダを転送しない前提）

## あわせて直したもの: 参照先が消えていた「追補 A」8 箇所

#11604 の最後で spec を整頓したとき、追補 A の中身を `design.md` から `research.md` へ移した一方で、参照している側を直し忘れていました。master に参照先のない「追補 A」が 8 箇所（`design.md` 本文 3 箇所、ソースとテスト 5 ファイル）残っていたので、実際の記載先を指すように直しました。

## 差分

- `vault-sparse-filter.ts`（新規）＋ spec — 公開するパターン集合、その object ID の算出、絞り方の判定、repo への設置（gc で消えないよう ref で保持）
- `vault-pkt-line.ts` / `vault-want-guard.ts` — want 区間から `filter` 行も取り出す（`want` の capability 列に現れる `filter` という語と混同しないこと）
- `git-proxy-controller.ts` — 公開していない絞り方を upload-pack 起動前に拒否
- `vault-upload-pack-spawner.ts` — `uploadpack.allowFilter=true`
- `server-runtime.ts` — 起動時にパターン集合を設置
- `clone-e2e.integ.ts` — end-to-end の固定（filter 付き clone / 拒否 / 公開 ID の一致）
- `README.md` — 動く手順、以後の制約、他の絞り方が断られること、`--depth=1` の削減幅が小さい理由
- spec — `requirements.md` 5.9–5.11、`design.md`「転送量を絞る手段」＋ Revalidation Triggers 2 件差し替え、`research.md` の実測と Decision D・E、`tasks.md` Phase 21、`spec.json`（フェーズ更新）

> 注: 1 本目のコミット（`fix(vault): correct the sparse-checkout recipe...`）は「partial clone 非対応」と書いた時点のもので、後続のコミットがその判断を置き換えています。最終状態が上記です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

