### PR TITLE
fix: Report a conflict when renaming a page with a stale revisionId

### DIFF
--- a/apps/app/src/server/routes/apiv3/pages/index.js
+++ b/apps/app/src/server/routes/apiv3/pages/index.js
@@ -300,6 +300,8 @@ export const setup = (crowi) => {
    *                  isRecursively:
    *                    type: boolean
    *                    description: whether rename page with descendants
+   *                  revisionId:
+   *                    $ref: '#/components/schemas/ObjectId'
    *                required:
    *                  - pageId
    *                  - revisionId
@@ -312,12 +314,16 @@ export const setup = (crowi) => {
    *                  properties:
    *                    page:
    *                      $ref: '#/components/schemas/Page'
+   *          400:
+   *            description: revisionId is missing, or the destination is under a non-existent user's user page. An empty page may be renamed without revisionId.
    *          403:
    *            description: Page is forbidden.
    *          404:
    *            description: Page is not found.
    *          409:
-   *            description: page path is already existed
+   *            description: The destination path is already taken, cannot be used, or revisionId is not the latest revision.
+   *          500:
+   *            description: Failed to rename page.
    */
   router.put(
     '/rename',

--- a/apps/app/src/server/routes/apiv3/pages/index.js
+++ b/apps/app/src/server/routes/apiv3/pages/index.js
@@ -410,7 +410,9 @@ export const setup = (crowi) => {
           );
         }
 
-        if (!page.isEmpty && !page.isUpdatable(revisionId)) {
+        // isUpdatable is async: without the await the negation is always false and
+        // this conflict check never fires
+        if (!page.isEmpty && !(await page.isUpdatable(revisionId))) {
           return res.apiv3Err(
             new ErrorV3(
               "Someone could update this page, so couldn't delete.",

--- a/apps/app/src/server/routes/apiv3/pages/rename.integ.ts
+++ b/apps/app/src/server/routes/apiv3/pages/rename.integ.ts
@@ -1,9 +1,9 @@
 /**
  * Integration test — PUT /pages/rename must answer with the canonical status for
  * every outcome: 404 (no such page), 403 (the page exists but the requester may not
- * read it), 400 (a non-empty page renamed without revisionId) and 200 (renamed).
- * PR #11615 split the single 401 this route used to return into 403 / 404, which is
- * what the first two cases pin.
+ * read it), 400 (a non-empty page renamed without revisionId), 409 (revisionId is
+ * not the latest) and 200 (renamed). PR #11615 split the single 401 this route used
+ * to return into 403 / 404, which is what the first two cases pin.
  *
  * Why the fixtures look the way they do:
  *
@@ -325,6 +325,29 @@ describe('PUT /rename', () => {
         code: 'invalid_body',
         message: 'revisionId must be a mongoId',
       }),
+    ]);
+
+    const untouchedPage = await crowi.models.Page.findById(page._id);
+    expect(untouchedPage?.path).toBe(sourcePath);
+  });
+
+  it('returns 409 when revisionId is not the latest revision', async () => {
+    const page = await createPage(sourcePath, 'source body', requester);
+
+    const response = await request(app)
+      .put('/rename')
+      .set('X-Forwarded-For', TEST_IP)
+      .send({
+        pageId: page._id.toString(),
+        newPagePath: renamedPath,
+        revisionId: new Types.ObjectId().toString(),
+      });
+
+    // Only the code is asserted: the message this route pairs with it still says
+    // "couldn't delete", which is a wart a fix should be free to correct.
+    expect(response.status).toBe(409);
+    expect(response.body.errors).toEqual([
+      expect.objectContaining({ code: 'notfound_or_forbidden' }),
     ]);
 
     const untouchedPage = await crowi.models.Page.findById(page._id);

--- a/apps/app/src/server/routes/apiv3/pages/rename.integ.ts
+++ b/apps/app/src/server/routes/apiv3/pages/rename.integ.ts
@@ -1,17 +1,60 @@
-import { type IUser, PageGrant } from '@growi/core';
+/**
+ * Integration test — PUT /pages/rename must answer with the canonical status for
+ * every outcome: 404 (no such page), 403 (the page exists but the requester may not
+ * read it), 400 (a non-empty page renamed without revisionId) and 200 (renamed).
+ * PR #11615 split the single 401 this route used to return into 403 / 404, which is
+ * what the first two cases pin.
+ *
+ * Why the fixtures look the way they do:
+ *
+ * - `app:isV5Compatible` is pinned in beforeAll and put back in afterAll. Installed
+ *   instances run with it ON (see service/installer.ts) and the rename forks on it
+ *   (see service/page/should-use-v4-process.ts), so leaving it at its default would
+ *   exercise the legacy v4 rename instead of the one users actually hit. It cannot be
+ *   left ambient either: the value lives in the `configs` collection, one database is
+ *   shared by every file its vitest worker runs, and a dozen sibling files switch it
+ *   on without putting it back — so an unpinned suite reads whatever the file before
+ *   it happened to leave behind.
+ *
+ * - Fixture pages go through `crowi.pageService.create` with the detached sub
+ *   operation awaited (the pattern in service/page/grant-preserve-on-update.integ.ts),
+ *   so each one is a real v5 page with a consistent parent link, revision and
+ *   descendantCount. Hand-built `Page.create` documents are not enough: the route
+ *   reads `page.isEmpty` and `page.isUpdatable(revisionId)`, and the v5 rename walks
+ *   the parent links.
+ *
+ * - Descendant renaming is deliberately NOT asserted here. This route's own job ends
+ *   at choosing the status code and handing the page to `pageService.renamePage`;
+ *   recursive rename is covered by service/page/v5.public-page.integ.ts. What the
+ *   suite does have to do is wait for the detached rename sub operation to settle, so
+ *   its background writes cannot land after the fixtures have been cleaned up.
+ *
+ * - `res.apiv3` / `res.apiv3Err` are installed per request on this suite's own app.
+ *   Handing the express module to `addCustomFunctionToResponse` (what production
+ *   does) would write them onto that module's shared response object, which every app
+ *   built later in the same worker inherits and nothing resets.
+ */
+
+import { getIdStringForRef, type IUserHasId, PageGrant } from '@growi/core';
+import { ConfigSource } from '@growi/core/dist/interfaces';
+import { escapeStringForMongoRegex } from '@growi/core/dist/utils';
 import type { NextFunction, Request, Response } from 'express';
 import express from 'express';
-import { type HydratedDocument, Types } from 'mongoose';
+import mongoose, { type HydratedDocument, Types } from 'mongoose';
 import request from 'supertest';
 
 import { getInstance } from '^/test/setup/crowi';
 
+import type { IOptionsForCreate } from '~/interfaces/page';
 import type Crowi from '~/server/crowi';
 import type { PageDocument } from '~/server/models/page';
+import PageOperation from '~/server/models/page-operation';
+import { Revision } from '~/server/models/revision';
 import addCustomFunctionToResponse from '~/server/routes/apiv3/response';
+import { prisma } from '~/utils/prisma';
 
 type AuthenticatedRequest = Request & {
-  user?: HydratedDocument<IUser>;
+  user?: HydratedDocument<IUserHasId>;
 };
 
 const passthroughMiddleware = (
@@ -32,49 +75,137 @@ vi.mock('~/server/middlewares/admin-required', () => ({
   default: () => passthroughMiddleware,
 }));
 
-describe('PUT /rename', () => {
-  const requesterUsername = 'rename-route-integ-requester';
-  const ownerUsername = 'rename-route-integ-owner';
-  const sourcePath = '/rename-route-integ/source';
-  const sourceChildPath = `${sourcePath}/child`;
-  const renamedPath = '/rename-route-integ/renamed';
-  const renamedChildPath = `${renamedPath}/child`;
-  const forbiddenPath = '/rename-route-integ/forbidden';
+// Every path this suite writes lives under here, so cleanup can match by prefix:
+// a rename also creates the empty ancestor page of its destination, which a list of
+// known paths would miss.
+const FIXTURE_ROOT = '/rename-route-integ';
+const sourcePath = `${FIXTURE_ROOT}/source`;
+const renamedPath = `${FIXTURE_ROOT}/renamed`;
+const forbiddenPath = `${FIXTURE_ROOT}/forbidden`;
 
+const requesterUsername = 'rename-route-integ-requester';
+const ownerUsername = 'rename-route-integ-owner';
+
+// Sentinel ip (reached via X-Forwarded-For) so cleanup removes only the activity
+// rows this suite created — the `activities` rows of every sibling suite live in the
+// same database. Keep it distinct from the sentinels those suites use.
+const TEST_IP = '10.0.0.114';
+
+const fixturePathPattern = new RegExp(
+  `^${escapeStringForMongoRegex(FIXTURE_ROOT)}(/|$)`,
+);
+
+describe('PUT /rename', () => {
   let app: express.Application;
   let crowi: Crowi;
-  let requester: HydratedDocument<IUser>;
-  let owner: HydratedDocument<IUser>;
-  let rootPage: HydratedDocument<PageDocument> | null = null;
+  let requester: HydratedDocument<IUserHasId>;
+  let owner: HydratedDocument<IUserHasId>;
+  let rootPage: HydratedDocument<PageDocument>;
   let rootPageWasCreated = false;
+  let rootDescendantCount: number;
+  let isV5CompatibleInDbBefore: boolean | undefined;
+
+  /**
+   * Create a real v5 page. `create` fires its sub operation without awaiting it, so
+   * run that explicitly to keep the fixture deterministic (and to leave no
+   * PageOperation document behind).
+   */
+  const createPage = async (
+    path: string,
+    body: string,
+    user: HydratedDocument<IUserHasId>,
+    options: IOptionsForCreate = {},
+  ): Promise<HydratedDocument<PageDocument>> => {
+    const createSubOperationSpy = vi
+      .spyOn(crowi.pageService, 'createSubOperation')
+      .mockResolvedValue();
+
+    const created = await crowi.pageService.create(path, body, user, options);
+
+    const argsForCreateSubOperation = createSubOperationSpy.mock.calls[0];
+    createSubOperationSpy.mockRestore();
+    await crowi.pageService.createSubOperation(
+      ...(argsForCreateSubOperation as Parameters<
+        typeof crowi.pageService.createSubOperation
+      >),
+    );
+
+    return created;
+  };
+
+  const latestRevisionIdOf = (page: HydratedDocument<PageDocument>): string => {
+    const { revision } = page;
+    if (revision == null) {
+      throw new Error('the fixture page must have a revision');
+    }
+    return getIdStringForRef(revision);
+  };
+
+  /**
+   * The v5 rename calls `renameSubOperation` without awaiting it, and that operation
+   * deletes the PageOperation document once it is done. Wait for that so its writes
+   * cannot outlive the test.
+   */
+  const waitForRenameToSettle = async (
+    fromPath: string,
+    maxWaitMs = 10_000,
+  ): Promise<void> => {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < maxWaitMs) {
+      if ((await PageOperation.countDocuments({ fromPath })) === 0) {
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    throw new Error(
+      `the rename from ${fromPath} did not settle within ${maxWaitMs}ms`,
+    );
+  };
+
+  const removeFixtures = async (): Promise<void> => {
+    const { Page } = crowi.models;
+
+    const fixturePageIds = (
+      await Page.find({ path: fixturePathPattern }, { _id: 1 })
+    ).map((page) => page._id);
+    await Revision.deleteMany({ pageId: { $in: fixturePageIds } });
+    await Page.deleteMany({ path: fixturePathPattern });
+    await PageOperation.deleteMany({ fromPath: fixturePathPattern });
+    await prisma.activities.deleteMany({ where: { ip: TEST_IP } });
+
+    // Creating and renaming under the root page bumps its descendantCount, and the
+    // root page is shared with every other file using this database.
+    if (rootDescendantCount != null) {
+      await Page.updateOne(
+        { _id: rootPage._id },
+        { $set: { descendantCount: rootDescendantCount } },
+      );
+    }
+  };
 
   beforeAll(async () => {
     crowi = await getInstance();
-    const { Page, User } = crowi.models;
+    const { Page } = crowi.models;
+    const User = mongoose.model<IUserHasId>('User');
 
-    await Page.deleteMany({
-      path: {
-        $in: [
-          sourcePath,
-          sourceChildPath,
-          renamedPath,
-          renamedChildPath,
-          forbiddenPath,
-        ],
-      },
-    });
+    // Read the value stored in the database, not the effective one, so afterAll can
+    // leave the `configs` collection exactly as it found it (no row when there was
+    // none) for every other file sharing this database.
+    isV5CompatibleInDbBefore = crowi.configManager.getConfig(
+      'app:isV5Compatible',
+      ConfigSource.db,
+    );
+    await crowi.configManager.updateConfig('app:isV5Compatible', true);
+
     await User.deleteMany({
       username: { $in: [requesterUsername, ownerUsername] },
     });
 
-    rootPage = await Page.findOne({ path: '/' });
-    if (rootPage == null) {
-      rootPage = await Page.create({
-        path: '/',
-        grant: PageGrant.GRANT_PUBLIC,
-      });
-      rootPageWasCreated = true;
-    }
+    const existingRootPage = await Page.findOne({ path: '/' });
+    rootPage =
+      existingRootPage ??
+      (await Page.create({ path: '/', grant: PageGrant.GRANT_PUBLIC }));
+    rootPageWasCreated = existingRootPage == null;
 
     requester = await User.create({
       name: requesterUsername,
@@ -87,10 +218,21 @@ describe('PUT /rename', () => {
       email: `${ownerUsername}@example.com`,
     });
 
-    addCustomFunctionToResponse(express);
+    // Install the real apiv3 helpers on this suite's responses only — see the file
+    // header for why the express module must not be handed over here.
+    const responseHelpers: { response: Record<string, unknown> } = {
+      response: {},
+    };
+    addCustomFunctionToResponse(responseHelpers);
 
     app = express();
+    // Make req.ip the sentinel above: it is what renamePage records on its activity.
+    app.set('trust proxy', true);
     app.use(express.json());
+    app.use((_req, res, next) => {
+      Object.assign(res, responseHelpers.response);
+      next();
+    });
     app.use((req: AuthenticatedRequest, _res, next) => {
       req.user = requester;
       next();
@@ -98,52 +240,41 @@ describe('PUT /rename', () => {
 
     const { setup } = await import('./index');
     app.use('/', setup(crowi));
+
+    // Drop anything a previous interrupted run left behind, then record the root
+    // page's descendantCount as the value every test must restore it to.
+    await removeFixtures();
+    rootDescendantCount =
+      (await Page.findById(rootPage._id))?.descendantCount ?? 0;
   }, 120_000);
 
   afterEach(async () => {
-    await crowi.models.Page.deleteMany({
-      path: {
-        $in: [
-          sourcePath,
-          sourceChildPath,
-          renamedPath,
-          renamedChildPath,
-          forbiddenPath,
-        ],
-      },
-    });
+    await removeFixtures();
   });
 
   afterAll(async () => {
-    await crowi.models.Page.deleteMany({
-      path: {
-        $in: [
-          sourcePath,
-          sourceChildPath,
-          renamedPath,
-          renamedChildPath,
-          forbiddenPath,
-        ],
-      },
-    });
+    await removeFixtures();
     await crowi.models.User.deleteMany({
       username: { $in: [requesterUsername, ownerUsername] },
     });
-    if (rootPageWasCreated && rootPage != null) {
+    if (rootPageWasCreated) {
       await crowi.models.Page.deleteOne({ _id: rootPage._id });
     }
+    await crowi.configManager.updateConfigs(
+      { 'app:isV5Compatible': isV5CompatibleInDbBefore },
+      { removeIfUndefined: true },
+    );
   });
 
-  it('returns 404 when an authenticated user renames a missing page', async () => {
+  it('returns 404 when the page does not exist', async () => {
     const pageId = new Types.ObjectId();
 
-    const response = await request(app).put('/rename').send({
-      pageId: pageId.toString(),
-      newPagePath: renamedPath,
-    });
+    const response = await request(app)
+      .put('/rename')
+      .set('X-Forwarded-For', TEST_IP)
+      .send({ pageId: pageId.toString(), newPagePath: renamedPath });
 
     expect(response.status).toBe(404);
-    expect(response.status).not.toBe(500);
     expect(response.body.errors).toEqual([
       expect.objectContaining({
         code: 'notfound_or_forbidden',
@@ -152,24 +283,23 @@ describe('PUT /rename', () => {
     ]);
   });
 
-  it('returns 403 and leaves a forbidden page unchanged', async () => {
-    const page = await crowi.models.Page.create({
-      path: forbiddenPath,
+  it('returns 403 and leaves the page untouched when the requester may not read it', async () => {
+    const page = await createPage(forbiddenPath, 'forbidden body', owner, {
       grant: PageGrant.GRANT_OWNER,
-      grantedUsers: [owner._id],
-      creator: owner._id,
-      lastUpdateUser: owner._id,
-      isEmpty: true,
-      descendantCount: 0,
     });
 
-    const response = await request(app).put('/rename').send({
-      pageId: page._id.toString(),
-      newPagePath: renamedPath,
-    });
+    // A valid revisionId is sent so a 403 can only come from the grant filter — a
+    // missing one would be answered with 400 before the grant is ever consulted.
+    const response = await request(app)
+      .put('/rename')
+      .set('X-Forwarded-For', TEST_IP)
+      .send({
+        pageId: page._id.toString(),
+        newPagePath: `${FIXTURE_ROOT}/forbidden-renamed`,
+        revisionId: latestRevisionIdOf(page),
+      });
 
     expect(response.status).toBe(403);
-    expect(response.status).not.toBe(500);
     expect(response.body.errors).toEqual([
       expect.objectContaining({
         code: 'notfound_or_forbidden',
@@ -177,44 +307,48 @@ describe('PUT /rename', () => {
       }),
     ]);
 
-    const unchangedPage = await crowi.models.Page.findById(page._id);
-    expect(unchangedPage?.path).toBe(forbiddenPath);
+    const untouchedPage = await crowi.models.Page.findById(page._id);
+    expect(untouchedPage?.path).toBe(forbiddenPath);
   });
 
-  it('renames an accessible page and its descendant', async () => {
-    if (rootPage == null) {
-      throw new Error('root page must be initialized in beforeAll');
-    }
+  it('returns 400 when a non-empty page is renamed without revisionId', async () => {
+    const page = await createPage(sourcePath, 'source body', requester);
 
-    const page = await crowi.models.Page.create({
-      path: sourcePath,
-      parent: rootPage._id,
-      grant: PageGrant.GRANT_PUBLIC,
-      creator: requester._id,
-      lastUpdateUser: requester._id,
-      isEmpty: true,
-      descendantCount: 1,
-    });
-    const childPage = await crowi.models.Page.create({
-      path: sourceChildPath,
-      grant: PageGrant.GRANT_PUBLIC,
-      creator: requester._id,
-      lastUpdateUser: requester._id,
-      descendantCount: 0,
-    });
+    const response = await request(app)
+      .put('/rename')
+      .set('X-Forwarded-For', TEST_IP)
+      .send({ pageId: page._id.toString(), newPagePath: renamedPath });
 
-    const response = await request(app).put('/rename').send({
-      pageId: page._id.toString(),
-      newPagePath: renamedPath,
-    });
+    expect(response.status).toBe(400);
+    expect(response.body.errors).toEqual([
+      expect.objectContaining({
+        code: 'invalid_body',
+        message: 'revisionId must be a mongoId',
+      }),
+    ]);
+
+    const untouchedPage = await crowi.models.Page.findById(page._id);
+    expect(untouchedPage?.path).toBe(sourcePath);
+  });
+
+  it('renames an accessible page', async () => {
+    const page = await createPage(sourcePath, 'source body', requester);
+
+    const response = await request(app)
+      .put('/rename')
+      .set('X-Forwarded-For', TEST_IP)
+      .send({
+        pageId: page._id.toString(),
+        newPagePath: renamedPath,
+        revisionId: latestRevisionIdOf(page),
+      });
 
     expect(response.status).toBe(200);
     expect(response.body.page.path).toBe(renamedPath);
 
+    await waitForRenameToSettle(sourcePath);
+
     const renamedPage = await crowi.models.Page.findById(page._id);
     expect(renamedPage?.path).toBe(renamedPath);
-
-    const renamedChildPage = await crowi.models.Page.findById(childPage._id);
-    expect(renamedChildPage?.path).toBe(renamedChildPath);
   });
 });


### PR DESCRIPTION
#11615 のフォローアップです。レビューで挙がった指摘のうち、テスト側 7 件と公開仕様 1 件を直しました。作業中に競合検知（409）が一度も動いていないことが分かったので、それも直しています。

#11615 自体の指摘 3 点（`notfound_or_forbidden` のコードとメッセージを元のまま残す / モックを外して実際のページ取得を通す / 型アサーションを使わない）はすでに反映済みで、この PR では触っていません。

## コミット

### 1. `test(pages): rebuild the rename route integ test on real v5 fixtures`

追加されたテストは通っていましたが、通る理由が一般には成り立たないものでした。

- **設定値の既定に暗黙に依存していた。** `app:isV5Compatible` をどこにも設定せずに読んでいました。この値は `configs` コレクションに入り、結合テストの DB は同じ worker が担当するファイル全部で共有されるので、値はファイルをまたいで持ち越されます。この値を true に書き換えて元に戻さないファイルが 12 個あり、そのどれかが先に走った worker に入ると、子ページの検証が失敗します（`expected '/rename-route-integ/source/child' to be '/rename-route-integ/renamed/child'`）。さらに v5 のリネームは子の処理を待たずに始めるので、`Unhandled Rejection: Error: Target not found` が worker に残り、vitest が「同じ worker の他のテスト結果も信用できない」旨の警告を出します。beforeAll で値を固定し、afterAll では `configs` コレクションを元の状態（行が無かったなら行が無い状態）に戻すようにしました。
- **実際の GROWI が通る経路を通っていなかった。** 既定では旧 v4 のリネームだけを通ります。しかも子ページが見つかるのは fixture が `parent` を持たない壊れた形だからで、`parent` を足すという一番自然に見える修正で緑から赤に変わる状態でした。fixture は `pageService.create` とその後続処理を待つ形（`service/page/grant-preserve-on-update.integ.ts` と同じやり方）に変え、本物の v5 ページにしました。子ページの検証はこのルートのテストから外しています（再帰リネームは `service/page/v5.public-page.integ.ts` が担当）。代わりに、後ろで走るリネームの後続処理が終わるのを待ちます。
- **後片付けが書いたものを全部戻していなかった。** リネームが作る中間の空ページ、`PageOperation` の行、activity の行、root ページの `descendantCount` が残り、後続のファイルに持ち越されていました。削除をパスの前方一致にし、activity の行は専用の IP を目印にして消し、root ページの `descendantCount` は元の値に戻します。
- **`addCustomFunctionToResponse(express)` が express の共有部分を書き換えたままにしていた。** 同じ worker で後から作られるすべての express アプリに残り、戻す処理もありませんでした。このテスト専用のアプリで、リクエストごとに `res.apiv3` / `res.apiv3Err` を入れる形に変えました。
- **fixture が全部空ページだったので revisionId 関係の分岐を通っていなかった。** また `expect(status).not.toBe(500)` は直前の行で 404 を確定させているので絶対に失敗しません。空でないページを revisionId 無しでリネームして 400 になる検証を足し、意味の無いアサーションを削り、fixture のどこが効いているのかを冒頭に書きました。

### 2. `fix(pages): make the rename conflict check able to fire`

`page.isUpdatable()` は async（`models/obsolete-page.js`）なので、`!page.isUpdatable(revisionId)` は Promise を否定していて常に false になります。つまり **古い revisionId を送っても 409 にならず、そのままリネームが実行されていました**。await を付けて、この分岐が本来意図していた競合検知が働くようにしています。

追加した 409 のテストは、await が無い状態では赤（409 のはずが 200）になります。

同じ形が他に 2 箇所ありますが、それぞれ別のエンドポイントで挙動の変わり方も別なので、この PR では触っていません（このファイル内の削除エンドポイントの `pagesToDelete.filter(p => p.isEmpty || p.isUpdatable(...))` と `routes/page.js`）。

### 3. `docs(openapi): document every response of PUT /pages/rename`

`responses` には 200 / 403 / 404 / 409 しか書かれていませんでしたが、ハンドラは 400 を 2 通り（revisionId 未指定、存在しないユーザーのユーザーページ配下への移動）と 500 も返します。この記述は公開仕様と SDK の生成元なので、クライアント側には一番よく起きる失敗に対応する型がありませんでした。あわせて `revisionId` を properties に足しました（`required` にあるのに properties に無い状態でした）。

## 検証

devcontainer の MongoDB（`MONGO_URI` を明示）で実測しています。

- `pnpm vitest run rename.integ` → 5 passed。`Unhandled Rejection` は出ません。
- 設定値の持ち越しに強くなったことの確認: `configs` の `app:isV5Compatible` を **true にした場合 / false にした場合 / 行を消した場合** の 3 通りで実行し、いずれも 5 passed。実行後の `configs` は 3 通りすべてで元の状態に戻っていました。
- 後片付けの確認: 実行後の DB に、`/rename-route-integ` 配下のページ・`pageoperations`・専用 IP の activity・テスト用ユーザーがいずれも残っていないことを確認。root ページが先に存在する場合は、`descendantCount` が元の値に戻り root 自体も残ることを確認。
- テストが本当に効いているかの確認（意図的に壊して赤になるか）: `meta.isForbidden ? 403 : 404` を `404` に変えると 403 のテストが赤。await を外すと 409 のテストが赤。
- `pnpm run lint:typecheck` / `lint:biome` / `lint:route-guard` / `lint:import-convention` / `lint:no-cjs` はすべて通過。
- `pnpm run lint:openapi:apiv3`（仕様の生成と検証）通過。生成された仕様で `/pages/rename` の responses が `200, 400, 403, 404, 409, 500` になり、`revisionId` が properties に入ることを確認。

## 残した指摘

レビューで挙がったうち 1 件は、直さないほうがよいと判断して残しています。#11615 で使うようになった `findPageAndMetaDataByViewer` は `basicOnly: true` でも `constructBasicPageInfo` を実行し、空でないページでは `page.revision` を必ず存在するものとして扱います。`isEmpty: false` かつ `revision` が無いページをリネームすると、そこで例外になって 500 になります（`master` では成功していました）。ただし同じ計算は `/page/info` など既存のエンドポイントも通っているので、このルートだけ特別に弱くなったわけではなく、標準の取得関数を使い回すこと自体は 403 と 404 の判定を 1 箇所に保つという意味で正しい形です。別 issue に記録します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
