### PR TITLE
fix(openapi): Restore operationId injection in the published apiv3 spec

### DIFF
--- a/apps/app/bin/openapi/assert-operation-ids.spec.ts
+++ b/apps/app/bin/openapi/assert-operation-ids.spec.ts
@@ -1,0 +1,103 @@
+import fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { assertOperationIds } from './assert-operation-ids';
+
+/**
+ * The generated spec is published to docs.growi.org and consumed by code
+ * generators (orval, in `@growi/sdk-typescript`) that derive every symbol name
+ * from `operationId`. A spec that loses those ids still validates as OpenAPI,
+ * so nothing downstream rejects it — it just silently renames the whole
+ * generated client (#11634).
+ *
+ * This assertion is the artifact-level guard: it runs on the finished file, so
+ * it catches a generation step that exited successfully while doing nothing.
+ */
+async function writeSpec(spec: unknown): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(tmpdir(), 'assert-operation-ids-'));
+  const file = path.join(dir, 'openapi.json');
+  await fs.writeFile(file, JSON.stringify(spec));
+  return file;
+}
+
+const operation = (operationId?: string) => ({
+  responses: { 200: { description: 'ok' } },
+  ...(operationId != null ? { operationId } : {}),
+});
+
+describe('assertOperationIds', () => {
+  it('accepts a spec whose every operation has an operationId', async () => {
+    const file = await writeSpec({
+      openapi: '3.0.0',
+      info: { title: 'test', version: '1.0.0' },
+      paths: {
+        '/page/exist': { get: operation('getExistForPage') },
+        '/pages/delete': { post: operation('postDeleteForPages') },
+      },
+    });
+
+    expect(() => assertOperationIds(file)).not.toThrow();
+  });
+
+  it('rejects a spec where every operationId is missing', async () => {
+    const file = await writeSpec({
+      openapi: '3.0.0',
+      info: { title: 'test', version: '1.0.0' },
+      paths: {
+        '/page/exist': { get: operation() },
+        '/pages/delete': { post: operation() },
+      },
+    });
+
+    expect(() => assertOperationIds(file)).toThrow(/operationId/);
+  });
+
+  it('rejects a spec where only some operationIds are missing', async () => {
+    const file = await writeSpec({
+      openapi: '3.0.0',
+      info: { title: 'test', version: '1.0.0' },
+      paths: {
+        '/page/exist': { get: operation('getExistForPage') },
+        '/pages/delete': { post: operation() },
+      },
+    });
+
+    expect(() => assertOperationIds(file)).toThrow(/POST \/pages\/delete/);
+  });
+
+  it('rejects a spec that declares no operations at all', async () => {
+    const file = await writeSpec({
+      openapi: '3.0.0',
+      info: { title: 'test', version: '1.0.0' },
+      paths: {},
+    });
+
+    expect(() => assertOperationIds(file)).toThrow(/no operations/i);
+  });
+
+  it('ignores non-operation keys of a path item', async () => {
+    const file = await writeSpec({
+      openapi: '3.0.0',
+      info: { title: 'test', version: '1.0.0' },
+      paths: {
+        '/page/{pageId}': {
+          parameters: [{ name: 'pageId', in: 'path', required: true }],
+          summary: 'a path-level summary, not an operation',
+          get: operation('getPageByPageId'),
+        },
+      },
+    });
+
+    expect(() => assertOperationIds(file)).not.toThrow();
+  });
+
+  it('rejects a file that is not readable as JSON', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'assert-operation-ids-'));
+    const file = path.join(dir, 'openapi.json');
+    await fs.writeFile(file, 'this is not valid json');
+
+    expect(() => assertOperationIds(file)).toThrow();
+  });
+});

--- a/apps/app/bin/openapi/assert-operation-ids.ts
+++ b/apps/app/bin/openapi/assert-operation-ids.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+import { isHttpMethod } from './http-methods';
+
+type Operation = { operationId?: string };
+
+/**
+ * Fails when the spec at `file` is not safe to publish.
+ *
+ * This runs on the *finished artifact* instead of inside the generation step,
+ * so it still fires when a generation step exits successfully without having
+ * done its work. That is the failure mode behind #11634: the operationId
+ * injection step never ran, the script reported success anyway, and the spec
+ * published to docs.growi.org carried 4 operationIds instead of 241. Code
+ * generators (orval, in `@growi/sdk-typescript`) fall back to naming functions
+ * after the HTTP method and path when an operationId is absent, so the result
+ * was a silent, wholesale rename of the generated client rather than an error.
+ */
+export const assertOperationIds = (file: string): void => {
+  const spec = JSON.parse(readFileSync(file, 'utf8'));
+
+  const operations = Object.entries<Record<string, unknown>>(
+    spec.paths ?? {},
+  ).flatMap(([path, pathItem]) =>
+    Object.entries(pathItem)
+      .filter(([key]) => isHttpMethod(key))
+      .map(([method, operation]) => ({
+        label: `${method.toUpperCase()} ${path}`,
+        operationId: (operation as Operation).operationId,
+      })),
+  );
+
+  if (operations.length === 0) {
+    throw new Error(
+      `${file} declares no operations — the spec is empty or its paths could not be read`,
+    );
+  }
+
+  const withoutId = operations.filter((op) => op.operationId == null);
+  if (withoutId.length > 0) {
+    throw new Error(
+      `${withoutId.length} of ${operations.length} operations in ${file} have no operationId: ${withoutId
+        .map((op) => op.label)
+        .join(', ')}`,
+    );
+  }
+};
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try {
+    const file = process.argv[2];
+    if (file == null) {
+      throw new Error('usage: assert-operation-ids <openapi-spec.json>');
+    }
+    assertOperationIds(file);
+  } catch (err) {
+    // biome-ignore lint/suspicious/noConsole: this is a CLI entry point
+    console.error(err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  }
+}

--- a/apps/app/bin/openapi/generate-operation-ids/cli.spec.ts
+++ b/apps/app/bin/openapi/generate-operation-ids/cli.spec.ts
@@ -77,7 +77,10 @@ describe('cli', () => {
     });
   });
 
-  it('handles generateOperationIds error correctly', async () => {
+  // The caller is a shell script whose only signal is this process's exit code.
+  // Swallowing the rejection here made the script report success while the spec
+  // it published had no operationId at all (#11634).
+  it('propagates a generateOperationIds failure instead of completing normally', async () => {
     // Mock generateOperationIds to throw error
     const error = new Error('Test error');
     vi.mocked(generateOperationIds).mockRejectedValue(error);
@@ -87,11 +90,7 @@ describe('cli', () => {
 
     // Import the module that contains the main function
     const cliModule = await import('./cli');
-    await cliModule.main();
-
-    // Verify error was logged
-    // biome-ignore lint/suspicious/noConsole: This is a test file
-    expect(console.error).toHaveBeenCalledWith(error);
+    await expect(cliModule.main()).rejects.toThrow('Test error');
 
     // Verify writeFileSync was not called
     expect(writeFileSync).not.toHaveBeenCalled();

--- a/apps/app/bin/openapi/generate-operation-ids/cli.ts
+++ b/apps/app/bin/openapi/generate-operation-ids/cli.ts
@@ -1,4 +1,5 @@
 import { writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 import { Command } from 'commander';
 
 import { generateOperationIds } from './generate-operation-ids';
@@ -16,15 +17,22 @@ export const main = async (): Promise<void> => {
   const { out: outputFile, overwriteExisting } = program.opts();
   const [inputFile] = program.args;
 
+  // Let a failure propagate: the caller is a shell script whose only signal is
+  // this process's exit code, and swallowing it here made the script report
+  // success while publishing a spec with no operationId (#11634).
   const jsonStrings = await generateOperationIds(inputFile, {
     overwriteExisting,
-    // biome-ignore lint/suspicious/noConsole: Allow to dump errors
-  }).catch(console.error);
-  if (jsonStrings != null) {
-    writeFileSync(outputFile ?? inputFile, jsonStrings);
-  }
+  });
+  writeFileSync(outputFile ?? inputFile, jsonStrings);
 };
 
-if (import.meta.url === `file://${process.argv[1]}`) {
-  main();
+// `pathToFileURL` rather than string-concatenating `file://`: argv[1] is a
+// plain path while import.meta.url is percent-encoded, so a checkout path
+// containing a space or `#` would make the two differ and silently skip main().
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main().catch((err) => {
+    // biome-ignore lint/suspicious/noConsole: this is a CLI entry point
+    console.error(err);
+    process.exitCode = 1;
+  });
 }

--- a/apps/app/bin/openapi/generate-operation-ids/generate-operation-ids.ts
+++ b/apps/app/bin/openapi/generate-operation-ids/generate-operation-ids.ts
@@ -5,6 +5,8 @@ import type {
   PathItemObject,
 } from 'openapi-typescript';
 
+import { HTTP_METHODS } from '../http-methods';
+
 const toPascal = (s: string): string =>
   s
     .split('-')
@@ -55,18 +57,7 @@ export async function generateOperationIds(
 
   Object.entries(api.paths || {}).forEach(([path, pathItem]) => {
     const item = pathItem as PathItemObject;
-    (
-      [
-        'get',
-        'post',
-        'put',
-        'delete',
-        'patch',
-        'options',
-        'head',
-        'trace',
-      ] as const
-    ).forEach((method) => {
+    HTTP_METHODS.forEach((method) => {
       const operation = item[method] as OperationObject | undefined;
       if (
         operation == null ||

--- a/apps/app/bin/openapi/generate-spec-apiv3.sh
+++ b/apps/app/bin/openapi/generate-spec-apiv3.sh
@@ -2,10 +2,24 @@
 #   cd apps/app && sh bin/openapi/generate-spec-apiv3.sh
 #   APP_PATH=/path/to/apps/app sh bin/openapi/generate-spec-apiv3.sh
 #   APP_PATH=/path/to/apps/app OUT=/path/to/output sh bin/openapi/generate-spec-apiv3.sh
+#
+# APP_PATH may be absolute or relative in any form; growi-docs' api:build passes
+# a bare relative `tmp/growi/apps/app`.
+
+# Fail on the first failing step. The operationId injection below is what
+# external consumers of this spec depend on, and it used to be able to fail
+# while the script still exited 0 and printed a success message (#11634).
+set -e
 
 APP_PATH=${APP_PATH:-"."}
 
 OUT=${OUT:-"${APP_PATH}/tmp/openapi-spec-apiv3.json"}
+
+# `node --import` resolves its value as an ES module specifier, not as a
+# filesystem path, so a bare relative form such as `tmp/growi/apps/app/...` is
+# read as a *package name* and fails with ERR_MODULE_NOT_FOUND. Resolve APP_PATH
+# to an absolute path once so every specifier below is unambiguous.
+APP_PATH_ABS=$(cd "${APP_PATH}" && pwd)
 
 swagger-jsdoc \
   -o "${OUT}" \
@@ -20,7 +34,15 @@ swagger-jsdoc \
   "${APP_PATH}/src/server/routes/login.js" \
   "${APP_PATH}/src/server/models/openapi/**/*.{js,ts}"
 
-if [ $? -eq 0 ]; then
-  node --import "${APP_PATH}/bin/runtime/dev-esm-resolver.mjs" "${APP_PATH}/bin/openapi/generate-operation-ids/cli.ts" "${OUT}" --out "${OUT}" --overwrite-existing
-  echo "OpenAPI spec generated and transformed: ${OUT}"
-fi
+node --import "${APP_PATH_ABS}/bin/runtime/dev-esm-resolver.mjs" \
+  "${APP_PATH_ABS}/bin/openapi/generate-operation-ids/cli.ts" \
+  "${OUT}" --out "${OUT}" --overwrite-existing
+
+# Check the finished artifact, not just the exit codes above: a generation step
+# that exits 0 without doing its work would otherwise publish a spec whose
+# operationIds are missing, silently renaming every symbol in the generated SDKs.
+node --import "${APP_PATH_ABS}/bin/runtime/dev-esm-resolver.mjs" \
+  "${APP_PATH_ABS}/bin/openapi/assert-operation-ids.ts" \
+  "${OUT}"
+
+echo "OpenAPI spec generated and transformed: ${OUT}"

--- a/apps/app/bin/openapi/generate-spec-apiv3.spec.ts
+++ b/apps/app/bin/openapi/generate-spec-apiv3.spec.ts
@@ -1,0 +1,151 @@
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join, resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { isHttpMethod } from './http-methods';
+
+/**
+ * Contract test for the apiv3 spec generation script.
+ *
+ * The script is consumed by an *external* repository: growi-docs' `api:build`
+ * runs it as `APP_PATH=tmp/growi/apps/app sh "${APP_PATH}/bin/openapi/generate-spec-apiv3.sh"`
+ * and publishes the result to docs.growi.org. So the contract under test is the
+ * one that caller depends on, exercised the way it actually calls it — a child
+ * `sh <script>` process with APP_PATH given as a **bare relative path**.
+ *
+ * Regression guard for #11634: `node --import` resolves its value as an ES
+ * module specifier, not as a filesystem path, so a bare relative APP_PATH made
+ * Node read `tmp/growi/...` as a *package name* and fail with
+ * ERR_MODULE_NOT_FOUND. The injection step never ran, yet the script still
+ * exited 0 and printed "generated and transformed" — publishing a spec with no
+ * operationId, which silently renamed every symbol in the generated SDKs.
+ *
+ * `swagger-jsdoc` is stubbed so these tests exercise the script's wiring and
+ * failure propagation rather than re-scanning every route file (that is what
+ * `generate-operation-ids.spec.ts` and the real build cover).
+ */
+
+const APP_ROOT = resolve(import.meta.dirname, '..', '..');
+const REPO_ROOT = resolve(APP_ROOT, '..', '..');
+const SCRIPT = 'apps/app/bin/openapi/generate-spec-apiv3.sh';
+
+/** Two operations taken from the endpoints named in #11634, with no operationId. */
+const SPEC_WITHOUT_OPERATION_IDS = JSON.stringify({
+  openapi: '3.0.0',
+  info: { title: 'test', version: '1.0.0' },
+  paths: {
+    '/page/exist': { get: { responses: { 200: { description: 'ok' } } } },
+    '/pages/delete': { post: { responses: { 200: { description: 'ok' } } } },
+  },
+});
+
+describe.skipIf(process.platform === 'win32')('generate-spec-apiv3.sh', () => {
+  let dir: string;
+  let stubDir: string;
+  let out: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'generate-spec-apiv3-'));
+    stubDir = join(dir, 'bin');
+    out = join(dir, 'openapi-spec-apiv3.json');
+    writeFileSync(join(dir, 'fixture.json'), SPEC_WITHOUT_OPERATION_IDS);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  /**
+   * Put a stub `swagger-jsdoc` first on PATH. It copies `payloadFile` to the
+   * path given after `-o`, mimicking the real generator's only observable
+   * effect, and exits with `exitCode`.
+   */
+  const stubSwaggerJsdoc = (payloadFile: string, exitCode = 0): void => {
+    const stub = join(stubDir, 'swagger-jsdoc');
+    mkdirSync(stubDir, { recursive: true });
+    writeFileSync(
+      stub,
+      [
+        '#!/bin/sh',
+        'while [ $# -gt 0 ]; do',
+        '  if [ "$1" = "-o" ]; then shift; OUTF="$1"; fi',
+        '  shift',
+        'done',
+        `cat "${payloadFile}" > "$OUTF"`,
+        `exit ${exitCode}`,
+        '',
+      ].join('\n'),
+      { mode: 0o755 },
+    );
+    chmodSync(stub, 0o755);
+  };
+
+  /** Run the script the way growi-docs does: bare relative APP_PATH, from the repo root. */
+  const runScript = () =>
+    spawnSync('sh', [SCRIPT], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        APP_PATH: 'apps/app',
+        OUT: out,
+        PATH: `${stubDir}${delimiter}${process.env.PATH ?? ''}`,
+      },
+    });
+
+  it('injects an operationId into every operation when APP_PATH is a bare relative path', () => {
+    stubSwaggerJsdoc(join(dir, 'fixture.json'));
+
+    const result = runScript();
+
+    expect(result.status).toBe(0);
+
+    const spec = JSON.parse(readFileSync(out, 'utf8'));
+
+    // The published names the SDK generates from (#11634 lists both).
+    expect(spec.paths['/page/exist'].get.operationId).toBe('getExistForPage');
+    expect(spec.paths['/pages/delete'].post.operationId).toBe(
+      'postDeleteForPages',
+    );
+
+    // Drift guard: no operation may reach the artifact without an id, however
+    // the injection step is wired up.
+    const withoutId = Object.entries<Record<string, { operationId?: string }>>(
+      spec.paths,
+    ).flatMap(([path, item]) =>
+      Object.entries(item)
+        .filter(([method]) => isHttpMethod(method))
+        .filter(([, operation]) => operation.operationId == null)
+        .map(([method]) => `${method.toUpperCase()} ${path}`),
+    );
+    expect(withoutId).toEqual([]);
+  });
+
+  it('fails and does not claim success when the operationId injection step fails', () => {
+    writeFileSync(join(dir, 'fixture.json'), 'this is not valid json');
+    stubSwaggerJsdoc(join(dir, 'fixture.json'));
+
+    const result = runScript();
+
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).not.toContain('generated and transformed');
+  });
+
+  it('fails when the swagger-jsdoc step itself fails', () => {
+    stubSwaggerJsdoc(join(dir, 'fixture.json'), 1);
+
+    const result = runScript();
+
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).not.toContain('generated and transformed');
+  });
+});

--- a/apps/app/bin/openapi/http-methods.ts
+++ b/apps/app/bin/openapi/http-methods.ts
@@ -1,0 +1,23 @@
+/**
+ * The operation keys of an OpenAPI Path Item Object.
+ *
+ * A path item also carries non-operation keys (`parameters`, `summary`,
+ * `$ref`, ...), so anything walking a spec's operations has to filter by this
+ * list. Declared once here so the generator and the artifact assertion cannot
+ * drift apart on which keys count as an operation.
+ */
+export const HTTP_METHODS = [
+  'get',
+  'post',
+  'put',
+  'delete',
+  'patch',
+  'options',
+  'head',
+  'trace',
+] as const;
+
+export type HttpMethod = (typeof HTTP_METHODS)[number];
+
+export const isHttpMethod = (key: string): key is HttpMethod =>
+  (HTTP_METHODS as readonly string[]).includes(key);

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -67,7 +67,6 @@
     "repl": "cross-env NODE_ENV=development pnpm run tsrun src/server/repl.ts",
     "prisma:generate": "prisma generate",
     "prisma:pull": "prisma db pull",
-    "openapi:build:generate-operation-ids": "vite build -c bin/openapi/generate-operation-ids/vite.config.ts",
     "openapi:generate-spec:apiv3": "sh bin/openapi/generate-spec-apiv3.sh",
     "openapi:generate-spec:apiv1": "sh bin/openapi/generate-spec-apiv1.sh",
     "version:patch": "pnpm version patch --no-git-tag-version --no-git-checks",


### PR DESCRIPTION
## 概要

公開中の apiv3 OpenAPI spec から `operationId` がほぼ全て失われていた問題（241 個 → 4 個）を修正します。原因は「注入ステップが失敗していた」ではなく、**一度も実行されていなかった**ことでした。

## 根本原因

`node --import` に渡す値は、ファイルパスではなく **ES モジュールの指定子（specifier）** として解決されます。`./` `../` `/` のいずれでも始まらず URL スキームも無い値は、Node がパッケージ名と見なして `node_modules` を探しにいきます。

`growi-docs` の公開ビルドは相対パスを bare 形式で渡します。

```
"api:build": "cross-env APP_PATH=tmp/growi/apps/app run-s api:swagger2openapi:* api:redoc:*"
```

展開結果は `node --import "tmp/growi/apps/app/bin/runtime/dev-esm-resolver.mjs" ...` となり、`tmp` というパッケージを探して `ERR_MODULE_NOT_FOUND` で終了します。`cli.ts` に到達する前に落ちるため、注入は一切行われません。

**なぜ気づかれなかったか**: 開発用の `api:dev:swagger2openapi` は `APP_PATH=../growi/apps/app` を渡します。`../` 始まりは正しい相対指定子なので通ります。落ちるのは公開経路だけでした。

**退行が入った箇所**: この呼び出しは以前はすべて `${APP_PATH}/...` を **引数のパス**として渡していました（`ts-node`、bundle 済み `dist/cli.mjs`、v7.5.7 の `npx tsx`）。引数のパスは cwd 基準で解決されるので、どんな相対形でも動きます。8.0.x で同じ値がモジュール指定子の位置へ移ったことが退行の原因です。

## 失敗が見えなかった理由（2 か所）

1. **スクリプト**が `swagger-jsdoc` の終了コードしか見ておらず、`echo "generated and transformed"` を無条件に出していた
2. **`cli.ts`** が `.catch(console.error)` で例外を握りつぶし、書き込みを飛ばしたまま正常終了していた（壊れた JSON を与えると exit 0 かつ出力ファイルなし）

どちらも単独で「終了コード 0 のまま何も起きない」を成立させます。片方だけ直しても再発します。

## 変更内容

| コミット | 内容 |
| --- | --- |
| `fix(openapi): let the operationId CLI fail instead of exiting 0` | 例外を伝播させ、entry point で非ゼロ終了に。entry 判定を `pathToFileURL(process.argv[1])` に変更（パスに空白等が含まれると `file://` 文字列連結では一致せず main() が黙ってスキップされる） |
| `feat(openapi): add an artifact-level operationId assertion` | 完成した spec ファイルを検査する `assertOperationIds` を追加。生成ステップの**外側**で走るので、ステップが 0 終了しつつ何もしなかった場合も捕まえます。Path Item の operation キー一覧は `http-methods.ts` に集約 |
| `fix(openapi): resolve APP_PATH before passing it to node --import` | `APP_PATH` を一度だけ絶対パスに解決。`set -e` で全ステップを致命的にし、成功メッセージは実際に成功したときだけ出す |
| `chore(openapi): drop the dangling generate-operation-ids build script` | 既に存在しない `vite.config.ts` を参照していた script を削除 |

issue の提案 2（件数の閾値チェック）は、閾値ではなく**成立すべき条件そのもの**（全 operation に `operationId` があること／operation が 0 件でないこと）の検査にしました。endpoint が増減しても閾値の調整が不要です。

## 検証

**実際の生成（`apps/app` で実行）**

```
>>> EXIT=0
>>> operationId count = 249
>>> info.version = 8.0.1-RC.0
```

**growi-docs の公開経路を再現**（`tmp/growi` を実ディレクトリで配置し、bare 相対 `APP_PATH` で実スクリプトを実行）

修正前:
```
ERR_MODULE_NOT_FOUND: Cannot find package 'tmp'
OpenAPI spec generated and transformed: ./tmp/openapi-spec-apiv3.json   ← 成功と表示
>>> SCRIPT EXIT CODE = 0
>>> operationId count in output = 0
```

修正後: exit 0、operationId が実際に注入される。

**テスト（21 件 pass）** — `generate-spec-apiv3.spec.ts` は growi-docs と同じ形（bare 相対 `APP_PATH` の子プロセス `sh <script>`）でスクリプトを走らせます。

mutation check（テストが本当に落ちることの確認）:

| 意図的に壊した箇所 | 結果 |
| --- | --- |
| `--import` を bare 相対形に戻す（元のバグ） | 「injects an operationId ...」が RED |
| `set -e` を削除 | 失敗検知の 2 件が RED |
| artifact 検査ステップを削除 | 3 件とも GREEN（想定どおり。これは将来の再発に対する二重の防御で、単体テスト 6 件が担保） |

## 未対応（このリポジトリ外）

- **`8.0.1-RC.0` の spec 再公開**: `growi-docs` の deploy workflow を再実行する必要があります
- **`growi-docs` 側**: `api:build` の `APP_PATH` は `./tmp/growi/apps/app` の方が意図が明確です。ただし本 PR で外部からどの相対形でも動くようにしたので、必須ではありません
- **Node のバージョン前提**: `growi-docs` の workflow は `node-version: 22.x` を指定していますが、このスクリプトは Node のネイティブな型除去と `module.registerHooks` に依存しています。`22.x` は最新の 22 系に解決されるので現状は満たされていますが、この前提はどこにも書かれていません

## SDK への影響

この修正で `operationId` が復活するため、`@growi/sdk-typescript` のシンボル名は次の再生成で 1.12.0 相当の形に戻ります。1.13.0 で発生した改名（export 490 削除 / 523 追加）と同規模の変更が逆向きに起きるため、リリース段取りで考慮が必要です。

Closes #11634
