### PR TITLE
fix: Restore native "Choose File" button styling outside .tw-root

### DIFF
--- a/apps/app/src/styles/tailwind.css
+++ b/apps/app/src/styles/tailwind.css
@@ -13,6 +13,15 @@
   :root :not(.tw-root, .tw-root *) {
     all: revert-layer;
   }
+
+  /* ::file-selector-button is a separate generated box, not matched by the
+   * host-element selector above, so preflight's unlayered border/background
+   * reset on it (input[type=file]'s native "Choose File" button) survives
+   * outside .tw-root and renders as an invisible, borderless control. Revert
+   * it explicitly for the same set of elements. */
+  :root :not(.tw-root, .tw-root *)::file-selector-button {
+    all: revert-layer;
+  }
 }
 
 /* Explicitly scan only AI Elements source files. */


### PR DESCRIPTION
## Summary

Fixes #11606 — the "Choose File" button on the data-import screen (and, in
fact, every `<input type="file">` outside the AI chat sidebar's `.tw-root`
scope) rendered as flat, borderless text with no button chrome, even though
the input itself still worked correctly.

## Root Cause

`apps/app/src/styles/tailwind.css` loads Tailwind CSS v4 globally via
`_app.page.tsx`. Tailwind's preflight reset strips border, background, and
padding from `::file-selector-button` — the browser-generated pseudo-element
that renders the native "Choose File" button for `input[type=file]` — via an
unscoped selector in `preflight.css`.

GROWI already carries a rule meant to undo every such Tailwind reset outside
the AI-chat-sidebar `.tw-root` scope:

```css
:root :not(.tw-root, .tw-root *) {
  all: revert-layer;
}
```

However, this only reverts styles on the matched *host elements*.
`::file-selector-button` is a separate, browser-generated box attached to the
input, and a selector targeting the host element cannot reach into a
pseudo-element it generates. So this one reset slipped through the
neutralization and applies everywhere outside `.tw-root` — not just on the
importer screen, but on every raw file input in the app (confirmed the same
symptom on `/me`'s profile image upload).

The `<input type="file">` markup in `UploadForm.jsx` itself is not the
problem — it uses the same unstyled pattern as `ProfileImageSettings.tsx`
and `CustomizeLogoSetting.tsx`.

## Changes

- Added the pseudo-element counterpart of the existing neutralization rule
  in `apps/app/src/styles/tailwind.css`, so `::file-selector-button` is
  reverted for the same set of elements the host-element rule already covers.

## Test Plan

- [x] Reproduced visually with Playwright against the running dev server:
      `/admin/importer` showed "Choose File No file chosen" as plain text
      before the fix.
- [x] After the fix, `/admin/importer` renders a properly styled "Choose
      File" button, matching the issue's "expected" screenshot.
- [x] Also confirmed the same before/after on `/me` (profile image upload),
      which has the identical latent bug.
- [x] `pnpm run lint:biome` passes.
- [ ] `pnpm run lint:typecheck` currently fails on master with pre-existing
      Prisma-generated-client errors (`prismaNamespace` missing members)
      unrelated to this change — confirmed via `git stash` that the same
      errors exist without this diff.
- [ ] `turbo run test --filter @growi/app` has 2 pre-existing failures in
      `search-delegator/elasticsearch.integ.ts` (Elasticsearch request
      timeout / index_not_found_exception) — reproduced in isolation on this
      branch and unrelated to a CSS-only change.

Closes #11606