### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
   - [docker-compose](#docker-compose)
   - [Helm (Experimental)](#helm-experimental)
   - [On-premise](#on-premise)
+  - [Managed hosting](#managed-hosting)
 - [Environment Variables](#environment-variables)
 - [Documentation](#documentation)
 - [License](#license)
@@ -68,6 +69,10 @@
 
 - [GROWI Docs: Install on Ubuntu Server](https://docs.growi.org/en/admin-guide/getting-started/ubuntu-server.html)
 - [GROWI Docs: Install on CentOS](https://docs.growi.org/en/admin-guide/getting-started/centos.html)
+
+### Managed hosting
+
+- [![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/growi) one-click managed GROWI on Zenith: storage, backups, email and a free subdomain included. A share of every subscription goes back to GROWI.
 
 ## Configuration
 


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added GROWI to our marketplace, so this PR adds a small "Deploy with Zenith" badge under "Quick Start for Production" in the README (links to https://zenith.hosting/host/growi).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

### What this changes

- one new `### Managed hosting` subsection at the end of "Quick Start for Production", next to docker-compose / Helm / On-premise
- the matching line in the Table Of Contents so it stays in sync

README.md only, nothing else touched, no code and no changeset.

### Notes

I know GROWI.cloud is the official managed offering, and I am not trying to sit above it. Happy to move this lower, reword it, mark it clearly as third-party, or close this if you would rather the README only point at first-party hosting.

If you do want it, I am also happy to mirror the same lines into `README_JP.md` in Japanese. I left it out of this PR to keep the diff to a single file, just say the word.
