### PR TITLE
test(growi-vault): Stop the reconcile overhead integ test failing in pairs

### DIFF
--- a/apps/app/src/features/growi-vault/server/services/reconcile/__tests__/reconcile-orchestrator-overhead.integ.ts
+++ b/apps/app/src/features/growi-vault/server/services/reconcile/__tests__/reconcile-orchestrator-overhead.integ.ts
@@ -4,7 +4,9 @@
  * Performance and idempotency integration tests for ReconcileOrchestrator.
  *
  * Tests:
- *   1. Accept gate latency — assert < 200ms (p99 approximated by single measurement)
+ *   1. Accept gate — submit returns while the reconcile it scheduled is still in
+ *      flight (see the test for why this is asserted relatively rather than as a
+ *      wall-clock budget)
  *   2. Instruction count bounded — each page produces exactly 1 instruction when
  *      it has a unique namespace (the makeNamespaceMapper stub gives each page its
  *      own namespace, so no mid-stream chunk flush occurs; all buffers flush at
@@ -145,6 +147,46 @@ function waitForReconcileStatus(
   });
 }
 
+/**
+ * Wait until no reconcile is still in flight.
+ *
+ * `afterEach` empties vault_instructions and vault_reconcile_log, but a reconcile
+ * that is still running goes on writing into them afterwards, and that late row is
+ * counted by the next test. The per-test `waitForReconcileStatus` calls do not
+ * prevent this: they sit at the end of the test body, so any assertion that fails
+ * before them skips the wait entirely. That is exactly how this file used to fail
+ * in pairs — a failed assertion in the accept-gate test turned the following test's
+ * "expected 25" into "expected 26". Draining here instead makes the cleanup
+ * independent of whether the test passed.
+ */
+function waitForNoActiveReconciles(timeoutMs = 30000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      VaultReconcileLog.countDocuments({
+        status: { $in: ['pending', 'running'] },
+      })
+        .then((count: number) => {
+          if (count === 0) {
+            resolve();
+            return;
+          }
+          if (Date.now() >= deadline) {
+            reject(
+              new Error(
+                `Timeout waiting for ${count} in-flight reconcile(s) to settle`,
+              ),
+            );
+            return;
+          }
+          setTimeout(tick, 50);
+        })
+        .catch(reject);
+    };
+    tick();
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
@@ -165,6 +207,7 @@ beforeAll(async () => {
 });
 
 afterEach(async () => {
+  await waitForNoActiveReconciles();
   await mongoose.connection.collection('vault_reconcile_log').deleteMany({});
   await mongoose.connection.collection('vault_instructions').deleteMany({});
   await mongoose.connection.collection('pages').deleteMany({
@@ -220,11 +263,29 @@ function buildService(opts: {
 }
 
 // ---------------------------------------------------------------------------
-// Test 1: Accept gate latency < 200ms
+// Test 1: Accept gate does not block on the reconcile
 // ---------------------------------------------------------------------------
 
-describe('Accept gate latency', () => {
-  it('accept gate resolves within 200ms for a normal request', async () => {
+describe('Accept gate', () => {
+  /**
+   * What is being guarded: the gate stays a cheap synchronous path (要件 6.2 —
+   * one findOne, no collection scan) and hands the work to the background
+   * orchestrator instead of awaiting it.
+   *
+   * Why this is asserted relatively — "submit returned before the reconcile it
+   * scheduled finished" — rather than as a wall-clock budget: a slower machine
+   * slows the gate and the reconcile by the same factor, so the property holds
+   * regardless of how loaded the runner is. The absolute bound this replaced
+   * (`elapsed < 200ms`) behaved the other way round on both counts. It failed on
+   * CI runner noise alone (313ms observed on an otherwise healthy run), and it
+   * could not have caught the regression it looked like it was guarding: measured
+   * here, the gate takes ~8ms and the whole reconcile ~63ms, so a gate that
+   * awaited the entire reconcile would still have come in under 200ms and passed.
+   *
+   * 要件 6.10's "accept gate p99 ≤ 200ms" is a production SLO. A single sample in
+   * CI cannot measure a p99, so this test does not attempt to.
+   */
+  it('resolves while the reconcile it scheduled is still in flight', async () => {
     await Page.insertMany([
       {
         path: '/overhead-latency',
@@ -236,7 +297,6 @@ describe('Accept gate latency', () => {
 
     const service = buildService({});
 
-    const start = Date.now();
     const result = await service.submit({
       targetType: 'sub-tree',
       targetPath: '/overhead-latency',
@@ -245,19 +305,23 @@ describe('Accept gate latency', () => {
         isAdmin: true,
       },
     });
-    const elapsed = Date.now() - start;
 
     expect(result.status).toBe('accepted');
-    expect(elapsed).toBeLessThan(200);
-
-    // Wait for background reconcile to reach a terminal state before afterEach
-    // clears vault_instructions, so it doesn't bleed into the next test.
     const { reconcileId } = result as {
       status: 'accepted';
       reconcileId: string;
       descendantCount: number;
     };
-    await waitForReconcileStatus(reconcileId, ['completed', 'failed']);
+
+    // Read the status the moment submit resolves: a gate that awaited the
+    // orchestrator would already be at a terminal status here.
+    const log = await VaultReconcileLog.findOne({ reconcileId }).lean();
+    expect(['pending', 'running']).toContain(
+      (log as Record<string, unknown> | null)?.status,
+    );
+
+    // The in-flight reconcile is drained by afterEach, which runs whether or not
+    // the assertions above hold.
   });
 });
 


### PR DESCRIPTION
## 症状

CI の 1 回の実行（[run 31175665930](https://github.com/growilabs/growi/actions/runs/31175665930)）で、`reconcile-orchestrator-overhead.integ.ts` の 2 件が同時に失敗しました。

```
× accept gate resolves within 200ms ... → expected 313 to be less than 200
× vault_instructions count equals N ... → expected 26 to be 25
```

2 件目は 1 件目が引き起こしたもので、直すべき原因は 1 つです。

各テストは、バックグラウンドで動いている reconcile が終わるのをテスト本体の**最後**で待っています。そのため、その待ちより手前で `expect` が失敗すると、待ち処理は実行されません。すると `afterEach` が `vault_instructions` を削除する時点で reconcile がまだ書き込みを続けていて、削除より後に入った 1 行が次のテストで数えられてしまいます。これが `expected 26 to be 25` です。

## 変更内容

### 1. `afterEach` が削除の前に実行中の reconcile の完了を待つ

後片付けがテストの成否に依存しないようにしました。accept gate のテストをわざと失敗させて確認すると、以前は続くテストも `expected 26 to be 25` で失敗していましたが、今は 1 件だけが失敗します。

### 2. accept gate のテストを相対的な検証に置き換えた

`elapsed < 200ms` という壁時計での上限をやめ、「submit は、自分が登録した reconcile がまだ実行中のうちに返る」という形で検証します。

元の絶対値の上限は、2 つの意味で適切ではありませんでした。

- **落ちるべきでないときに落ちる** — CI の実行マシンが混んでいるだけで失敗します（他は健全な実行で 313ms を観測）。
- **本来検出したい不具合を検出できない** — 手元での実測では gate が約 8ms、reconcile 全体が約 63ms です。つまり gate が reconcile 全体を待ってしまう実装に変わっても、200ms 未満で通ってしまいます。

相対的な形なら、実行マシンが遅いときは gate と reconcile の両方が同じだけ遅くなるので、マシンの負荷に左右されません。

なお、要件 6.10 の「accept gate p99 ≤ 200ms」は本番環境に対する SLO です。CI での 1 回の測定で p99 は求められないため、このテストではそれを測ろうとしていません。

## 検証

- `pnpm vitest run reconcile-orchestrator-overhead.integ` → 3 件すべて成功
- わざと失敗させた実行で、次のテストまで失敗が広がらないことを確認
- 5 回連続で成功することを確認
- reconcile の結合テスト一式（11 件）が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
