### PR TITLE
fix: return canonical errors when renaming unavailable pages

### DIFF
--- a/apps/app/src/server/routes/apiv3/pages/index.js
+++ b/apps/app/src/server/routes/apiv3/pages/index.js
@@ -313,9 +313,9 @@ export const setup = (crowi) => {
    *                    page:
    *                      $ref: '#/components/schemas/Page'
    *          403:
-   *            description: Page is forbidden (page-is-forbidden).
+   *            description: Page is forbidden.
    *          404:
-   *            description: Page is not found (page-not-found).
+   *            description: Page is not found.
    *          409:
    *            description: page path is already existed
    */
@@ -391,20 +391,12 @@ export const setup = (crowi) => {
 
         if (page == null) {
           const { meta } = pageWithMeta;
-          if (meta.isForbidden) {
-            return res.apiv3Err(
-              new ErrorV3(
-                'Page is forbidden',
-                'page-is-forbidden',
-                undefined,
-                meta,
-              ),
-              403,
-            );
-          }
           return res.apiv3Err(
-            new ErrorV3('Page is not found', 'page-not-found', undefined, meta),
-            404,
+            new ErrorV3(
+              `Page '${pageId}' is not found or forbidden`,
+              'notfound_or_forbidden',
+            ),
+            meta.isForbidden ? 403 : 404,
           );
         }
 

--- a/apps/app/src/server/routes/apiv3/pages/index.js
+++ b/apps/app/src/server/routes/apiv3/pages/index.js
@@ -23,6 +23,7 @@ import loginRequiredFactory from '~/server/middlewares/login-required';
 import { GlobalNotificationSettingEvent } from '~/server/models/GlobalNotificationSetting';
 import PageTagRelation from '~/server/models/page-tag-relation';
 import { configManager } from '~/server/service/config-manager';
+import { findPageAndMetaDataByViewer } from '~/server/service/page/find-page-and-meta-data-by-viewer';
 import { preNotifyService } from '~/server/service/pre-notify';
 import loggerFactory from '~/utils/logger';
 
@@ -48,6 +49,7 @@ export const setup = (crowi) => {
   const adminRequired = adminRequiredFactory(crowi);
 
   const { Page, User } = crowi.models;
+  const { pageGrantService, pageService } = crowi;
 
   const activityEvent = crowi.events.activity;
 
@@ -310,8 +312,10 @@ export const setup = (crowi) => {
    *                  properties:
    *                    page:
    *                      $ref: '#/components/schemas/Page'
-   *          401:
-   *            description: page id is invalid
+   *          403:
+   *            description: Page is forbidden (page-is-forbidden).
+   *          404:
+   *            description: Page is not found (page-not-found).
    *          409:
    *            description: page path is already existed
    */
@@ -373,18 +377,38 @@ export const setup = (crowi) => {
       let renamedPage;
 
       try {
-        page = await Page.findByIdAndViewer(pageId, req.user, null, true);
-        options.isRecursively = page.descendantCount > 0;
+        const pageWithMeta = await findPageAndMetaDataByViewer(
+          pageService,
+          pageGrantService,
+          {
+            pageId,
+            path: null,
+            user: req.user,
+            basicOnly: true,
+          },
+        );
+        page = pageWithMeta.data;
 
         if (page == null) {
+          const { meta } = pageWithMeta;
+          if (meta.isForbidden) {
+            return res.apiv3Err(
+              new ErrorV3(
+                'Page is forbidden',
+                'page-is-forbidden',
+                undefined,
+                meta,
+              ),
+              403,
+            );
+          }
           return res.apiv3Err(
-            new ErrorV3(
-              `Page '${pageId}' is not found or forbidden`,
-              'notfound_or_forbidden',
-            ),
-            401,
+            new ErrorV3('Page is not found', 'page-not-found', undefined, meta),
+            404,
           );
         }
+
+        options.isRecursively = page.descendantCount > 0;
 
         // empty page does not require revisionId validation
         if (!page.isEmpty && revisionId == null) {

--- a/apps/app/src/server/routes/apiv3/pages/rename.integ.ts
+++ b/apps/app/src/server/routes/apiv3/pages/rename.integ.ts
@@ -1,0 +1,207 @@
+import type { NextFunction, Request, Response } from 'express';
+import express from 'express';
+import { Types } from 'mongoose';
+import request from 'supertest';
+import { mock } from 'vitest-mock-extended';
+
+import type Crowi from '~/server/crowi';
+import addCustomFunctionToResponse from '~/server/routes/apiv3/response';
+import { findPageAndMetaDataByViewer } from '~/server/service/page/find-page-and-meta-data-by-viewer';
+
+type AuthenticatedRequest = Request & {
+  user?: { _id: Types.ObjectId; readOnly: boolean };
+};
+
+const authenticatedMiddleware = (
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+) => {
+  if (req.user == null) {
+    return res.sendStatus(403);
+  }
+  return next();
+};
+
+const passthroughMiddleware = (
+  _req: Request,
+  _res: Response,
+  next: NextFunction,
+) => next();
+
+vi.mock('~/server/middlewares/access-token-parser', () => ({
+  accessTokenParser: () => passthroughMiddleware,
+}));
+
+vi.mock('~/server/middlewares/login-required', () => ({
+  default: () => authenticatedMiddleware,
+}));
+
+vi.mock('~/server/middlewares/admin-required', () => ({
+  default: () => authenticatedMiddleware,
+}));
+
+vi.mock('~/server/service/page/find-page-and-meta-data-by-viewer', () => ({
+  findPageAndMetaDataByViewer: vi.fn(),
+}));
+
+describe('PUT /rename', () => {
+  const pageId = '507f1f77bcf86cd799439011';
+  const user = { _id: new Types.ObjectId(), readOnly: false };
+
+  const pageExists = vi.fn();
+  const renamePage = vi.fn();
+  const fireGlobalNotification = vi.fn();
+
+  const mockedFindPageAndMetaDataByViewer = vi.mocked(
+    findPageAndMetaDataByViewer,
+  );
+
+  let app: express.Application;
+  let crowi: Crowi;
+
+  beforeAll(async () => {
+    crowi = mock<Crowi>({
+      models: {
+        Page: { exists: pageExists } as unknown as Crowi['models']['Page'],
+        User: {} as Crowi['models']['User'],
+      },
+      events: {
+        activity: { emit: vi.fn() },
+      },
+      globalNotificationService: {
+        fire: fireGlobalNotification,
+      },
+      pageService: {
+        renamePage,
+      },
+      pageGrantService: mock<Crowi['pageGrantService']>(),
+    });
+
+    addCustomFunctionToResponse(express);
+
+    app = express();
+    app.use(express.json());
+    app.use((req: AuthenticatedRequest, _res, next) => {
+      req.user = user;
+      next();
+    });
+
+    const pagesModule = (await import('./index')) as unknown as {
+      setup: (crowi: Crowi) => express.Router;
+    };
+    app.use('/', pagesModule.setup(crowi));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pageExists.mockResolvedValue(null);
+    fireGlobalNotification.mockResolvedValue(undefined);
+  });
+
+  it('returns page-not-found for an authenticated request with a valid missing page ID', async () => {
+    mockedFindPageAndMetaDataByViewer.mockResolvedValueOnce({
+      data: null,
+      meta: {
+        isNotFound: true,
+        isForbidden: false,
+      },
+    } as never);
+
+    const response = await request(app).put('/rename').send({
+      pageId,
+      newPagePath: '/renamed-page',
+    });
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({
+      errors: [
+        {
+          code: 'page-not-found',
+          args: {
+            isNotFound: true,
+            isForbidden: false,
+          },
+          message: 'Page is not found',
+        },
+      ],
+    });
+    expect(renamePage).not.toHaveBeenCalled();
+    expect(mockedFindPageAndMetaDataByViewer).toHaveBeenCalledWith(
+      crowi.pageService,
+      crowi.pageGrantService,
+      {
+        pageId,
+        path: null,
+        user,
+        basicOnly: true,
+      },
+    );
+  });
+
+  it('returns page-is-forbidden for an authenticated request without page access', async () => {
+    mockedFindPageAndMetaDataByViewer.mockResolvedValueOnce({
+      data: null,
+      meta: {
+        isNotFound: true,
+        isForbidden: true,
+      },
+    } as never);
+
+    const response = await request(app).put('/rename').send({
+      pageId,
+      newPagePath: '/renamed-page',
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({
+      errors: [
+        {
+          code: 'page-is-forbidden',
+          args: {
+            isNotFound: true,
+            isForbidden: true,
+          },
+          message: 'Page is forbidden',
+        },
+      ],
+    });
+    expect(renamePage).not.toHaveBeenCalled();
+  });
+
+  it('continues to rename an accessible page', async () => {
+    const page = {
+      _id: pageId,
+      path: '/source-page',
+      descendantCount: 1,
+      isEmpty: true,
+    };
+    const renamedPage = {
+      ...page,
+      path: '/renamed-page',
+    };
+
+    mockedFindPageAndMetaDataByViewer.mockResolvedValueOnce({
+      data: page,
+      meta: {
+        isNotFound: false,
+      },
+    } as never);
+    renamePage.mockResolvedValueOnce(renamedPage);
+
+    const response = await request(app).put('/rename').send({
+      pageId,
+      newPagePath: '/renamed-page',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ page: renamedPage });
+    expect(renamePage).toHaveBeenCalledWith(
+      page,
+      '/renamed-page',
+      user,
+      expect.objectContaining({ isRecursively: true }),
+      expect.objectContaining({ endpoint: '/rename' }),
+    );
+  });
+});

--- a/apps/app/src/server/routes/apiv3/pages/rename.integ.ts
+++ b/apps/app/src/server/routes/apiv3/pages/rename.integ.ts
@@ -1,26 +1,17 @@
+import { type IUser, PageGrant } from '@growi/core';
 import type { NextFunction, Request, Response } from 'express';
 import express from 'express';
-import { Types } from 'mongoose';
+import { type HydratedDocument, Types } from 'mongoose';
 import request from 'supertest';
-import { mock } from 'vitest-mock-extended';
+
+import { getInstance } from '^/test/setup/crowi';
 
 import type Crowi from '~/server/crowi';
+import type { PageDocument } from '~/server/models/page';
 import addCustomFunctionToResponse from '~/server/routes/apiv3/response';
-import { findPageAndMetaDataByViewer } from '~/server/service/page/find-page-and-meta-data-by-viewer';
 
 type AuthenticatedRequest = Request & {
-  user?: { _id: Types.ObjectId; readOnly: boolean };
-};
-
-const authenticatedMiddleware = (
-  req: AuthenticatedRequest,
-  res: Response,
-  next: NextFunction,
-) => {
-  if (req.user == null) {
-    return res.sendStatus(403);
-  }
-  return next();
+  user?: HydratedDocument<IUser>;
 };
 
 const passthroughMiddleware = (
@@ -34,48 +25,66 @@ vi.mock('~/server/middlewares/access-token-parser', () => ({
 }));
 
 vi.mock('~/server/middlewares/login-required', () => ({
-  default: () => authenticatedMiddleware,
+  default: () => passthroughMiddleware,
 }));
 
 vi.mock('~/server/middlewares/admin-required', () => ({
-  default: () => authenticatedMiddleware,
-}));
-
-vi.mock('~/server/service/page/find-page-and-meta-data-by-viewer', () => ({
-  findPageAndMetaDataByViewer: vi.fn(),
+  default: () => passthroughMiddleware,
 }));
 
 describe('PUT /rename', () => {
-  const pageId = '507f1f77bcf86cd799439011';
-  const user = { _id: new Types.ObjectId(), readOnly: false };
-
-  const pageExists = vi.fn();
-  const renamePage = vi.fn();
-  const fireGlobalNotification = vi.fn();
-
-  const mockedFindPageAndMetaDataByViewer = vi.mocked(
-    findPageAndMetaDataByViewer,
-  );
+  const requesterUsername = 'rename-route-integ-requester';
+  const ownerUsername = 'rename-route-integ-owner';
+  const sourcePath = '/rename-route-integ/source';
+  const sourceChildPath = `${sourcePath}/child`;
+  const renamedPath = '/rename-route-integ/renamed';
+  const renamedChildPath = `${renamedPath}/child`;
+  const forbiddenPath = '/rename-route-integ/forbidden';
 
   let app: express.Application;
   let crowi: Crowi;
+  let requester: HydratedDocument<IUser>;
+  let owner: HydratedDocument<IUser>;
+  let rootPage: HydratedDocument<PageDocument> | null = null;
+  let rootPageWasCreated = false;
 
   beforeAll(async () => {
-    crowi = mock<Crowi>({
-      models: {
-        Page: { exists: pageExists } as unknown as Crowi['models']['Page'],
-        User: {} as Crowi['models']['User'],
+    crowi = await getInstance();
+    const { Page, User } = crowi.models;
+
+    await Page.deleteMany({
+      path: {
+        $in: [
+          sourcePath,
+          sourceChildPath,
+          renamedPath,
+          renamedChildPath,
+          forbiddenPath,
+        ],
       },
-      events: {
-        activity: { emit: vi.fn() },
-      },
-      globalNotificationService: {
-        fire: fireGlobalNotification,
-      },
-      pageService: {
-        renamePage,
-      },
-      pageGrantService: mock<Crowi['pageGrantService']>(),
+    });
+    await User.deleteMany({
+      username: { $in: [requesterUsername, ownerUsername] },
+    });
+
+    rootPage = await Page.findOne({ path: '/' });
+    if (rootPage == null) {
+      rootPage = await Page.create({
+        path: '/',
+        grant: PageGrant.GRANT_PUBLIC,
+      });
+      rootPageWasCreated = true;
+    }
+
+    requester = await User.create({
+      name: requesterUsername,
+      username: requesterUsername,
+      email: `${requesterUsername}@example.com`,
+    });
+    owner = await User.create({
+      name: ownerUsername,
+      username: ownerUsername,
+      email: `${ownerUsername}@example.com`,
     });
 
     addCustomFunctionToResponse(express);
@@ -83,125 +92,129 @@ describe('PUT /rename', () => {
     app = express();
     app.use(express.json());
     app.use((req: AuthenticatedRequest, _res, next) => {
-      req.user = user;
+      req.user = requester;
       next();
     });
 
-    const pagesModule = (await import('./index')) as unknown as {
-      setup: (crowi: Crowi) => express.Router;
-    };
-    app.use('/', pagesModule.setup(crowi));
-  });
+    const { setup } = await import('./index');
+    app.use('/', setup(crowi));
+  }, 120_000);
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    pageExists.mockResolvedValue(null);
-    fireGlobalNotification.mockResolvedValue(undefined);
-  });
-
-  it('returns page-not-found for an authenticated request with a valid missing page ID', async () => {
-    mockedFindPageAndMetaDataByViewer.mockResolvedValueOnce({
-      data: null,
-      meta: {
-        isNotFound: true,
-        isForbidden: false,
+  afterEach(async () => {
+    await crowi.models.Page.deleteMany({
+      path: {
+        $in: [
+          sourcePath,
+          sourceChildPath,
+          renamedPath,
+          renamedChildPath,
+          forbiddenPath,
+        ],
       },
-    } as never);
+    });
+  });
+
+  afterAll(async () => {
+    await crowi.models.Page.deleteMany({
+      path: {
+        $in: [
+          sourcePath,
+          sourceChildPath,
+          renamedPath,
+          renamedChildPath,
+          forbiddenPath,
+        ],
+      },
+    });
+    await crowi.models.User.deleteMany({
+      username: { $in: [requesterUsername, ownerUsername] },
+    });
+    if (rootPageWasCreated && rootPage != null) {
+      await crowi.models.Page.deleteOne({ _id: rootPage._id });
+    }
+  });
+
+  it('returns 404 when an authenticated user renames a missing page', async () => {
+    const pageId = new Types.ObjectId();
 
     const response = await request(app).put('/rename').send({
-      pageId,
-      newPagePath: '/renamed-page',
+      pageId: pageId.toString(),
+      newPagePath: renamedPath,
     });
 
     expect(response.status).toBe(404);
-    expect(response.body).toEqual({
-      errors: [
-        {
-          code: 'page-not-found',
-          args: {
-            isNotFound: true,
-            isForbidden: false,
-          },
-          message: 'Page is not found',
-        },
-      ],
-    });
-    expect(renamePage).not.toHaveBeenCalled();
-    expect(mockedFindPageAndMetaDataByViewer).toHaveBeenCalledWith(
-      crowi.pageService,
-      crowi.pageGrantService,
-      {
-        pageId,
-        path: null,
-        user,
-        basicOnly: true,
-      },
-    );
+    expect(response.status).not.toBe(500);
+    expect(response.body.errors).toEqual([
+      expect.objectContaining({
+        code: 'notfound_or_forbidden',
+        message: `Page '${pageId}' is not found or forbidden`,
+      }),
+    ]);
   });
 
-  it('returns page-is-forbidden for an authenticated request without page access', async () => {
-    mockedFindPageAndMetaDataByViewer.mockResolvedValueOnce({
-      data: null,
-      meta: {
-        isNotFound: true,
-        isForbidden: true,
-      },
-    } as never);
+  it('returns 403 and leaves a forbidden page unchanged', async () => {
+    const page = await crowi.models.Page.create({
+      path: forbiddenPath,
+      grant: PageGrant.GRANT_OWNER,
+      grantedUsers: [owner._id],
+      creator: owner._id,
+      lastUpdateUser: owner._id,
+      isEmpty: true,
+      descendantCount: 0,
+    });
 
     const response = await request(app).put('/rename').send({
-      pageId,
-      newPagePath: '/renamed-page',
+      pageId: page._id.toString(),
+      newPagePath: renamedPath,
     });
 
     expect(response.status).toBe(403);
-    expect(response.body).toEqual({
-      errors: [
-        {
-          code: 'page-is-forbidden',
-          args: {
-            isNotFound: true,
-            isForbidden: true,
-          },
-          message: 'Page is forbidden',
-        },
-      ],
-    });
-    expect(renamePage).not.toHaveBeenCalled();
+    expect(response.status).not.toBe(500);
+    expect(response.body.errors).toEqual([
+      expect.objectContaining({
+        code: 'notfound_or_forbidden',
+        message: `Page '${page._id}' is not found or forbidden`,
+      }),
+    ]);
+
+    const unchangedPage = await crowi.models.Page.findById(page._id);
+    expect(unchangedPage?.path).toBe(forbiddenPath);
   });
 
-  it('continues to rename an accessible page', async () => {
-    const page = {
-      _id: pageId,
-      path: '/source-page',
-      descendantCount: 1,
-      isEmpty: true,
-    };
-    const renamedPage = {
-      ...page,
-      path: '/renamed-page',
-    };
+  it('renames an accessible page and its descendant', async () => {
+    if (rootPage == null) {
+      throw new Error('root page must be initialized in beforeAll');
+    }
 
-    mockedFindPageAndMetaDataByViewer.mockResolvedValueOnce({
-      data: page,
-      meta: {
-        isNotFound: false,
-      },
-    } as never);
-    renamePage.mockResolvedValueOnce(renamedPage);
+    const page = await crowi.models.Page.create({
+      path: sourcePath,
+      parent: rootPage._id,
+      grant: PageGrant.GRANT_PUBLIC,
+      creator: requester._id,
+      lastUpdateUser: requester._id,
+      isEmpty: true,
+      descendantCount: 1,
+    });
+    const childPage = await crowi.models.Page.create({
+      path: sourceChildPath,
+      grant: PageGrant.GRANT_PUBLIC,
+      creator: requester._id,
+      lastUpdateUser: requester._id,
+      descendantCount: 0,
+    });
 
     const response = await request(app).put('/rename').send({
-      pageId,
-      newPagePath: '/renamed-page',
+      pageId: page._id.toString(),
+      newPagePath: renamedPath,
     });
 
     expect(response.status).toBe(200);
-    expect(response.body).toEqual({ page: renamedPage });
-    expect(renamePage).toHaveBeenCalledWith(
-      page,
-      '/renamed-page',
-      user,
-      expect.objectContaining({ isRecursively: true }),
-      expect.objectContaining({ endpoint: '/rename' }),
-    );
+    expect(response.body.page.path).toBe(renamedPath);
+
+    const renamedPage = await crowi.models.Page.findById(page._id);
+    expect(renamedPage?.path).toBe(renamedPath);
+
+    const renamedChildPage = await crowi.models.Page.findById(childPage._id);
+    expect(renamedChildPage?.path).toBe(renamedChildPath);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #11572.

The rename route previously read `page.descendantCount` before checking whether the page lookup returned `null`, causing a 500 for a valid-but-missing page ID.

- return `404 page-not-found` for missing pages
- return `403 page-is-forbidden` for inaccessible pages
- align the APIV3 OpenAPI responses
- add focused regression coverage for missing, forbidden, and successful rename requests

## Validation

Validated with Node 24.18.0 and pnpm 11.1.1.

- focused rename integration tests
- related APIV3 page route tests
- typecheck
- APIV3 OpenAPI validation