### PR TITLE
fix(comment): Make /comments.update respond so editing leaves edit mode

### DIFF
--- a/apps/app/playwright/20-basic-features/comments.spec.ts
+++ b/apps/app/playwright/20-basic-features/comments.spec.ts
@@ -44,6 +44,29 @@ test.describe('Comment', () => {
     ).toHaveText('2');
   });
 
+  test('Successfully edit comments', async ({ page }) => {
+    const editedText = 'edited comment';
+    await page.goto('/comment');
+
+    const firstComment = page.locator('.page-comment').first();
+    await firstComment.hover();
+    await firstComment.getByTestId('comment-edit-button').click();
+
+    const editor = page.locator('.cm-content').first();
+    await expect(editor).toBeVisible();
+    await editor.fill(editedText);
+    await page.getByTestId('comment-submit-button').first().click();
+
+    // Leaving edit mode is the observable result of a successful update: the
+    // editor closes and the rendered comment shows the new text. A silently
+    // saved edit that keeps the editor open (the /comments.update handler
+    // failing to respond at all) fails here.
+    await expect(editor).not.toBeVisible();
+    await expect(page.locator('.page-comment-body').first()).toHaveText(
+      editedText,
+    );
+  });
+
   // test('Successfully delete comments', async({ page }) => {
   //   await page.goto('/comment');
 

--- a/apps/app/src/client/components/PageComment/CommentControl.tsx
+++ b/apps/app/src/client/components/PageComment/CommentControl.tsx
@@ -16,6 +16,7 @@ export const CommentControl = (props: CommentControlProps): JSX.Element => {
       <NotAvailableIfReadOnlyUserNotAllowedToComment>
         <>
           <button
+            data-testid="comment-edit-button"
             type="button"
             className="btn btn-link p-2 opacity-50"
             onClick={onClickEditBtn}

--- a/apps/app/src/server/routes/comment.integ.ts
+++ b/apps/app/src/server/routes/comment.integ.ts
@@ -76,6 +76,20 @@ describe('/comments.get share-link authorization (integration)', () => {
       data: { id: pageBId.toString(), path: '/comment-integ-b', v: 0 },
     });
 
+    // api.update re-links the comment with `revision: { connect: { id } }`, and
+    // Prisma rejects a `connect` to a missing record, so revision A must exist
+    // as a real row (the GET tests only ever use these ids as stored scalars).
+    await prisma.revisions.create({
+      data: {
+        id: revAId.toString(),
+        v: 0,
+        authorId: new ObjectId().toString(),
+        body: 'revision A body',
+        format: 'markdown',
+        pageId: pageAId.toString(),
+      },
+    });
+
     // Seed one comment on page A and one on page B (with distinct revisions).
     // Comments live in Prisma (the mongoose Comment model was migrated), so
     // seed through the same `prisma.comments.add` the route handler uses.
@@ -156,9 +170,21 @@ describe('/comments.get share-link authorization (integration)', () => {
       req.isSharedPage = true;
       next();
     };
-    app.post('/comments.add', forceShared, comment.api.add);
-    app.post('/comments.update', forceShared, comment.api.update);
-    app.post('/comments.remove', forceShared, comment.api.remove);
+    // routes/index.js puts `addActivity` in front of every write route, so the
+    // handlers' success paths read `res.locals.activity._id`. Mirror that here,
+    // otherwise a success path would fail for a reason unrelated to the route.
+    const stubActivity = (
+      _req: TestRequest,
+      res: Response,
+      next: NextFunction,
+    ) => {
+      res.locals.activity = { _id: new ObjectId() };
+      next();
+    };
+
+    app.post('/comments.add', forceShared, stubActivity, comment.api.add);
+    app.post('/comments.update', forceShared, stubActivity, comment.api.update);
+    app.post('/comments.remove', forceShared, stubActivity, comment.api.remove);
   });
 
   beforeEach(() => {
@@ -176,6 +202,7 @@ describe('/comments.get share-link authorization (integration)', () => {
     await prisma.comments.deleteMany({
       where: { id: { in: [commentAId, commentBId] } },
     });
+    await prisma.revisions.deleteMany({ where: { id: revAId.toString() } });
     await prisma.pages.deleteMany({
       where: { id: { in: [pageAId.toString(), pageBId.toString()] } },
     });
@@ -508,6 +535,74 @@ describe('/comments.get share-link authorization (integration)', () => {
 
       expect(res.body.ok).toBe(false);
       expect(accessSpy).toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * The authorized-editor path of `/comments.update`.
+   *
+   * Every pre-existing `/comments.update` test above exercises a rejection, so
+   * the handler could (and did) fail to produce any response at all on the happy
+   * path without a single test noticing. When that happens the request never
+   * completes: the comment is written to the DB, but the client's `await` never
+   * settles, so the comment editor stays open and the edit looks like it did
+   * nothing. These tests pin the response itself.
+   */
+  describe('POST /comments.update — authorized editor', () => {
+    const editorId = new ObjectId();
+    let editableCommentId: string;
+
+    const sendUpdate = (comment: string) =>
+      request(app)
+        .post('/comments.update')
+        .send({
+          commentForm: {
+            comment,
+            comment_id: editableCommentId,
+            revision_id: revAId.toString(),
+          },
+        });
+
+    beforeEach(async () => {
+      const seeded = await prisma.comments.add(
+        pageAId.toString(),
+        editorId.toString(),
+        revAId.toString(),
+        'original body',
+        -1,
+      );
+      editableCommentId = seeded.id;
+
+      // the creator of the comment, on a page they can access
+      currentUser = { _id: editorId };
+      accessSpy.mockResolvedValue(true);
+    });
+
+    afterEach(async () => {
+      await prisma.comments.deleteMany({ where: { id: editableCommentId } });
+    });
+
+    it('responds with the updated comment', async () => {
+      const res = await sendUpdate('edited body');
+
+      expect(res.body.ok).toBe(true);
+      // mongoose-compatible field names, as `/comments.get` and `/comments.add` return
+      expect(res.body.comment).toMatchObject({
+        _id: editableCommentId,
+        comment: 'edited body',
+        page: pageAId.toString(),
+        creator: editorId.toString(),
+        revision: revAId.toString(),
+      });
+    });
+
+    it('persists the new comment body', async () => {
+      await sendUpdate('edited body');
+
+      const stored = await prisma.comments.findUnique({
+        where: { id: editableCommentId },
+      });
+      expect(stored?.comment).toBe('edited body');
     });
   });
 });

--- a/apps/app/src/server/routes/comment.js
+++ b/apps/app/src/server/routes/comment.js
@@ -545,10 +545,10 @@ export const setup = (crowi, _app) => {
       ApiResponse.success({
         comment: {
           ...updatedComment,
-          page: createdComment.pageId,
-          creator: createdComment.creatorId,
-          revision: createdComment.revisionId,
-          replyTo: createdComment.replyToId,
+          page: updatedComment.pageId,
+          creator: updatedComment.creatorId,
+          revision: updatedComment.revisionId,
+          replyTo: updatedComment.replyToId,
         },
       }),
     );


### PR DESCRIPTION
## 症状

既存コメントを編集して Comment ボタンを押すと、コメントは保存されるのに UI が何も変化しない（編集モードから抜けない・エラーも出ない）。新規コメントの追加は正常。

## 原因

`api.update` が成功レスポンスを組み立てるときに、`api.add` のローカル変数である `createdComment` を参照していた。`api.update` には `createdComment` が存在しないため `ReferenceError: createdComment is not defined` になる。

```js
// apps/app/src/server/routes/comment.js
res.json(ApiResponse.success({
  comment: {
    ...updatedComment,
    page: createdComment.pageId,      // ← createdComment は api.add のローカル変数
    creator: createdComment.creatorId,
    ...
```

問題はこの例外が **`try`/`catch` の外**（レスポンス組み立て部分）で起きることです。apiv1 のルートは `routes/index.js` で express 4 にそのまま登録されており async の例外をつかむラッパーがないため、unhandled rejection になって **レスポンスが一切送られません**（500 すら返らない）。クライアントの axios は timeout 未設定なので `await updateComment(...)` が永久に解決せず、後続の `initializeEditor()` / `onCommented?.()`（= `setIsReEdit(false)`）が動きません。

つまり「DB への書き込みだけ成功して UI が無反応」という症状になります。新規追加が正常なのは、`api.add` では `createdComment` が正しく定義済みだからです。

## 影響範囲

Mongoose → Prisma 移行のコミット 8a41d408ab（2026-06-19）で入ったもので、**v8.0.0 に含まれています**。`dev/7.5.x` は Mongoose のままで `res.json(ApiResponse.success({ comment: updatedComment }))` なので影響ありません。

## 修正

4 行を `updatedComment` に直しました。

## テスト

先に失敗を確認してから修正しています。

**結合テスト** — `/comments.update` の既存テストは拒否パスのみで、応答を検証するものが 1 本もありませんでした。これが見逃しの直接の原因なので、認可済み編集者の成功パスを追加しました。

- 修正前: `ReferenceError: createdComment is not defined at api.update (comment.js:548)` + リクエストが返らずタイムアウト
- 修正後: `comment.integ.ts` 27 件 green（comment 関連は全 39 件 green）

**e2e テスト** — コメントの e2e は追加と返信だけを見ており、編集が未カバーでした。編集のテストを追加し、バグを戻すと `expect(editor).not.toBeVisible()` で明確に落ちる（ハングではない）ことも確認しています。edit ボタンには既存の `comment-delete-button` に合わせて `data-testid` を付けました。

**ブラウザでの実測** — dev サーバを立てて実際にコメントを編集し、報告された症状そのものを確認しました。

| | 修正前 | 修正後 |
|---|---|---|
| `/comments.update` | 応答なし | 200 |
| 編集モードから抜ける | false | true |
| 表示されるコメント本文 | (編集エディタのまま) | 編集後のテキスト |

`pnpm run lint` は全項目 pass（route-top-level-guard / import-extension-guard / tsgo / biome / OpenAPI 検証を含む）。

## 別途対応が必要な既知バグ（本 PR では未修正）

`Comment.tsx` が `CommentEditor` に `pageId={comment._id}` を渡しています（ページ ID ではなくコメント ID）。実測でも編集時に `GET /comments.get?page_id=<コメントのID>` という無意味なリクエストが飛ぶのを確認しました。添付ファイルのアップロード先 ID も誤ります。

ただし 2023 年のディレクトリ移動より前から存在する長年のバグで、本 PR の症状の原因ではありません（一覧の更新は親の `onComment` が正しいキーで行うため）。アップロード周りの挙動が変わるのでスコープ外としています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
