### PR TITLE
chore(app): remove orphaned openai:serviceType / openai:apiKey config keys

### DIFF
--- a/apps/app/src/server/service/config-manager/config-definition.ts
+++ b/apps/app/src/server/service/config-manager/config-definition.ts
@@ -289,10 +289,6 @@ export const CONFIG_KEYS = [
   'slackbot:withProxy:saltForGtoP',
   'slackbot:withProxy:saltForPtoG',
 
-  // OpenAI Settings
-  'openai:serviceType',
-  'openai:apiKey',
-
   // AI Tools Settings
   'aiTools:suggestPathAgenticSearchLimit',
   'aiTools:suggestPathAgenticChildListingLimit',
@@ -1283,17 +1279,6 @@ export const CONFIG_DEFINITIONS = {
   'slackbot:withProxy:saltForPtoG': defineConfig<string>({
     envVarName: 'SLACKBOT_WITH_PROXY_SALT_FOR_PTOG',
     defaultValue: 'ptog',
-    isSecret: true,
-  }),
-
-  // OpenAI Settings
-  'openai:serviceType': defineConfig<'openai' | 'azure-openai'>({
-    envVarName: 'OPENAI_SERVICE_TYPE',
-    defaultValue: 'openai',
-  }),
-  'openai:apiKey': defineConfig<string | undefined>({
-    envVarName: 'OPENAI_API_KEY',
-    defaultValue: undefined,
     isSecret: true,
   }),
 


### PR DESCRIPTION
## Summary

- Removes `'openai:serviceType'` and `'openai:apiKey'` from `CONFIG_KEYS` and their `defineConfig(...)` entries in `apps/app/src/server/service/config-manager/config-definition.ts`.

## Root Cause

These two keys had no readers left in the codebase. Their only consumer was the legacy `features/openai` client-delegator (used by the now-retired `suggest-path`), which was fully removed in `cf9bba177e`. AI provider selection today goes entirely through `isAiConfigured()`, driven by the multi-vendor `ai:providers` / `ai:providerApiKeys` / `ai:allowedModels` config — it never touches `openai:serviceType` / `openai:apiKey`. Leaving the dead keys in place lets operators set `OPENAI_SERVICE_TYPE` / `OPENAI_API_KEY` believing they configure AI, when the real switch is `AI_PROVIDERS` / `AI_PROVIDER_API_KEYS` (silent no-op).

## Changes

- Remove `'openai:serviceType'`, `'openai:apiKey'` from `CONFIG_KEYS` (and the now-empty `// OpenAI Settings` heading).
- Remove the two corresponding `defineConfig(...)` entries.

## Test Plan

- [x] `pnpm run lint:typecheck` passes
- [x] `pnpm run lint:biome` passes
- [x] `pnpm vitest run config-definition config-manager reconcile-config` — 118 tests pass
- [x] `turbo run test --filter @growi/app` — 5015 tests pass (462 files)
- [x] Repo-wide search confirms no remaining references to either key outside this file

Closes #11651