### PR TITLE
fix: Report a conflict when deleting a page with a stale revisionId

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -417,6 +417,7 @@
     "notfound_or_forbidden": "Original page is not found or forbidden.",
     "already_exists": "Page with the path already exists.",
     "outdated": "Page is updated someone and now outdated.",
+    "invalid_body": "The request does not tell which version of the page it applies to.",
     "user_not_admin": "Only admin user can delete",
     "single_deletion_empty_pages": "Empty pages cannot be single deleted",
     "complete_deletion_not_allowed_for_user": "You are not allowed to delete this page completely"

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -419,6 +419,7 @@
     "notfound_or_forbidden": "Page originale introuvable ou accès restreint.",
     "already_exists": "Une page avec ce chemin existe déjà.",
     "outdated": "Page obsolète.",
+    "invalid_body": "La requête n'indique pas à quelle révision de la page elle s'applique.",
     "user_not_admin": "Seul un administrateur peut supprimer la page",
     "single_deletion_empty_pages": "Une page vide ne peut pas être supprimée",
     "complete_deletion_not_allowed_for_user": "Vous n'êtes pas autorisé à supprimer cette page"

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -451,6 +451,7 @@
     "notfound_or_forbidden": "元のページが見つからないか、アクセス権がありません。",
     "already_exists": "そのパスを持つページは既に存在しています。",
     "outdated": "ページが他のユーザーによって更新されました。",
+    "invalid_body": "操作対象のページのバージョンがリクエストに含まれていません。",
     "user_not_admin": "権限のあるユーザーのみが削除できます",
     "single_deletion_empty_pages": "空ページの単体削除はできません",
     "complete_deletion_not_allowed_for_user": "ページを完全に削除する権限がありません"

--- a/apps/app/public/static/locales/ko_KR/translation.json
+++ b/apps/app/public/static/locales/ko_KR/translation.json
@@ -388,6 +388,7 @@
     "notfound_or_forbidden": "원본 페이지를 찾을 수 없거나 접근이 금지되었습니다.",
     "already_exists": "경로가 있는 페이지가 이미 존재합니다.",
     "outdated": "페이지가 업데이트되어 현재 오래되었습니다.",
+    "invalid_body": "요청에 대상 페이지의 버전 정보가 포함되어 있지 않습니다.",
     "user_not_admin": "관리자만 삭제할 수 있습니다.",
     "single_deletion_empty_pages": "빈 페이지는 단일 삭제할 수 없습니다.",
     "complete_deletion_not_allowed_for_user": "이 페이지를 완전히 삭제할 권한이 없습니다."

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -409,6 +409,7 @@
     "notfound_or_forbidden": "未找到或禁止原始页。",
     "already_exists": "具有该路径的页面已存在",
     "outdated": "页面已被某人更新，现在已过时。",
+    "invalid_body": "请求中未包含操作对象页面的版本信息。",
     "user_not_admin": "仅管理员用户可以删除",
     "single_deletion_empty_pages": "空的页面不能被单一删除",
     "complete_deletion_not_allowed_for_user": "您无权永久删除该页面"

--- a/apps/app/src/client/components/PageManagement/ApiErrorMessage.jsx
+++ b/apps/app/src/client/components/PageManagement/ApiErrorMessage.jsx
@@ -70,6 +70,23 @@ const ApiErrorMessage = (props) => {
             Invalid path
           </strong>
         );
+      // Raised when the request did not carry the revision the operation applies to.
+      // Reloading is the remedy, as for 'outdated'.
+      case 'invalid_body':
+        return (
+          <>
+            <strong>
+              <span className="material-symbols-outlined me-1">cancel</span>
+              {t('page_api_error.invalid_body')}
+            </strong>
+            <button type="button" className="btn-link" onClick={reload}>
+              <span className="material-symbols-outlined">
+                keyboard_double_arrow_right
+              </span>{' '}
+              {t('Load latest')}
+            </button>
+          </>
+        );
       case 'single_deletion_empty_pages':
         return (
           <strong>
@@ -78,10 +95,12 @@ const ApiErrorMessage = (props) => {
           </strong>
         );
       default:
+        // Show what the server said instead of hiding it: a code this switch does not
+        // know still arrives with a reason, and "Unknown error occured" throws it away.
         return (
           <strong>
             <span className="material-symbols-outlined me-1">cancel</span>{' '}
-            Unknown error occured
+            {errorMessage ?? 'Unknown error occured'}
           </strong>
         );
     }

--- a/apps/app/src/client/components/PageManagement/ApiErrorMessage.spec.jsx
+++ b/apps/app/src/client/components/PageManagement/ApiErrorMessage.spec.jsx
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+
+import { render, screen } from '@testing-library/react';
+
+// Render i18n keys verbatim: the assertions are about which message the component
+// chooses for a given error, not about the wording of the translation.
+vi.mock('next-i18next', () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+    i18n: { language: 'en_US' },
+  }),
+}));
+
+import ApiErrorMessage from './ApiErrorMessage';
+
+describe('ApiErrorMessage', () => {
+  it('explains a missing revision and offers to load the latest', () => {
+    render(
+      <ApiErrorMessage
+        errorCode="invalid_body"
+        errorMessage="revision_id must be a mongoId"
+      />,
+    );
+
+    expect(screen.getByText('page_api_error.invalid_body')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Load latest/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the server's message for a code it does not know", () => {
+    render(
+      <ApiErrorMessage
+        errorCode="exceeded_maximum_number"
+        errorMessage="The maximum number of pages you can select is 20."
+      />,
+    );
+
+    expect(
+      screen.getByText('The maximum number of pages you can select is 20.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Unknown error occured/)).not.toBeInTheDocument();
+  });
+
+  it('falls back to the generic text when an unknown code carries no message', () => {
+    render(<ApiErrorMessage errorCode="some_code_without_message" />);
+
+    expect(screen.getByText(/Unknown error occured/)).toBeInTheDocument();
+  });
+
+  it('keeps rendering the message of a code it knows', () => {
+    render(
+      <ApiErrorMessage
+        errorCode="outdated"
+        errorMessage="Someone could update this page, so couldn't delete."
+      />,
+    );
+
+    expect(screen.getByText('page_api_error.outdated')).toBeInTheDocument();
+    expect(
+      screen.queryByText("Someone could update this page, so couldn't delete."),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/app/src/server/routes/apiv3/pages/delete-pages.integ.ts
+++ b/apps/app/src/server/routes/apiv3/pages/delete-pages.integ.ts
@@ -1,0 +1,257 @@
+/**
+ * Integration test — POST /pages/delete must not soft delete a page whose
+ * revisionId is no longer the latest.
+ *
+ * The route filters the selected pages through `page.isUpdatable(revisionId)`, which
+ * is async: before the fix this test ships with, the bare call returned a truthy
+ * Promise and every page passed the filter, so the conflict was ignored and the page
+ * was deleted anyway.
+ *
+ * Only the conflict case is covered here. It is the case the filter exists for, and
+ * it is answered before `deleteMultiplePages` — which the route fires without
+ * awaiting — is reached, so the test needs no background work to settle. The
+ * successful deletion of a page is covered by service/page/v5.public-page.integ.ts.
+ *
+ * The fixture and cleanup conventions are the ones documented at the top of
+ * rename.integ.ts: `app:isV5Compatible` is pinned and restored, pages are built
+ * through `pageService.create` with the sub operation awaited, everything written
+ * lives under one path prefix, and the response helpers are installed per request on
+ * this suite's own app rather than on the express module's shared response object.
+ */
+
+import { getIdStringForRef, type IUserHasId } from '@growi/core';
+import { ConfigSource } from '@growi/core/dist/interfaces';
+import { escapeStringForMongoRegex } from '@growi/core/dist/utils';
+import type { NextFunction, Request, Response } from 'express';
+import express from 'express';
+import mongoose, { type HydratedDocument, Types } from 'mongoose';
+import request from 'supertest';
+
+import { getInstance } from '^/test/setup/crowi';
+
+import type Crowi from '~/server/crowi';
+import type { PageDocument } from '~/server/models/page';
+import PageOperation from '~/server/models/page-operation';
+import { Revision } from '~/server/models/revision';
+import addCustomFunctionToResponse from '~/server/routes/apiv3/response';
+import { prisma } from '~/utils/prisma';
+
+type AuthenticatedRequest = Request & {
+  user?: HydratedDocument<IUserHasId>;
+};
+
+const passthroughMiddleware = (
+  _req: Request,
+  _res: Response,
+  next: NextFunction,
+) => next();
+
+vi.mock('~/server/middlewares/access-token-parser', () => ({
+  accessTokenParser: () => passthroughMiddleware,
+}));
+
+vi.mock('~/server/middlewares/login-required', () => ({
+  default: () => passthroughMiddleware,
+}));
+
+vi.mock('~/server/middlewares/admin-required', () => ({
+  default: () => passthroughMiddleware,
+}));
+
+const FIXTURE_ROOT = '/delete-pages-route-integ';
+const targetPath = `${FIXTURE_ROOT}/target`;
+
+const requesterUsername = 'delete-pages-route-integ-requester';
+
+// Sentinel ip (reached via X-Forwarded-For) so cleanup removes only the activity rows
+// this suite created. Keep it distinct from the sentinels sibling suites use.
+const TEST_IP = '10.0.0.115';
+
+// A soft delete moves the page under /trash, so cleanup has to match both places.
+const fixturePathPattern = new RegExp(
+  `^(/trash)?${escapeStringForMongoRegex(FIXTURE_ROOT)}(/|$)`,
+);
+
+describe('POST /delete', () => {
+  let app: express.Application;
+  let crowi: Crowi;
+  let requester: HydratedDocument<IUserHasId>;
+  let rootPage: HydratedDocument<PageDocument>;
+  let rootPageWasCreated = false;
+  let rootDescendantCount: number;
+  let isV5CompatibleInDbBefore: boolean | undefined;
+
+  const createPage = async (
+    path: string,
+    body: string,
+  ): Promise<HydratedDocument<PageDocument>> => {
+    const createSubOperationSpy = vi
+      .spyOn(crowi.pageService, 'createSubOperation')
+      .mockResolvedValue();
+
+    const created = await crowi.pageService.create(path, body, requester, {});
+
+    const argsForCreateSubOperation = createSubOperationSpy.mock.calls[0];
+    createSubOperationSpy.mockRestore();
+    await crowi.pageService.createSubOperation(
+      ...(argsForCreateSubOperation as Parameters<
+        typeof crowi.pageService.createSubOperation
+      >),
+    );
+
+    return created;
+  };
+
+  const latestRevisionIdOf = (page: HydratedDocument<PageDocument>): string => {
+    const { revision } = page;
+    if (revision == null) {
+      throw new Error('the fixture page must have a revision');
+    }
+    return getIdStringForRef(revision);
+  };
+
+  /**
+   * The route answers before `deleteMultiplePages` finishes — it is fired without
+   * being awaited — so wait for the page document to reach the deleted state before
+   * asserting on it or cleaning up around it.
+   */
+  const waitForPageToBeDeleted = async (
+    pageId: Types.ObjectId,
+    maxWaitMs = 10_000,
+  ): Promise<HydratedDocument<PageDocument>> => {
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < maxWaitMs) {
+      const page = await crowi.models.Page.findById(pageId);
+      if (page?.status === 'deleted') {
+        return page;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    throw new Error(`page ${pageId} was not deleted within ${maxWaitMs}ms`);
+  };
+
+  const removeFixtures = async (): Promise<void> => {
+    const { Page } = crowi.models;
+
+    const fixturePageIds = (
+      await Page.find({ path: fixturePathPattern }, { _id: 1 })
+    ).map((page) => page._id);
+    await Revision.deleteMany({ pageId: { $in: fixturePageIds } });
+    await Page.deleteMany({ path: fixturePathPattern });
+    await PageOperation.deleteMany({ fromPath: fixturePathPattern });
+    await prisma.activities.deleteMany({ where: { ip: TEST_IP } });
+
+    if (rootDescendantCount != null) {
+      await Page.updateOne(
+        { _id: rootPage._id },
+        { $set: { descendantCount: rootDescendantCount } },
+      );
+    }
+  };
+
+  beforeAll(async () => {
+    crowi = await getInstance();
+    const { Page } = crowi.models;
+    const User = mongoose.model<IUserHasId>('User');
+
+    isV5CompatibleInDbBefore = crowi.configManager.getConfig(
+      'app:isV5Compatible',
+      ConfigSource.db,
+    );
+    await crowi.configManager.updateConfig('app:isV5Compatible', true);
+
+    await User.deleteMany({ username: requesterUsername });
+
+    const existingRootPage = await Page.findOne({ path: '/' });
+    rootPage = existingRootPage ?? (await Page.create({ path: '/', grant: 1 }));
+    rootPageWasCreated = existingRootPage == null;
+
+    requester = await User.create({
+      name: requesterUsername,
+      username: requesterUsername,
+      email: `${requesterUsername}@example.com`,
+    });
+
+    const responseHelpers: { response: Record<string, unknown> } = {
+      response: {},
+    };
+    addCustomFunctionToResponse(responseHelpers);
+
+    app = express();
+    app.set('trust proxy', true);
+    app.use(express.json());
+    app.use((_req, res, next) => {
+      Object.assign(res, responseHelpers.response);
+      next();
+    });
+    app.use((req: AuthenticatedRequest, _res, next) => {
+      req.user = requester;
+      next();
+    });
+
+    const { setup } = await import('./index');
+    app.use('/', setup(crowi));
+
+    await removeFixtures();
+    rootDescendantCount =
+      (await Page.findById(rootPage._id))?.descendantCount ?? 0;
+  }, 120_000);
+
+  afterEach(async () => {
+    await removeFixtures();
+  });
+
+  afterAll(async () => {
+    await removeFixtures();
+    await crowi.models.User.deleteMany({ username: requesterUsername });
+    if (rootPageWasCreated) {
+      await crowi.models.Page.deleteOne({ _id: rootPage._id });
+    }
+    await crowi.configManager.updateConfigs(
+      { 'app:isV5Compatible': isV5CompatibleInDbBefore },
+      { removeIfUndefined: true },
+    );
+  });
+
+  it('keeps a page whose revisionId is not the latest revision', async () => {
+    const page = await createPage(targetPath, 'target body');
+
+    const response = await request(app)
+      .post('/delete')
+      .set('X-Forwarded-For', TEST_IP)
+      .send({
+        pageIdToRevisionIdMap: {
+          [page._id.toString()]: new Types.ObjectId().toString(),
+        },
+      });
+
+    // Every selected page is filtered out, which the route reports as
+    // "No pages can be deleted." — a 500 for what is really a conflict. The status is
+    // asserted as it is today; a fix that reports 409 instead should update this.
+    expect(response.status).toBe(500);
+
+    const survivingPage = await crowi.models.Page.findById(page._id);
+    expect(survivingPage?.path).toBe(targetPath);
+    expect(survivingPage?.status).toBe('published');
+  });
+
+  it('deletes a page whose revisionId is the latest revision', async () => {
+    const page = await createPage(targetPath, 'target body');
+
+    const response = await request(app)
+      .post('/delete')
+      .set('X-Forwarded-For', TEST_IP)
+      .send({
+        pageIdToRevisionIdMap: {
+          [page._id.toString()]: latestRevisionIdOf(page),
+        },
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.paths).toEqual([targetPath]);
+
+    // Without this case, filtering every page out unconditionally would also pass.
+    const deletedPage = await waitForPageToBeDeleted(page._id);
+    expect(deletedPage.path).toBe(`/trash${targetPath}`);
+  });
+});

--- a/apps/app/src/server/routes/apiv3/pages/delete-pages.integ.ts
+++ b/apps/app/src/server/routes/apiv3/pages/delete-pages.integ.ts
@@ -32,7 +32,6 @@ import { getInstance } from '^/test/setup/crowi';
 import type Crowi from '~/server/crowi';
 import type { PageDocument } from '~/server/models/page';
 import PageOperation from '~/server/models/page-operation';
-import { Revision } from '~/server/models/revision';
 import addCustomFunctionToResponse from '~/server/routes/apiv3/response';
 import { prisma } from '~/utils/prisma';
 
@@ -135,8 +134,10 @@ describe('POST /delete', () => {
 
     const fixturePageIds = (
       await Page.find({ path: fixturePathPattern }, { _id: 1 })
-    ).map((page) => page._id);
-    await Revision.deleteMany({ pageId: { $in: fixturePageIds } });
+    ).map((page) => page._id.toString());
+    await prisma.revisions.deleteMany({
+      where: { pageId: { in: fixturePageIds } },
+    });
     await Page.deleteMany({ path: fixturePathPattern });
     await PageOperation.deleteMany({ fromPath: fixturePathPattern });
     await prisma.activities.deleteMany({ where: { ip: TEST_IP } });

--- a/apps/app/src/server/routes/apiv3/pages/index.js
+++ b/apps/app/src/server/routes/apiv3/pages/index.js
@@ -1056,9 +1056,33 @@ export const setup = (crowi) => {
             isRecursively,
           );
       } else {
+        // isUpdatable is async, so it has to be awaited before the result is used as
+        // a predicate: a bare call returns a Promise, which is always truthy, and
+        // kept every page regardless of whether its revision is still the latest.
+        // Resolved up front rather than inside the filter, which cannot await.
+        let isUpdatableFlags;
+        try {
+          isUpdatableFlags = await Promise.all(
+            pagesToDelete.map((p) =>
+              // an empty page has no revision to compare
+              p.isEmpty
+                ? true
+                : p.isUpdatable(pageIdToRevisionIdMap[p._id].toString()),
+            ),
+          );
+        } catch (err) {
+          logger.error(
+            'Failed to check whether the pages to delete are up to date.',
+            err,
+          );
+          return res.apiv3Err(
+            new ErrorV3('Failed to find pages to delete.'),
+            500,
+          );
+        }
+
         const filteredPages = pagesToDelete.filter(
-          (p) =>
-            p.isEmpty || p.isUpdatable(pageIdToRevisionIdMap[p._id].toString()),
+          (_p, index) => isUpdatableFlags[index],
         );
         pagesCanBeDeleted = await crowi.pageService.filterPagesByCanDelete(
           filteredPages,

--- a/apps/app/src/server/routes/page-remove.integ.ts
+++ b/apps/app/src/server/routes/page-remove.integ.ts
@@ -1,0 +1,224 @@
+/**
+ * Integration test — POST /_api/pages.remove must not soft delete a non-empty page
+ * unless the caller says which revision it saw, and that revision is still the latest.
+ *
+ * The handler checks this through `page.isUpdatable(revision_id)`, which is async:
+ * before the fix this test ships with, the bare call returned a truthy Promise, `!` of
+ * it was always false, and the page was deleted whatever `revision_id` said — or did
+ * not say.
+ *
+ * The two refusals are deliberately separate. A missing `revision_id` is answered with
+ * `invalid_body` before `isUpdatable` is consulted, because `isUpdatable` cannot tell
+ * "you did not tell me" apart from "what you told me is stale" and would report the
+ * latter. This mirrors apiv3 PUT /pages/rename.
+ *
+ * apiv1 reports failures as HTTP 200 with `ok: false` and a `code`, so these cases
+ * assert on the body rather than on the status.
+ *
+ * Fixture and cleanup conventions follow apiv3/pages/rename.integ.ts: `app:isV5Compatible`
+ * is pinned and restored, pages are built through `pageService.create` with the sub
+ * operation awaited, and everything written lives under one path prefix — which for a
+ * soft delete has to include the /trash copy.
+ */
+
+import { getIdStringForRef, type IUserHasId } from '@growi/core';
+import { ConfigSource } from '@growi/core/dist/interfaces';
+import { escapeStringForMongoRegex } from '@growi/core/dist/utils';
+import type { Request } from 'express';
+import express from 'express';
+import mongoose, { type HydratedDocument, Types } from 'mongoose';
+import request from 'supertest';
+
+import { getInstance } from '^/test/setup/crowi';
+
+import type Crowi from '~/server/crowi';
+import type { PageDocument } from '~/server/models/page';
+import PageOperation from '~/server/models/page-operation';
+import { Revision } from '~/server/models/revision';
+import { prisma } from '~/utils/prisma';
+
+type AuthenticatedRequest = Request & {
+  user?: HydratedDocument<IUserHasId>;
+};
+
+const FIXTURE_ROOT = '/page-remove-route-integ';
+const targetPath = `${FIXTURE_ROOT}/target`;
+
+const requesterUsername = 'page-remove-route-integ-requester';
+
+// Sentinel ip (reached via X-Forwarded-For) so cleanup removes only the activity rows
+// this suite created. Keep it distinct from the sentinels sibling suites use.
+const TEST_IP = '10.0.0.116';
+
+// A soft delete moves the page under /trash, so cleanup has to match both places.
+const fixturePathPattern = new RegExp(
+  `^(/trash)?${escapeStringForMongoRegex(FIXTURE_ROOT)}(/|$)`,
+);
+
+describe('POST /pages.remove', () => {
+  let app: express.Application;
+  let crowi: Crowi;
+  let requester: HydratedDocument<IUserHasId>;
+  let rootPage: HydratedDocument<PageDocument>;
+  let rootPageWasCreated = false;
+  let rootDescendantCount: number;
+  let isV5CompatibleInDbBefore: boolean | undefined;
+
+  const createPage = async (
+    path: string,
+    body: string,
+  ): Promise<HydratedDocument<PageDocument>> => {
+    const createSubOperationSpy = vi
+      .spyOn(crowi.pageService, 'createSubOperation')
+      .mockResolvedValue();
+
+    const created = await crowi.pageService.create(path, body, requester, {});
+
+    const argsForCreateSubOperation = createSubOperationSpy.mock.calls[0];
+    createSubOperationSpy.mockRestore();
+    await crowi.pageService.createSubOperation(
+      ...(argsForCreateSubOperation as Parameters<
+        typeof crowi.pageService.createSubOperation
+      >),
+    );
+
+    return created;
+  };
+
+  const latestRevisionIdOf = (page: HydratedDocument<PageDocument>): string => {
+    const { revision } = page;
+    if (revision == null) {
+      throw new Error('the fixture page must have a revision');
+    }
+    return getIdStringForRef(revision);
+  };
+
+  const removeFixtures = async (): Promise<void> => {
+    const { Page } = crowi.models;
+
+    const fixturePageIds = (
+      await Page.find({ path: fixturePathPattern }, { _id: 1 })
+    ).map((page) => page._id);
+    await Revision.deleteMany({ pageId: { $in: fixturePageIds } });
+    await Page.deleteMany({ path: fixturePathPattern });
+    await PageOperation.deleteMany({ fromPath: fixturePathPattern });
+    await prisma.activities.deleteMany({ where: { ip: TEST_IP } });
+
+    if (rootDescendantCount != null) {
+      await Page.updateOne(
+        { _id: rootPage._id },
+        { $set: { descendantCount: rootDescendantCount } },
+      );
+    }
+  };
+
+  beforeAll(async () => {
+    crowi = await getInstance();
+    const { Page } = crowi.models;
+    const User = mongoose.model<IUserHasId>('User');
+
+    isV5CompatibleInDbBefore = crowi.configManager.getConfig(
+      'app:isV5Compatible',
+      ConfigSource.db,
+    );
+    await crowi.configManager.updateConfig('app:isV5Compatible', true);
+
+    await User.deleteMany({ username: requesterUsername });
+
+    const existingRootPage = await Page.findOne({ path: '/' });
+    rootPage = existingRootPage ?? (await Page.create({ path: '/', grant: 1 }));
+    rootPageWasCreated = existingRootPage == null;
+
+    requester = await User.create({
+      name: requesterUsername,
+      username: requesterUsername,
+      email: `${requesterUsername}@example.com`,
+    });
+
+    app = express();
+    app.set('trust proxy', true);
+    app.use(express.json());
+    app.use((req: AuthenticatedRequest, _res, next) => {
+      req.user = requester;
+      next();
+    });
+
+    // The terminal handler only, without the auth chain and the body validators the
+    // real mount puts in front of it — none of them touch revision_id.
+    const { setup } = await import('./page');
+    const actions = setup(crowi, app);
+    app.post('/pages.remove', actions.api.remove);
+
+    await removeFixtures();
+    rootDescendantCount =
+      (await Page.findById(rootPage._id))?.descendantCount ?? 0;
+  }, 120_000);
+
+  afterEach(async () => {
+    await removeFixtures();
+  });
+
+  afterAll(async () => {
+    await removeFixtures();
+    await crowi.models.User.deleteMany({ username: requesterUsername });
+    if (rootPageWasCreated) {
+      await crowi.models.Page.deleteOne({ _id: rootPage._id });
+    }
+    await crowi.configManager.updateConfigs(
+      { 'app:isV5Compatible': isV5CompatibleInDbBefore },
+      { removeIfUndefined: true },
+    );
+  });
+
+  it('refuses a non-empty page sent without revision_id', async () => {
+    const page = await createPage(targetPath, 'target body');
+
+    const response = await request(app)
+      .post('/pages.remove')
+      .set('X-Forwarded-For', TEST_IP)
+      .send({ page_id: page._id.toString() });
+
+    expect(response.body).toMatchObject({ ok: false, code: 'invalid_body' });
+
+    const survivingPage = await crowi.models.Page.findById(page._id);
+    expect(survivingPage?.path).toBe(targetPath);
+    expect(survivingPage?.status).toBe('published');
+  });
+
+  it('refuses a revision_id that is not the latest revision', async () => {
+    const page = await createPage(targetPath, 'target body');
+
+    const response = await request(app)
+      .post('/pages.remove')
+      .set('X-Forwarded-For', TEST_IP)
+      .send({
+        page_id: page._id.toString(),
+        revision_id: new Types.ObjectId().toString(),
+      });
+
+    expect(response.body).toMatchObject({ ok: false, code: 'outdated' });
+
+    const survivingPage = await crowi.models.Page.findById(page._id);
+    expect(survivingPage?.path).toBe(targetPath);
+    expect(survivingPage?.status).toBe('published');
+  });
+
+  it('deletes a page whose revision_id is the latest revision', async () => {
+    const page = await createPage(targetPath, 'target body');
+
+    const response = await request(app)
+      .post('/pages.remove')
+      .set('X-Forwarded-For', TEST_IP)
+      .send({
+        page_id: page._id.toString(),
+        revision_id: latestRevisionIdOf(page),
+      });
+
+    // Without this case, refusing every request would also pass the two above.
+    expect(response.body).toMatchObject({ ok: true, path: targetPath });
+
+    const deletedPage = await crowi.models.Page.findById(page._id);
+    expect(deletedPage?.path).toBe(`/trash${targetPath}`);
+    expect(deletedPage?.status).toBe('deleted');
+  });
+});

--- a/apps/app/src/server/routes/page-remove.integ.ts
+++ b/apps/app/src/server/routes/page-remove.integ.ts
@@ -34,7 +34,6 @@ import { getInstance } from '^/test/setup/crowi';
 import type Crowi from '~/server/crowi';
 import type { PageDocument } from '~/server/models/page';
 import PageOperation from '~/server/models/page-operation';
-import { Revision } from '~/server/models/revision';
 import { prisma } from '~/utils/prisma';
 
 type AuthenticatedRequest = Request & {
@@ -98,8 +97,10 @@ describe('POST /pages.remove', () => {
 
     const fixturePageIds = (
       await Page.find({ path: fixturePathPattern }, { _id: 1 })
-    ).map((page) => page._id);
-    await Revision.deleteMany({ pageId: { $in: fixturePageIds } });
+    ).map((page) => page._id.toString());
+    await prisma.revisions.deleteMany({
+      where: { pageId: { in: fixturePageIds } },
+    });
     await Page.deleteMany({ path: fixturePathPattern });
     await PageOperation.deleteMany({ fromPath: fixturePathPattern });
     await prisma.activities.deleteMany({ where: { ip: TEST_IP } });

--- a/apps/app/src/server/routes/page.js
+++ b/apps/app/src/server/routes/page.js
@@ -305,7 +305,7 @@ export const setup = (crowi, _app) => {
    *               revision_id:
    *                 type: string
    *                 format: ObjectId
-   *                 description: Revision ID for conflict detection. Required to soft delete a non-empty page — the request is rejected with 'outdated' unless it is the page's latest revision. Not consulted when completely is true, or for an empty page.
+   *                 description: Revision ID for conflict detection. Required to soft delete a non-empty page — omitting it is rejected with 'invalid_body', and a value that is not the page's latest revision is rejected with 'outdated'. Not consulted when completely is true, or for an empty page.
    *                 example: "507f1f77bcf86cd799439012"
    *               completely:
    *                 type: boolean
@@ -435,6 +435,16 @@ export const setup = (crowi, _app) => {
         if (notRecursivelyAndEmpty) {
           return res.json(
             ApiResponse.error(`Page '${pageId}' is not found.`, 'notfound'),
+          );
+        }
+
+        // A missing revision_id is answered on its own rather than through
+        // isUpdatable, which cannot tell it apart from a stale one and would report
+        // that someone else had updated the page. Same split as
+        // apiv3 PUT /pages/rename, which pairs this code with its own conflict check.
+        if (!page.isEmpty && previousRevision == null) {
+          return res.json(
+            ApiResponse.error('revision_id must be a mongoId', 'invalid_body'),
           );
         }
 

--- a/apps/app/src/server/routes/page.js
+++ b/apps/app/src/server/routes/page.js
@@ -305,7 +305,7 @@ export const setup = (crowi, _app) => {
    *               revision_id:
    *                 type: string
    *                 format: ObjectId
-   *                 description: Revision ID for conflict detection
+   *                 description: Revision ID for conflict detection. Required to soft delete a non-empty page — the request is rejected with 'outdated' unless it is the page's latest revision. Not consulted when completely is true, or for an empty page.
    *                 example: "507f1f77bcf86cd799439012"
    *               completely:
    *                 type: boolean
@@ -327,6 +327,7 @@ export const setup = (crowi, _app) => {
    *               summary: Recursive soft delete
    *               value:
    *                 page_id: "507f1f77bcf86cd799439011"
+   *                 revision_id: "507f1f77bcf86cd799439012"
    *                 recursively: true
    *             completeDelete:
    *               summary: Complete deletion
@@ -437,7 +438,9 @@ export const setup = (crowi, _app) => {
           );
         }
 
-        if (!page.isEmpty && !page.isUpdatable(previousRevision)) {
+        // isUpdatable is async: without the await the negation is always false and
+        // this conflict check never fires
+        if (!page.isEmpty && !(await page.isUpdatable(previousRevision))) {
           return res.json(
             ApiResponse.error(
               "Someone could update this page, so couldn't delete.",


### PR DESCRIPTION
#11680 で見つかった `page.isUpdatable()` の await 漏れのうち、残っていた2箇所を直します。#11680 とは別のエンドポイントなので独立した PR です（同じファイルの別の箇所を触るので、どちらの順にマージしても競合しません）。

## 何が起きていたか

`page.isUpdatable()` は async です（`models/obsolete-page.js`。`populate('revision','origin')` を待つ必要があるため）。それを await せずに使うと、

- `!page.isUpdatable(revisionId)` は Promise を否定するので常に false
- `.filter(p => p.isEmpty || p.isUpdatable(...))` は常に全件を通す

となり、**「他の人がこのページを更新している」という競合検知が一度も働いていませんでした**。

`isUpdatable` が async になった e32195d0（2024-03-02）以降ずっとです。そのコミットはモデル1ファイルだけを変更し、呼び出し側を1つも直していません。以降 await していた呼び出し元は `routes/apiv3/page/update-page.ts` の1つだけでした。導入時期は apiv3 の削除が 2022-02-08、apiv1 は monorepo 化以前なので、**約2年4か月のあいだ無効だった**ことになります。

## 1. `POST /_api/v3/pages/delete`（複数ページのごみ箱移動）

クライアントから受け取った `pageIdToRevisionIdMap` で各ページの revision を照合し、古いものを対象から外すつもりの `filter` が、実際には何も外していませんでした。**クライアントが見ていた revision が既に古くても、そのままごみ箱に移動されていました。**

`Array#filter` は await できないので、先に `Promise.all` で判定結果を作り、filter は添字で読むようにしています。`p.isEmpty` の短絡は維持しました（空ページには比較する revision が無く、`pageIdToRevisionIdMap` を引くのは空でないページだけ）。

await するようになったことで、これまで黙って捨てられていた2つの失敗が到達可能になるので try/catch で囲んでいます。`isUpdatable` の中の populate が失敗する場合（revision が欠けたページ）と、`pageIdToRevisionIdMap` の値が null の場合です。囲まないとリクエストが応答を返さないまま止まります（同期例外が async ハンドラの外へ出て Express 4 が拾わない）。

| 送り方 | 修正前 | 修正後 |
|---|---|---|
| 対応表そのものが無い | 400（validator の `.exists()`） | 同じ |
| 対応表が空 `{}` | 400 `Select pages to delete.` | 同じ |
| 値が最新と一致 | ごみ箱へ移動（200） | 同じ |
| 値が最新と不一致 | **ごみ箱へ移動**（競合を見逃す） | **対象から外れる**。全部外れれば `500 No pages can be deleted.` |
| 値が `null` | **応答が返らないまま止まる** | 500 `Failed to find pages to delete.` |

対象ページは `Object.keys(対応表)` から引くので、対応表にキーが無いページが対象に入ることはありません。つまりこのエンドポイントには「revision_id を送らない」に相当する経路がありません。

なお、対象が全部外れたときの応答は既存どおり `500 No pages can be deleted.` です。競合を 500 で返すのは適切ではないので 409 にする改善は考えられますが、契約が変わるのでこの PR では触らず、テストには現状のステータスを記録しています。

## 2. `POST /_api/pages.remove`（単一ページのごみ箱移動、apiv1）

同じ形です。この呼び出しはハンドラの try/catch の中にあるので、await を足す以外の変更は要りません。

加えて、**`revision_id` が無いケースを `isUpdatable` に渡す前に切り出しました。** `previousRevision` は `req.body.revision_id || null` なので、送られてこないと null になり、null はどの revision とも一致しません。つまり `isUpdatable` は「送られてこなかった」と「送られてきたが古い」を区別できず、どちらも `outdated`（他の人が更新した）と報告してしまいます。前者は apiv3 `PUT /pages/rename` が既に使っているコード（`invalid_body` / `revisionId must be a mongoId`）で答えるようにしました。rename も同じ2つの検査を同じ順に持っているので、これで削除2本とリネームが同じ状況を同じ形で報告します。

空でないページのごみ箱移動の場合。

| revision_id | 修正前 | 修正後 |
|---|---|---|
| 送る・最新と一致 | ごみ箱へ移動 | 同じ |
| 送る・最新と不一致 | **ごみ箱へ移動**（競合を見逃す） | **`outdated` で拒否** |
| 送らない | **ごみ箱へ移動** | **`invalid_body` で拒否** |

`completely: true` のときは別の分岐（完全削除）に入るので revision は見ません。空ページも `!page.isEmpty` で飛ばされます。apiv1 の「拒否」は HTTP 200 のまま本文が `{ ok: false, code, error }` になる形式です。

アプリ内の呼び出し元はすべて id 文字列を送っているので UI への影響はありません。確認した経路: `PageDeleteModal` が受け取る `revision` は、ページ表示からは `PageControls` 経由で `revision._id`、ページツリーと検索結果からは `getIdStringForRef(page.revision)`、ごみ箱の警告表示からは `pageData?.revision?._id` です。

swagger の `revision_id` の説明と例も直しました（`recursiveDelete` の例が `revision_id` を省いていて、この変更後は拒否される内容だったため）。

## 3. エラーの理由が画面に出るようにする

`invalid_body` は `client/components/PageManagement/ApiErrorMessage.jsx` の switch に無く、画面には "Unknown error occured" と出るだけでした。これは同じコードを既に返している apiv3 rename の分岐も同様です。あわせて直しました。

- `invalid_body` に専用のメッセージを追加しました。「どのバージョンに対する操作かがリクエストに含まれていない」という状況なので、`outdated` と同じ「最新版を読み込む」ボタンを添えています（再読み込みが解決手段になるため）。
- **switch が知らないコードは、サーバーが送ってきたメッセージを表示する**ようにしました。メッセージが無い場合だけ従来の文言に落ちます。これまでは `Apiv1ErrorHandler` と ErrorV3 のどちらも理由を持っているのに、それを捨てて "Unknown error occured" と表示していました。現状ここに落ちているコードには `exceeded_maximum_number`（"The maximum number of pages you can select is 20."）、`no_page_selected`、`not_single_page`、`notfound` があります。

翻訳は 5 ロケール（en_US / ja_JP / zh_CN / fr_FR / ko_KR）すべてに追加しました。各言語の文言は、そのロケールの `page_history.revision` が既に使っている語（版本 / Révision / 버전）に合わせています。

コンポーネントのテスト（`ApiErrorMessage.spec.jsx`）も追加しました。修正前の状態では該当2件が赤になることを確認しています。

## 検証

devcontainer の MongoDB を明示指定して実測しています。

- 新規 `apiv3/pages/delete-pages.integ.ts` → 2 passed。修正を戻すと競合のテストが赤（`expected 200 to be 500`）。
- 新規 `routes/page-remove.integ.ts`（このエンドポイントには従来テストがありませんでした）→ 3 passed。修正前の状態では 2つの拒否のテストがどちらも赤（どちらの場合もページが削除される）。3つ目に「最新 revision を送れば通る」を入れてあるので、全部拒否する実装では通りません。
- 既存の `delete-completely-cascade-activity.integ` / `attachment-removal-snapshot.spec` / `rename.integ` を通して 19 passed。
- `pnpm run lint:typecheck` / `lint:biome` / `lint:route-guard` 通過。
- 新規 `ApiErrorMessage.spec.jsx` → 4 passed。コンポーネントの変更を戻すと2件が赤。
- `pnpm run lint:openapi:apiv1`（仕様の生成と検証）通過。

Refs #11680

🤖 Generated with [Claude Code](https://claude.com/claude-code)
