### PR TITLE
fix: Page created at a path with a leftover redirect was not reachable at that path

### DIFF
--- a/apps/app/src/server/service/page/create-deletes-page-redirect.integ.ts
+++ b/apps/app/src/server/service/page/create-deletes-page-redirect.integ.ts
@@ -1,0 +1,111 @@
+import type { IUserHasId } from '@growi/core';
+import type { HydratedDocument, Model } from 'mongoose';
+import mongoose from 'mongoose';
+import { vi } from 'vitest';
+
+import { getInstance } from '^/test/setup/crowi';
+
+import type Crowi from '~/server/crowi';
+import type { PageDocument, PageModel } from '~/server/models/page';
+import PageRedirect from '~/server/models/page-redirect';
+
+/**
+ * A page created at a path that still carries a redirect is unreachable at its own
+ * path: page view resolves a requested path through its redirect
+ * (`resolvePathAndCheckIdentical`) without ever looking for a live page at it. So
+ * creating a page has to clear the redirect for its path, and has to do it where a
+ * failure can still be acted on — not from a sub-operation the caller never awaits.
+ */
+describe('PageService.create with a redirect on the target path', () => {
+  const PREFIX = '/create-redirect-integ';
+
+  let crowi: Crowi;
+  let Page: PageModel;
+  let User: Model<IUserHasId>;
+  let user: HydratedDocument<IUserHasId>;
+
+  /**
+   * Creates without ever running the sub operation, since what is under test is
+   * that the awaited part of `create` clears the redirect on its own.
+   */
+  const createWithoutSubOperation = async (
+    path: string,
+  ): Promise<HydratedDocument<PageDocument>> => {
+    const mockedCreateSubOperation = vi
+      .spyOn(crowi.pageService, 'createSubOperation')
+      .mockReturnValue(Promise.resolve());
+
+    try {
+      return await crowi.pageService.create(path, 'body', user, {});
+    } finally {
+      mockedCreateSubOperation.mockRestore();
+    }
+  };
+
+  beforeAll(async () => {
+    crowi = await getInstance();
+    await crowi.configManager.updateConfig('app:isV5Compatible', true);
+
+    User = mongoose.model<IUserHasId>('User');
+    Page = mongoose.model<PageDocument, PageModel>('Page');
+
+    // Suppress page events so their async listeners don't run DB work after the
+    // in-memory mongo is torn down (same pattern as grant-preserve-on-update).
+    vi.spyOn(crowi.pageService.pageEvent, 'emit').mockReturnValue(true);
+
+    const existingRoot = await Page.findOne({ path: '/' });
+    if (existingRoot == null) {
+      await Page.create({ path: '/', grant: Page.GRANT_PUBLIC });
+    }
+
+    const username = 'createRedirectUser';
+    user =
+      (await User.findOne({ username })) ??
+      (await User.create({
+        name: username,
+        username,
+        email: 'create-redirect@example.com',
+      }));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.spyOn(crowi.pageService.pageEvent, 'emit').mockReturnValue(true);
+    await Page.deleteMany({ path: new RegExp(`^${PREFIX}/`) });
+    await PageRedirect.deleteMany({ fromPath: new RegExp(`^${PREFIX}/`) });
+  });
+
+  it('has deleted the redirect by the time create resolves', async () => {
+    const path = `${PREFIX}/reused`;
+    await PageRedirect.create({ fromPath: path, toPath: `${PREFIX}/moved-to` });
+
+    await createWithoutSubOperation(path);
+
+    expect(await PageRedirect.findOne({ fromPath: path })).toBeNull();
+  });
+
+  it('creates no page when the redirect cannot be deleted', async () => {
+    const path = `${PREFIX}/undeletable`;
+    await PageRedirect.create({ fromPath: path, toPath: `${PREFIX}/moved-to` });
+    vi.spyOn(PageRedirect, 'deleteOne').mockImplementation(() => {
+      throw new Error('simulated failure to delete the redirect');
+    });
+
+    await expect(createWithoutSubOperation(path)).rejects.toThrow();
+
+    // Neither half of the inconsistent state was left behind: the page was not
+    // created, and the redirect that could not be deleted is still there.
+    vi.restoreAllMocks();
+    expect(await Page.findOne({ path })).toBeNull();
+    expect(await PageRedirect.findOne({ fromPath: path })).not.toBeNull();
+  });
+
+  it('creates a page normally when the path has no redirect', async () => {
+    const path = `${PREFIX}/fresh`;
+
+    const page = await createWithoutSubOperation(path);
+
+    expect(page.path).toBe(path);
+    expect(await Page.findOne({ path })).not.toBeNull();
+  });
+});

--- a/apps/app/src/server/service/page/index.ts
+++ b/apps/app/src/server/service/page/index.ts
@@ -4895,6 +4895,28 @@ class PageService implements IPageService {
       throw Error('Cannot process create');
     }
 
+    // Clear the redirect for this path before anything is written. Page view
+    // resolves a requested path through its redirect without checking for a live
+    // page at it (resolvePathAndCheckIdentical), so a page created while its
+    // redirect survives is unreachable at its own path. Deleting first means a
+    // failure here leaves nothing half-done: the redirect is still in place and no
+    // page was created, so the operation is safe to retry. This used to run in
+    // createSubOperation, which the caller does not await and which logged a
+    // failure without acting on it, leaving that state permanently.
+    try {
+      const { deletedCount } = await PageRedirect.deleteOne({ fromPath: path });
+      if (deletedCount > 0) {
+        logger.info(
+          `Deleted the page redirect from "${path}" before creating a page there.`,
+        );
+      }
+    } catch (err) {
+      logger.error(`Failed to delete the PageRedirect from "${path}"`, err);
+      throw new Error(
+        `Could not create a page at "${path}": the redirect registered for that path could not be removed, and the page would not be reachable at that path while it remains.`,
+      );
+    }
+
     // Prepare a page document
     const shouldNew = isGrantRestricted;
     const page = await this.preparePageDocumentToCreate(path, shouldNew);
@@ -4972,16 +4994,8 @@ class PageService implements IPageService {
     // Update descendantCount
     await this.updateDescendantCountOfAncestors(page._id, 1, false);
 
-    // Delete PageRedirect if exists
-    try {
-      await PageRedirect.deleteOne({ fromPath: page.path });
-      logger.warn(
-        `Deleted page redirect after creating a new page at path "${page.path}".`,
-      );
-    } catch (err) {
-      // no throw
-      logger.error('Failed to delete PageRedirect');
-    }
+    // The redirect for this path is deleted in create(), before the page is
+    // written — not here, where a failure could not be acted on.
 
     // update scopes for descendants
     if (options.overwriteScopesOfDescendants) {


### PR DESCRIPTION
## 症状

改名で残ったリダイレクトがあるパスに、あとから新しいページを作ると、**そのページを自分のパスで開けなくなります**。`/a` を `/b` に改名して `/a`→`/b` のリダイレクトが残り、その後 `/a` にページを作った場合、`/a` を開くと `/b` が表示されます。

ページ表示側の `resolvePathAndCheckIdentical`（`apps/app/src/pages/[[...path]]/page-data-props.ts`）は、リダイレクトが 1 件でもあれば無条件に `chains.end.toPath` へ移し、リクエストされたパスに実ページがあるかを一度も確認しません。

## 原因

ページ作成時にそのパスのリダイレクトを消す処理はありますが、確実ではありませんでした。

- `create()` は `this.createSubOperation(...)` を **`await` せずに**呼んでいる（`apps/app/src/server/service/page/index.ts`）
- その中の `PageRedirect.deleteOne` は `try`/`catch` で囲まれ、失敗時は `logger.error` だけで先へ進む（`// no throw`）

このため、一時的なエラーが 1 回起きるだけでリダイレクトが**恒久的に**残ります。加えて通常時も、`create()` が戻った時点では削除がまだ走っていません（`disableAncestorPagesTtl` と `updateDescendantCountOfAncestors` の後に来るため）。

## 変更

削除を `createSubOperation` から `create()` 本体へ移し、**バリデーション通過後・何も書き込む前**に置きました。失敗した場合は作成を中止します。

先に削除するのが失敗時の安全につながります。

| 順序 | 削除が失敗したとき |
|---|---|
| 削除 → 保存（本 PR） | リダイレクトは残ったまま、ページは作られない。何も中途半端な状態にならず、そのまま再試行できる |
| 保存 → 削除（従来） | ページとリダイレクトが両方存在する ＝ まさに防ぎたい状態。しかも元に戻す手段がない |

バリデーションより後に置いているので、作成が弾かれるケース（パス不正・権限・重複）で正常なリダイレクトを消してしまうことはありません。

なお、従来は削除件数に関係なく毎回 `logger.warn` を出していたので、実際に削除したときだけ `logger.info` を出す形にしました。

### `// no throw` を変えた理由

削除が「保存の後」にあった前提では、そこで throw しない判断は妥当でした（ページは既にできているので、throw しても状態は直らず、利用者にだけエラーが見えます）。削除を保存の前に移したことで前提が変わり、throw が安全側になります。ただし利用者から見た挙動は変わります（リダイレクト削除の一時的なエラーで作成が失敗する）。この交換で良くないと思われる場合はご指摘ください。

## テスト

`apps/app/src/server/service/page/create-deletes-page-redirect.integ.ts` を追加しました。`createSubOperation` を stub したまま（＝実行しないまま）検証しているので、`create()` の await される範囲で削除されていることを確認できます。

- `create` が解決した時点でリダイレクトが消えている
- 削除が失敗したときはページが作られない（リダイレクトも残っている）
- リダイレクトが無いパスでは従来どおり作成できる

いずれも RED を確認してから実装しています（1・2 が失敗 → 実装後に 3 件 pass）。

回帰確認: `src/server/service/page` 16 ファイル 182 件 pass、`src/server` 全体 157 ファイル 1471 件 pass。

## 関連

backlinks のリンク解決（#11623）で、この「消し残ったリダイレクト」が索引とクリックの食い違いを生むことが分かったのが発端です。#11623 側はページ表示と同じ「リダイレクト優先」に揃えて食い違いを解消しており、本 PR は原因そのものを塞ぎます。どちらか一方でも成立しますが、両方入れると「食い違わない」かつ「そもそも起きない」になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
