### PR TITLE
support: Publish vault-manager and pdf-converter images from master via changesets

### DIFF
--- a/.github/workflows/ci-vault.yml
+++ b/.github/workflows/ci-vault.yml
@@ -11,6 +11,10 @@ on:
       - tmp-mergify/merge-queue/**
     paths:
       - apps/growi-vault-manager/**
+      # vault-manager's only workspace dependencies. They are compiled into the
+      # published image, so a change here has to run these tests too.
+      - packages/core/**
+      - packages/logger/**
       - .github/workflows/ci-vault.yml
 
 concurrency:

--- a/.github/workflows/release-pdf-converter.yml
+++ b/.github/workflows/release-pdf-converter.yml
@@ -1,25 +1,88 @@
 name: Release Docker Image for @growi/pdf-converter
 
+# Publishes the pdf-converter image to Docker Hub.
+#
+# Trigger: a push to master that touches apps/pdf-converter/package.json.
+# The version in that file decides everything — the image is published only when
+# that version is a stable one that has not been tagged yet, so a push that edits
+# the manifest without releasing is a no-op.
+#
+# The version itself comes from changesets, the same way @growi/core and
+# @growi/pluginkit are released: write a changeset naming @growi/pdf-converter in
+# the development PR, and merging the generated "Release Subpackages" PR bumps
+# package.json and CHANGELOG.md on master. That merge is what publishes the image.
+# There is no separate release branch and no RC version marker.
+
 on:
-  pull_request:
+  push:
     branches:
-      - release/pdf-converter/**
-    types: [closed]
+      - master
+    paths:
+      - apps/pdf-converter/package.json
+      - .github/workflows/release-pdf-converter.yml
+  # Manual re-run for recovery. Publishing stays gated on the check below, so a
+  # dispatch on an already-released version does nothing.
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
-  build-and-push-image:
+  determine-release:
     runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.package-json.outputs.packageVersion }}
+      should-release: ${{ steps.decide.outputs.should-release }}
 
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.pull_request.base.ref }}
+        # Tags are the record of what has already been published; the check below
+        # reads them. History is not needed, so fetch the tags without it.
+        fetch-tags: true
 
     - name: Retrieve information from package.json
       uses: myrotvorets/info-from-package-json-action@v2.0.2
       id: package-json
       with:
         workingDir: apps/pdf-converter
+
+    - name: Decide whether this version needs publishing
+      id: decide
+      env:
+        VERSION: ${{ steps.package-json.outputs.packageVersion }}
+      run: |
+        TAG="pdf-converter/v${VERSION}"
+
+        # A prerelease version is a work-in-progress marker, never something to publish.
+        if [[ "$VERSION" == *-* ]]; then
+          echo "::notice::${VERSION} is a prerelease version - nothing to publish."
+          echo "should-release=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # The tag is created only after a successful publish, so its presence means
+        # this exact version is already on Docker Hub.
+        if git rev-parse -q --verify "refs/tags/${TAG}" > /dev/null; then
+          echo "::notice::${TAG} already exists - nothing to publish."
+          echo "should-release=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "::notice::Publishing ${TAG}."
+        echo "should-release=true" >> "$GITHUB_OUTPUT"
+
+
+  build-and-push-image:
+    needs: determine-release
+    if: needs.determine-release.outputs.should-release == 'true'
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
 
     - name: Docker meta
       id: meta
@@ -28,15 +91,16 @@ jobs:
         images: growilabs/pdf-converter
         tags: |
           type=raw,value=latest
-          type=semver,value=${{ steps.package-json.outputs.packageVersion }},pattern={{major}}
-          type=semver,value=${{ steps.package-json.outputs.packageVersion }},pattern={{major}}.{{minor}}
-          type=semver,value=${{ steps.package-json.outputs.packageVersion }},pattern={{major}}.{{minor}}.{{patch}}
+          type=semver,value=${{ needs.determine-release.outputs.version }},pattern={{major}}
+          type=semver,value=${{ needs.determine-release.outputs.version }},pattern={{major}}.{{minor}}
+          type=semver,value=${{ needs.determine-release.outputs.version }},pattern={{major}}.{{minor}}.{{patch}}
 
     - name: Login to docker.io registry
       run: |
         echo ${{ secrets.DOCKER_REGISTRY_PASSWORD_GROWIMOOGLE }} | docker login --username growimoogle --password-stdin
 
     - name: Set up Docker Buildx
+      id: buildx
       uses: docker/setup-buildx-action@v3
 
     - name: Build and push
@@ -51,12 +115,14 @@ jobs:
         cache-to: type=gha,mode=max
         tags: ${{ steps.meta.outputs.tags }}
 
+    # Runs after the push so the tag always means "this version is on Docker Hub",
+    # which is what determine-release relies on.
     - name: Add tag
       uses: anothrNick/github-tag-action@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        CUSTOM_TAG: pdf-converter/v${{ steps.package-json.outputs.packageVersion }}
-        VERBOSE : true
+        CUSTOM_TAG: pdf-converter/v${{ needs.determine-release.outputs.version }}
+        VERBOSE: true
 
     - name: Update Docker Hub Description
       uses: peter-evans/dockerhub-description@v4
@@ -65,58 +131,3 @@ jobs:
         password: ${{ secrets.DOCKER_REGISTRY_PASSWORD_GROWIMOOGLE }}
         repository: growilabs/pdf-converter
         readme-filepath: ./apps/pdf-converter/docker/README.md
-
-
-  create-pr-for-next-rc:
-    needs: build-and-push-image
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [24.x]
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.base.ref }}
-
-    - uses: pnpm/action-setup@v6
-
-    - uses: actions/setup-node@v6
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'pnpm'
-
-    - name: Install dependencies
-      run: |
-        pnpm add turbo --global
-        pnpm install --frozen-lockfile
-
-    - name: Bump versions for next RC
-      run: |
-        turbo run version:prerelease --filter=@growi/pdf-converter
-
-    - name: Retrieve information from package.json
-      uses: myrotvorets/info-from-package-json-action@v2.0.2
-      id: package-json
-      with:
-        workingDir: apps/pdf-converter
-
-    - name: Commit
-      uses: github-actions-x/commit@v2.9
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        push-branch: support/prepare-v${{ steps.package-json.outputs.packageVersion }}
-        commit-message: 'Bump version'
-        name: GitHub Action
-
-    - name: Create PR
-      uses: repo-sync/pull-request@v2
-      with:
-        source_branch: support/prepare-v${{ steps.package-json.outputs.packageVersion }}
-        destination_branch: master
-        pr_title: Prepare pdf-converter v${{ steps.package-json.outputs.packageVersion }}
-        pr_label: flag/exclude-from-changelog,type/prepare-next-version
-        pr_body: "An automated PR generated by ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-vault.yml
+++ b/.github/workflows/release-vault.yml
@@ -2,8 +2,19 @@ name: Release Docker Image for @growi/vault-manager
 
 # Publishes the growi-vault-manager image to Docker Hub.
 #
-# Trigger: a pull request into a `release/vault-manager/**` branch being MERGED
-# (closed with merge). The version comes from apps/growi-vault-manager/package.json.
+# Trigger: a push to master that touches apps/growi-vault-manager/package.json.
+# The version in that file decides everything — the image is published only when
+# that version is a stable one that has not been tagged yet, so a push that edits
+# the manifest without releasing is a no-op.
+#
+# The version itself comes from changesets, the same way @growi/core and
+# @growi/pluginkit are released: write a changeset naming @growi/vault-manager in
+# the development PR, and merging the generated "Release Subpackages" PR bumps
+# package.json and CHANGELOG.md on master. That merge is what publishes the image.
+# There is no separate release branch and no RC version marker.
+#
+# Note: the "Supported tags" list in apps/growi-vault-manager/docker/README.md is
+# not managed by changesets. Update it in the PR that carries the changeset.
 #
 # Secrets (already available in GitHub Actions):
 #   - DOCKER_REGISTRY_PASSWORD_GROWIMOOGLE
@@ -11,33 +22,77 @@ name: Release Docker Image for @growi/vault-manager
 #       pull the DHI base image from dhi.io (the release stage pulls
 #       `dhi.io/node:24-debian13-dev`) and to push the built image to docker.io.
 #       Same secret used by release-pdf-converter.yml.
-#
-# Assumptions to confirm in review:
-#   - Docker Hub repository name: growilabs/vault-manager
-#   - Release branch prefix: release/vault-manager/**
 
 on:
-  pull_request:
+  push:
     branches:
-      - release/vault-manager/**
-    types: [closed]
+      - master
+    paths:
+      - apps/growi-vault-manager/package.json
+      - .github/workflows/release-vault.yml
+  # Manual re-run for recovery. Publishing stays gated on the check below, so a
+  # dispatch on an already-released version does nothing.
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
-  build-and-push-image:
-    # Only publish when the PR is actually merged, not merely closed.
-    if: github.event.pull_request.merged == true
+  determine-release:
     runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.package-json.outputs.packageVersion }}
+      should-release: ${{ steps.decide.outputs.should-release }}
 
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.pull_request.base.ref }}
+        # Tags are the record of what has already been published; the check below
+        # reads them. History is not needed, so fetch the tags without it.
+        fetch-tags: true
 
     - name: Retrieve information from package.json
       uses: myrotvorets/info-from-package-json-action@v2.0.2
       id: package-json
       with:
         workingDir: apps/growi-vault-manager
+
+    - name: Decide whether this version needs publishing
+      id: decide
+      env:
+        VERSION: ${{ steps.package-json.outputs.packageVersion }}
+      run: |
+        TAG="vault-manager/v${VERSION}"
+
+        # A prerelease version is a work-in-progress marker, never something to publish.
+        if [[ "$VERSION" == *-* ]]; then
+          echo "::notice::${VERSION} is a prerelease version - nothing to publish."
+          echo "should-release=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        # The tag is created only after a successful publish, so its presence means
+        # this exact version is already on Docker Hub.
+        if git rev-parse -q --verify "refs/tags/${TAG}" > /dev/null; then
+          echo "::notice::${TAG} already exists - nothing to publish."
+          echo "should-release=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "::notice::Publishing ${TAG}."
+        echo "should-release=true" >> "$GITHUB_OUTPUT"
+
+
+  build-and-push-image:
+    needs: determine-release
+    if: needs.determine-release.outputs.should-release == 'true'
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
 
     - name: Docker meta
       id: meta
@@ -46,9 +101,9 @@ jobs:
         images: growilabs/vault-manager
         tags: |
           type=raw,value=latest
-          type=semver,value=${{ steps.package-json.outputs.packageVersion }},pattern={{major}}
-          type=semver,value=${{ steps.package-json.outputs.packageVersion }},pattern={{major}}.{{minor}}
-          type=semver,value=${{ steps.package-json.outputs.packageVersion }},pattern={{major}}.{{minor}}.{{patch}}
+          type=semver,value=${{ needs.determine-release.outputs.version }},pattern={{major}}
+          type=semver,value=${{ needs.determine-release.outputs.version }},pattern={{major}}.{{minor}}
+          type=semver,value=${{ needs.determine-release.outputs.version }},pattern={{major}}.{{minor}}.{{patch}}
 
     # Authenticate to dhi.io so the release stage can pull the DHI dev base image
     # (uses the same growimoogle Docker Hub credentials as the docker.io push).
@@ -85,11 +140,13 @@ jobs:
         cache-to: type=gha,mode=max
         tags: ${{ steps.meta.outputs.tags }}
 
+    # Runs after the push so the tag always means "this version is on Docker Hub",
+    # which is what determine-release relies on.
     - name: Add tag
       uses: anothrNick/github-tag-action@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        CUSTOM_TAG: vault-manager/v${{ steps.package-json.outputs.packageVersion }}
+        CUSTOM_TAG: vault-manager/v${{ needs.determine-release.outputs.version }}
         VERBOSE: true
 
     - name: Update Docker Hub Description
@@ -99,58 +156,3 @@ jobs:
         password: ${{ secrets.DOCKER_REGISTRY_PASSWORD_GROWIMOOGLE }}
         repository: growilabs/vault-manager
         readme-filepath: ./apps/growi-vault-manager/docker/README.md
-
-
-  create-pr-for-next-rc:
-    needs: build-and-push-image
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [24.x]
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.base.ref }}
-
-    - uses: pnpm/action-setup@v6
-
-    - uses: actions/setup-node@v6
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'pnpm'
-
-    - name: Install dependencies
-      run: |
-        pnpm add turbo --global
-        pnpm install --frozen-lockfile
-
-    - name: Bump versions for next RC
-      run: |
-        turbo run version:prerelease --filter=@growi/vault-manager
-
-    - name: Retrieve information from package.json
-      uses: myrotvorets/info-from-package-json-action@v2.0.2
-      id: package-json
-      with:
-        workingDir: apps/growi-vault-manager
-
-    - name: Commit
-      uses: github-actions-x/commit@v2.9
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        push-branch: support/prepare-vault-manager-v${{ steps.package-json.outputs.packageVersion }}
-        commit-message: 'Bump vault-manager version'
-        name: GitHub Action
-
-    - name: Create PR
-      uses: repo-sync/pull-request@v2
-      with:
-        source_branch: support/prepare-vault-manager-v${{ steps.package-json.outputs.packageVersion }}
-        destination_branch: master
-        pr_title: Prepare vault-manager v${{ steps.package-json.outputs.packageVersion }}
-        pr_label: flag/exclude-from-changelog,type/prepare-next-version
-        pr_body: "An automated PR generated by ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/growi-vault-manager/README.md
+++ b/apps/growi-vault-manager/README.md
@@ -144,6 +144,16 @@ Highlights of the refactor:
 - OCI standard labels (`org.opencontainers.image.source`, `title`, `description`, `vendor`, `authors`) on the release stage.
 - **Non-root runtime**: `docker/docker-entrypoint.ts` (run via Node 24 type stripping) creates and chowns the bare repo on the shared `/data` volume as root, then drops to the `node` user (uid/gid 1000) via native `process.setuid/setgid` before exec'ing the app. This keeps `vault-manager` and `apps/app` on a single uid so they can share the `/data` volume (Requirement 10.3); no `gosu`/`setpriv` binary is needed.
 
+### Releasing
+
+The image is released through changesets, the same flow `@growi/core` and `@growi/pluginkit` use — there is no release branch and no RC version marker.
+
+1. In the PR that changes `apps/growi-vault-manager/**` (or `packages/core` / `packages/logger`, which are compiled into the image), run `npx changeset` and give `@growi/vault-manager` a `patch` / `minor` / `major` bump. Update the "Supported tags" list in `docker/README.md` in the same PR — changesets does not manage that file.
+2. Merging that PR makes changesets open or update a **Release Subpackages** PR against `master`, which bumps `package.json` and writes `CHANGELOG.md`.
+3. Merging the Release Subpackages PR publishes the image. `.github/workflows/release-vault.yml` watches pushes to `master` that touch `apps/growi-vault-manager/package.json`, publishes when the version is a stable one with no `vault-manager/v<version>` tag yet, and creates that tag afterwards.
+
+Because the gate is "stable version, not tagged yet", a push that edits `package.json` without releasing does nothing, and the same version can never be published twice.
+
 ### Cross-repository impact: `growi-docker-compose`
 
 The separate [`growi-docker-compose`](https://github.com/growilabs/growi-docker-compose) repository consumes the published image, as an opt-in override in [`examples/growi-vault`](https://github.com/growilabs/growi-docker-compose/tree/master/examples/growi-vault). When the image is republished with a new major/minor, that override pins the tag and has to be updated there in a separate PR.

--- a/apps/growi-vault-manager/package.json
+++ b/apps/growi-vault-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/vault-manager",
-  "version": "1.1.1-RC.0",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
@@ -15,8 +15,6 @@
     "lint:typecheck": "tsc --noEmit",
     "lint": "run-p lint:**",
     "build": "pnpm tsc -p tsconfig.build.json",
-    "version:prerelease": "pnpm version prerelease --preid=RC --no-git-tag-version --no-git-checks",
-    "version:prepatch": "pnpm version prepatch --preid=RC --no-git-tag-version --no-git-checks",
     "test": "vitest run",
     "test:integ": "RUN_VAULT_INTEG=true vitest run src/__tests__"
   },

--- a/apps/pdf-converter/README.md
+++ b/apps/pdf-converter/README.md
@@ -42,3 +42,13 @@ You can update the client library by one of the following ways:
 - Execute `cd ${growi_root_path}/packages/pdf-converter-client && pnpm gen:client-code`
 - Start GROWI app
     - Inside GROWI devcontainer (not PDF-Converter devcontainer), execute `cd ${growi_root_path}/apps/app && turbo dev`
+
+# Releasing the docker image
+
+The image is released through changesets, the same flow `@growi/core` and `@growi/pluginkit` use — there is no release branch and no RC version marker.
+
+1. In the PR that changes `apps/pdf-converter/**`, run `npx changeset` and give `@growi/pdf-converter` a `patch` / `minor` / `major` bump.
+2. Merging that PR makes changesets open or update a **Release Subpackages** PR against `master`, which bumps `package.json` and writes `CHANGELOG.md`.
+3. Merging the Release Subpackages PR publishes the image. `.github/workflows/release-pdf-converter.yml` watches pushes to `master` that touch `apps/pdf-converter/package.json`, publishes when the version is a stable one with no `pdf-converter/v<version>` tag yet, and creates that tag afterwards.
+
+Because the gate is "stable version, not tagged yet", a push that edits `package.json` without releasing does nothing, and the same version can never be published twice.

--- a/apps/pdf-converter/README_JP.md
+++ b/apps/pdf-converter/README_JP.md
@@ -43,3 +43,13 @@ PDF-Converter API を更新した際は、必ずクライアントライブラ�
 - GROWI アプリを起動
     - GROWI の devcontainer 内 **(PDF-Converter の devcontainer ではない)** で
       `cd ${growi_root_path}/apps/app && turbo dev` を実行
+
+# docker image のリリース
+
+image のリリースは changesets を通して行います。`@growi/core` や `@growi/pluginkit` と同じ流れで、リリースブランチも RC 版数の印もありません。
+
+1. `apps/pdf-converter/**` を変更する PR の中で `npx changeset` を実行し、`@growi/pdf-converter` に `patch` / `minor` / `major` を指定します。
+2. その PR をマージすると、changesets が `master` 宛てに **Release Subpackages** PR を作成（または更新）し、その中で `package.json` の版数と `CHANGELOG.md` が更新されます。
+3. Release Subpackages PR をマージすると image が公開されます。`.github/workflows/release-pdf-converter.yml` が `master` への push のうち `apps/pdf-converter/package.json` を含むものを監視し、版数が安定版でかつ `pdf-converter/v<version>` タグが未作成のときだけ公開して、その後にタグを作ります。
+
+判定が「安定版かつタグ未作成」なので、リリースを伴わない `package.json` の編集では何も起きず、同じ版数を二度公開することもありません。

--- a/apps/pdf-converter/package.json
+++ b/apps/pdf-converter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growi/pdf-converter",
-  "version": "1.2.1-RC.0",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
@@ -16,8 +16,6 @@
     "lint": "run-p lint:**",
     "gen:swagger-spec": "SKIP_PUPPETEER_INIT=true node --import @swc-node/register/esm-register src/bin/index.ts generate-swagger --output ./specs",
     "build": "pnpm tsc -p tsconfig.build.json",
-    "version:prerelease": "pnpm version prerelease --preid=RC --no-git-tag-version --no-git-checks",
-    "version:prepatch": "pnpm version prepatch --preid=RC --no-git-tag-version --no-git-checks",
     "test": "SKIP_PUPPETEER_INIT=true vitest run"
   },
   "dependencies": {


### PR DESCRIPTION
vault-manager と pdf-converter の docker image リリースを、`@growi/core` / `@growi/pluginkit` と同じ changesets の流れに揃えます。

## 何が変わるか

これまでこの2つだけ、リリース PR を自動生成する仕組みがありませんでした。`release/vault-manager/current` / `release/pdf-converter/current` 宛ての PR を人が手で作ってマージする運用で、そもそも「リリースすべき変更が溜まっているか」を知る手段もありませんでした。

これからは開発 PR の中で `npx changeset` を書けば、あとは既存の Release Subpackages PR に乗ります。

1. 開発 PR で `npx changeset` を実行し、`@growi/vault-manager` または `@growi/pdf-converter` に `patch` / `minor` / `major` を指定する
2. マージすると changesets が master 宛ての **Release Subpackages** PR を作成・更新し、その中で `package.json` の版数と `CHANGELOG.md` が更新される
3. Release Subpackages PR をマージすると image が公開される

`release/*/current` ブランチと `-RC.0` の版数マーカーは使わなくなります。

## 公開の判定

`release-vault.yml` / `release-pdf-converter.yml` のトリガーを、リリースブランチへの PR マージから **master への push（対象は `package.json` の変更のみ）** に変えました。実際に焼くかどうかは次の2条件で判定します。

- 版数が安定版であること（プレリリースでない）
- `vault-manager/v<version>` / `pdf-converter/v<version>` タグがまだ無いこと

タグは push に成功した後に作るので、**タグの存在＝Docker Hub に上がっている**という関係が保たれます。この形にしたことで、リリースを伴わない `package.json` の編集では何も起きず、再実行しても同じ版数を二度公開しません。手動実行（`workflow_dispatch`）も同じ判定を通るので、失敗したリリースの焼き直しだけができます。

実タグに対して判定ロジックを実行して確認しました。

| 版数 | 判定 |
|---|---|
| `1.1.0` / `1.2.0`（このPR後の master） | 公開しない（タグ済み） |
| `1.1.1-RC.0` / `1.2.1-RC.0`（旧マーカー） | 公開しない（プレリリース） |
| `1.1.1` / `1.2.1` | 公開する |

**このPR自体がマージされたときも新ワークフローが起動しますが、両方ともタグ済みの版数なので何も焼きません。** これは意図した動きで、判定にタグを使っている理由でもあります。

## 版数マーカーの廃止

`package.json` の版数を、実際にリリース済みの版数（vault-manager `1.1.0` / pdf-converter `1.2.0`）に戻しました。core/pluginkit と同じ「最後にリリースした版を持つ」形です。changesets はこの版数から次を計算するので、`1.1.0` + patch → `1.1.1` になります（実測確認済み）。

これを維持していた `create-pr-for-next-rc` ジョブは削除しました。`-RC.0` は開発中の印として付いていただけで、apps/app と違って RC image を焼くワークフローが無く、誰も参照していませんでした。あわせて、そのジョブ専用だった `version:prerelease` / `version:prepatch` スクリプトも削除しています。残しておくと手で版数をいじって changesets の流れを壊す入口になるためです。`turbo.json` の定義は app / slackbot-proxy が使うのでそのままです。

## ci-vault.yml の paths 修正

`.github/workflows/ci-vault.yml` の `paths` に `packages/core/**` と `packages/logger/**` を追加しました。vault-manager の workspace 依存はこの2つだけで、どちらも image にコンパイルされて入るのに、これまで変更しても CI が回りませんでした。master から直接焼く形になると CI がマージと image の間の唯一の検査になるので、あわせて直しています。

pdf-converter は workspace 依存が無く、`ci-pdf-converter.yml` の `paths` は既に `pnpm-lock.yaml` や root の設定ファイルまで見ているので、そちらは変更していません。

## 補足

- `apps/growi-vault-manager/docker/README.md` の "Supported tags" 行は changesets の管轄外なので、changeset を書く PR で一緒に直す運用になります。README にもそう書きました
- pdf-converter 側は buildx のステップに `id` が無く `builder: ${{ steps.buildx.outputs.name }}` が空文字に解決されていたので、`id: buildx` を付けて元の意図どおりに解決するようにしました（setup-buildx-action が作った builder を既定にするため、動作は変わりません）
- 手順の記述がリポジトリ内に無かったので、各 app の README に Releasing の節を追加しました
- `release/vault-manager/current` と `release/pdf-converter/current` はこのPR後に使われなくなります。削除するか記録として残すかは別途決めてください

🤖 Generated with [Claude Code](https://claude.com/claude-code)
