### PR TITLE
fix: Replace dead Slack invite link with a single redirect page

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/growilabs/growi/discussions
     about: If you have feature requests or suggestions, you can create a new discussion and consider it with the community.
   - name: Questions
-    url: https://join.slack.com/t/wsgrowi/shared_invite/zt-45hm10bo3-djV8tFMsJdV1VfTiGeIKPg
+    url: https://docs.growi.org/slack
     about: If you have questions, you can join our Slack team and talk about anything, anytime.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/growilabs/growi/discussions
     about: If you have feature requests or suggestions, you can create a new discussion and consider it with the community.
   - name: Questions
-    url: https://communityinviter.com/apps/wsgrowi/invite/
+    url: https://join.slack.com/t/wsgrowi/shared_invite/zt-45hm10bo3-djV8tFMsJdV1VfTiGeIKPg
     about: If you have questions, you can join our Slack team and talk about anything, anytime.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 <p align="center">
   <a href="https://github.com/growilabs/growi/releases/latest"><img src="https://img.shields.io/github/release/growilabs/growi.svg" alt="Latest version"></a>
-  <a href="https://communityinviter.com/apps/wsgrowi/invite/"><img src="https://img.shields.io/badge/Slack-Join%20Us-4A154B?style=flat&logo=slack&logoColor=white" alt="Slack - Join US"></a>
+  <a href="https://join.slack.com/t/wsgrowi/shared_invite/zt-45hm10bo3-djV8tFMsJdV1VfTiGeIKPg"><img src="https://img.shields.io/badge/Slack-Join%20Us-4A154B?style=flat&logo=slack&logoColor=white" alt="Slack - Join US"></a>
 </p>
 
 <p align="center">
@@ -132,7 +132,7 @@ You can write issues and PRs in English or Japanese.
 
 ## Discussion
 
-If you have questions or suggestions, you can [join our Slack team](https://communityinviter.com/apps/wsgrowi/invite/) and talk about anything, anytime.
+If you have questions or suggestions, you can [join our Slack team](https://join.slack.com/t/wsgrowi/shared_invite/zt-45hm10bo3-djV8tFMsJdV1VfTiGeIKPg) and talk about anything, anytime.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 <p align="center">
   <a href="https://github.com/growilabs/growi/releases/latest"><img src="https://img.shields.io/github/release/growilabs/growi.svg" alt="Latest version"></a>
-  <a href="https://join.slack.com/t/wsgrowi/shared_invite/zt-45hm10bo3-djV8tFMsJdV1VfTiGeIKPg"><img src="https://img.shields.io/badge/Slack-Join%20Us-4A154B?style=flat&logo=slack&logoColor=white" alt="Slack - Join US"></a>
+  <a href="https://docs.growi.org/slack"><img src="https://img.shields.io/badge/Slack-Join%20Us-4A154B?style=flat&logo=slack&logoColor=white" alt="Slack - Join US"></a>
 </p>
 
 <p align="center">
@@ -132,7 +132,7 @@ You can write issues and PRs in English or Japanese.
 
 ## Discussion
 
-If you have questions or suggestions, you can [join our Slack team](https://join.slack.com/t/wsgrowi/shared_invite/zt-45hm10bo3-djV8tFMsJdV1VfTiGeIKPg) and talk about anything, anytime.
+If you have questions or suggestions, you can [join our Slack team](https://docs.growi.org/slack) and talk about anything, anytime.
 
 # License
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -7,7 +7,7 @@
 </p>
 <p align="center">
   <a href="https://github.com/growilabs/growi/releases/latest"><img src="https://img.shields.io/github/release/growilabs/growi.svg" alt="Latest version"></a>
-  <a href="https://join.slack.com/t/wsgrowi/shared_invite/zt-45hm10bo3-djV8tFMsJdV1VfTiGeIKPg"><img src="https://img.shields.io/badge/Slack-Join%20Us-4A154B?style=flat&logo=slack&logoColor=white" alt="Slack - Join US"></a>
+  <a href="https://docs.growi.org/slack"><img src="https://img.shields.io/badge/Slack-Join%20Us-4A154B?style=flat&logo=slack&logoColor=white" alt="Slack - Join US"></a>
 </p>
 
 <p align="center">
@@ -130,7 +130,7 @@ Issue と Pull requests の作成は英語・日本語どちらでも受け付�
 
 ## GROWI について話し合いましょう！
 
-質問や提案があれば、私たちの [Slack team](https://join.slack.com/t/wsgrowi/shared_invite/zt-45hm10bo3-djV8tFMsJdV1VfTiGeIKPg) にぜひご参加ください。
+質問や提案があれば、私たちの [Slack team](https://docs.growi.org/slack) にぜひご参加ください。
 いつでも、どこでも GROWI について議論しましょう！
 
 # ライセンス

--- a/README_JP.md
+++ b/README_JP.md
@@ -7,7 +7,7 @@
 </p>
 <p align="center">
   <a href="https://github.com/growilabs/growi/releases/latest"><img src="https://img.shields.io/github/release/growilabs/growi.svg" alt="Latest version"></a>
-  <a href="https://communityinviter.com/apps/wsgrowi/invite/"><img src="https://img.shields.io/badge/Slack-Join%20Us-4A154B?style=flat&logo=slack&logoColor=white" alt="Slack - Join US"></a>
+  <a href="https://join.slack.com/t/wsgrowi/shared_invite/zt-45hm10bo3-djV8tFMsJdV1VfTiGeIKPg"><img src="https://img.shields.io/badge/Slack-Join%20Us-4A154B?style=flat&logo=slack&logoColor=white" alt="Slack - Join US"></a>
 </p>
 
 <p align="center">
@@ -130,7 +130,7 @@ Issue と Pull requests の作成は英語・日本語どちらでも受け付�
 
 ## GROWI について話し合いましょう！
 
-質問や提案があれば、私たちの [Slack team](https://communityinviter.com/apps/wsgrowi/invite/) にぜひご参加ください。
+質問や提案があれば、私たちの [Slack team](https://join.slack.com/t/wsgrowi/shared_invite/zt-45hm10bo3-djV8tFMsJdV1VfTiGeIKPg) にぜひご参加ください。
 いつでも、どこでも GROWI について議論しましょう！
 
 # ライセンス

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@
 
 If you believe you have found a security vulnerability in any GROWI related repository, please report it to us using one of the methods described below.
 
-  * [Join our Slack team](https://join.slack.com/t/wsgrowi/shared_invite/zt-45hm10bo3-djV8tFMsJdV1VfTiGeIKPg) and send DM to `@yuki` who is the lead developer
+  * [Join our Slack team](https://docs.growi.org/slack) and send DM to `@yuki` who is the lead developer
   * Report to JPCERT/CC[^jpcertcc]
     * [[PDF] JPCERT/CC Vulnerability Coordination and Disclosure Policy](https://www.jpcert.or.jp/english/vh/vul-coordination-disclosure-policy_2019.pdf)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@
 
 If you believe you have found a security vulnerability in any GROWI related repository, please report it to us using one of the methods described below.
 
-  * [Join our Slack team](https://communityinviter.com/apps/wsgrowi/invite/) and send DM to `@yuki` who is the lead developer
+  * [Join our Slack team](https://join.slack.com/t/wsgrowi/shared_invite/zt-45hm10bo3-djV8tFMsJdV1VfTiGeIKPg) and send DM to `@yuki` who is the lead developer
   * Report to JPCERT/CC[^jpcertcc]
     * [[PDF] JPCERT/CC Vulnerability Coordination and Disclosure Policy](https://www.jpcert.or.jp/english/vh/vul-coordination-disclosure-policy_2019.pdf)
 

--- a/apps/slackbot-proxy/src/views/top.ejs
+++ b/apps/slackbot-proxy/src/views/top.ejs
@@ -41,7 +41,7 @@
           <div class="mt-3">
             GROWI is open-source software developed by GROWI, Inc. and we are looking for contributors who can work with
             us.<br>
-            Please <a href="https://communityinviter.com/apps/wsgrowi/invite/">join</a> Slack and feel free to talk to
+            Please <a href="https://join.slack.com/t/wsgrowi/shared_invite/zt-45hm10bo3-djV8tFMsJdV1VfTiGeIKPg">join</a> Slack and feel free to talk to
             GROWI, Inc. members!
           </div>
         </div>

--- a/apps/slackbot-proxy/src/views/top.ejs
+++ b/apps/slackbot-proxy/src/views/top.ejs
@@ -41,7 +41,7 @@
           <div class="mt-3">
             GROWI is open-source software developed by GROWI, Inc. and we are looking for contributors who can work with
             us.<br>
-            Please <a href="https://join.slack.com/t/wsgrowi/shared_invite/zt-45hm10bo3-djV8tFMsJdV1VfTiGeIKPg">join</a> Slack and feel free to talk to
+            Please <a href="https://docs.growi.org/slack">join</a> Slack and feel free to talk to
             GROWI, Inc. members!
           </div>
         </div>


### PR DESCRIPTION
## 概要

死んでいる Slack 招待リンクを差し替え、あわせて招待 URL の置き場所を 1 箇所に一本化します。

Closes #11619

**マージ順序**: このPRの前に growilabs/growi-docs#615 をマージ・デプロイして `https://docs.growi.org/slack` が生きた状態にしてください。

## 原因

CommunityInviter が旧ドメイン配下の招待ページごとサービスを廃止したため、`https://communityinviter.com/apps/wsgrowi/invite/` は誰から見ても **HTTP 404** になっています。`communityinviter.com/apps/kubernetes/community` など他ワークスペースの招待ページも同様に 404 で、トップページは "Community Inviter has been deprecated" と表示して `inviter.co` へリダイレクトします。GROWI 側の設定切れではありません。

代替手段の検討結果:

- Slack はメールアドレスを指定して招待する API（`admin.users.invite`）を Enterprise Grid 限定にしており、legacy token も廃止済みです。slackin 系の自動招待フォームは Free / Pro / Business+ では動きません（CNCF の `cncf/slack-inviter` でさえ中身は共有招待リンクへのリダイレクトです）。
- 後継サービスの inviter.co は Free プランで Slack 連携が対象外（Pro は月額 $19.99）です。

したがって、追加コストなしで使える Slack 標準の共有招待リンクを採用しました。

## なぜ URL を直接埋め込まないのか

共有招待リンクは永続ではありません。

- 1 リンクあたり **400 人**まで
- 累計 2,000 招待を超えると「無期限（Never expires）」指定が効かなくなる
- オーナーはいつでも無効化・再発行できる

つまり将来また必ず差し替えが発生します。今回 5 ファイル・7 箇所すべてが同時に死んだのは、URL を各所に直接埋め込んでいたからです。そこで growi-docs 側に置いたリダイレクトページ `https://docs.growi.org/slack` を指すようにして、次回の差し替えを 1 ファイルで済むようにします。

## 変更内容

旧 URL を参照していた 5 ファイル・7 箇所すべてを `https://docs.growi.org/slack` に差し替えました。

- `README.md`（バッジ・Discussion 節）
- `README_JP.md`（バッジ・Discussion 節）
- `SECURITY.md`
- `.github/ISSUE_TEMPLATE/config.yml`
- `apps/slackbot-proxy/src/views/top.ejs`

リダイレクトページ本体と、リンクの死活を見張るワークフローは growilabs/growi-docs#615 です。

## 動作確認

- [x] 新しい招待リンクが有効であることを確認（`302` → `wsgrowi.slack.com/join/shared_invite/...`）
- [x] `communityinviter` / `join.slack.com` の残存参照が 0 件であることを確認（`git grep`）
- [x] `.github/ISSUE_TEMPLATE/config.yml` が YAML として正しく読めることを確認
- [ ] growilabs/growi-docs#615 のデプロイ後、`https://docs.growi.org/slack` から実際に Slack に参加できること
- [ ] README のバッジと Issue テンプレートの Questions リンクが上記ページに到達すること

## 補足（このPRの範囲外）

`SECURITY.md` の脆弱性報告経路が Slack DM 依存のままなので、招待リンクが死ぬと報告経路も同時に死ぬ構造です（本 issue の報告者はまさにこれで詰まりました）。GitHub の Private Vulnerability Reporting は現在無効で、Supported Versions の表も `4.4.x` のままです。これらは別途対応が必要です。