### PR TITLE
fix: Links to pages with non-ASCII paths reload the whole document

### DIFF
--- a/apps/app/playwright/20-basic-features/page-link-transition.spec.ts
+++ b/apps/app/playwright/20-basic-features/page-link-transition.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from '@playwright/test';
+
+import {
+  type CreatedPage,
+  createPage,
+  deletePagesCompletely,
+} from '../utils/api/create-page';
+
+/**
+ * Links to pages whose path holds non-ASCII characters used to fall back to a
+ * browser transition, because the renderer percent-encodes the href and the
+ * routing decision was made against the encoded form. Nothing else in the
+ * e2e suite exercises a non-ASCII page path.
+ */
+const ROOT = '/PageLinkTransition';
+const ASCII_CHILD = 'AsciiChild';
+const NON_ASCII_CHILD = '日本語ページ';
+const ASCII_BODY = 'body of the ascii child';
+const NON_ASCII_BODY = 'body of the non-ascii child';
+
+const created: CreatedPage[] = [];
+
+test.beforeAll(async ({ browser }) => {
+  const ctx = await browser.newContext({
+    storageState: 'playwright/.auth/admin.json',
+  });
+  const { request } = ctx;
+
+  created.push(
+    await createPage(request, {
+      path: `${ROOT}/${ASCII_CHILD}`,
+      body: ASCII_BODY,
+    }),
+  );
+  created.push(
+    await createPage(request, {
+      path: `${ROOT}/${NON_ASCII_CHILD}`,
+      body: NON_ASCII_BODY,
+    }),
+  );
+  created.push(
+    await createPage(request, {
+      path: ROOT,
+      body: [
+        `- [[${ASCII_CHILD}]]`,
+        `- [[${NON_ASCII_CHILD}]]`,
+        `- [markdown-ascii](${ROOT}/${ASCII_CHILD})`,
+        `- [markdown-non-ascii](${ROOT}/${NON_ASCII_CHILD})`,
+      ].join('\n'),
+    }),
+  );
+
+  await ctx.close();
+});
+
+test.afterAll(async ({ browser }) => {
+  const ctx = await browser.newContext({
+    storageState: 'playwright/.auth/admin.json',
+  });
+  await deletePagesCompletely(ctx.request, created.slice().reverse());
+  await ctx.close();
+});
+
+test('Links in a page body reach their target without reloading the document', async ({
+  page,
+}) => {
+  for (const [linkText, expectedBody] of [
+    [ASCII_CHILD, ASCII_BODY],
+    [NON_ASCII_CHILD, NON_ASCII_BODY],
+    ['markdown-ascii', ASCII_BODY],
+    ['markdown-non-ascii', NON_ASCII_BODY],
+  ] as const) {
+    await page.goto(ROOT);
+    const link = page.locator('.wiki a', { hasText: linkText }).first();
+    await link.waitFor();
+
+    // a browser transition builds a new document and drops this mark;
+    // a client-side transition keeps the document, and the mark with it
+    await page.evaluate(() => {
+      document.documentElement.dataset.transitionProbe = 'kept';
+    });
+
+    await link.click();
+    await expect(page.locator('.wiki')).toContainText(expectedBody);
+
+    const probe = await page.evaluate(
+      () => document.documentElement.dataset.transitionProbe,
+    );
+    // soft so that every link is reported, not just the first broken one
+    expect
+      .soft(probe, `"${linkText}" must not reload the document`)
+      .toBe('kept');
+  }
+});

--- a/apps/app/src/components/ReactMarkdownComponents/NextLink.spec.tsx
+++ b/apps/app/src/components/ReactMarkdownComponents/NextLink.spec.tsx
@@ -23,12 +23,31 @@ vi.mock('next/link', () => ({
   ),
 }));
 
-vi.mock('~/states/global', () => ({
-  useSiteUrl: () => 'https://wiki.example.com',
+const mocks = vi.hoisted(() => ({
+  siteUrl: 'https://wiki.example.com' as string | undefined,
 }));
 
-const renderLink = (href: string) => {
-  const { container } = render(<NextLink href={href}>link text</NextLink>);
+vi.mock('~/states/global', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('~/states/global')>()),
+  useSiteUrl: () => mocks.siteUrl,
+}));
+
+beforeEach(() => {
+  mocks.siteUrl = 'https://wiki.example.com';
+});
+
+const renderLink = (
+  href: string,
+  props: Record<string, unknown> = {},
+): {
+  isClientSideTransition: boolean;
+  anchor: HTMLAnchorElement | null;
+} => {
+  const { container } = render(
+    <NextLink href={href} {...props}>
+      link text
+    </NextLink>,
+  );
   const anchor = container.querySelector('a');
   return {
     /** true when the link performs a client-side transition */
@@ -46,8 +65,13 @@ describe('NextLink', () => {
       ${'/Sandbox/%E3%83%9A%E3%83%BC%E3%82%B8%20%E5%90%8D'}   | ${'percent-encoded path containing a space'}
       ${'/Sandbox/%E6%97%A5%E6%9C%AC%E8%AA%9E?q=foo#heading'} | ${'percent-encoded path with query and hash'}
       ${'/Sandbox/日本語'}                                    | ${'non-ASCII page path written literally'}
+      ${'/Sandbox/mail%40example'}                            | ${'percent-encoded reserved character'}
+      ${'/Sandbox/a%2Fb'}                                     | ${'percent-encoded path separator'}
     `('routes $pathDescription through next/link', ({ href }) => {
-      expect(renderLink(href).isClientSideTransition).toBe(true);
+      const { isClientSideTransition, anchor } = renderLink(href);
+      expect(isClientSideTransition).toBe(true);
+      // the destination must survive the branch untouched -- query and hash included
+      expect(anchor?.getAttribute('href')).toBe(href);
     });
   });
 
@@ -61,12 +85,38 @@ describe('NextLink', () => {
       ${'/Sandbox/Bootstrap5.md'}            | ${'path reserved for the markdown endpoint'}
       ${'/%E6%97%A5%E6%9C%AC%E8%AA%9E.md'}   | ${'reserved suffix hidden behind percent-encoding'}
       ${'/user/%E6%97%A5%E6%9C%AC%E8%AA%9E'} | ${'user homepage root hidden behind percent-encoding'}
+      ${'/%61ttachment/653a1f1b'}            | ${'reserved prefix hidden behind percent-encoding'}
       ${'/Sandbox/broken%ZZ'}                | ${'malformed percent-encoding'}
       ${'/Sandbox/50%25off'}                 | ${'literal percent sign in the path'}
     `('keeps $reason on a plain anchor', ({ href }) => {
       const { isClientSideTransition, anchor } = renderLink(href);
       expect(isClientSideTransition).toBe(false);
       expect(anchor?.getAttribute('href')).toBe(href);
+    });
+
+    it('honours an explicit target on an otherwise routable path', () => {
+      const { isClientSideTransition, anchor } = renderLink('/Sandbox/日本語', {
+        target: '_self',
+      });
+      expect(isClientSideTransition).toBe(false);
+      expect(anchor?.getAttribute('target')).toBe('_self');
+    });
+  });
+
+  describe('attributes carried across the branch boundary', () => {
+    // The routable/non-routable branches render different elements, so a link
+    // must not lose attributes just because its path became routable.
+    it.each`
+      href                    | branch
+      ${'/Sandbox/日本語'}    | ${'client-side transition'}
+      ${'/Sandbox/日本語.md'} | ${'plain anchor'}
+    `('keeps id and data-* on the $branch branch', ({ href }) => {
+      const { anchor } = renderLink(href, {
+        id: 'my-anchor',
+        'data-tracking': 'x',
+      });
+      expect(anchor?.getAttribute('id')).toBe('my-anchor');
+      expect(anchor?.getAttribute('data-tracking')).toBe('x');
     });
   });
 
@@ -78,6 +128,27 @@ describe('NextLink', () => {
       expect(isClientSideTransition).toBe(false);
       expect(anchor?.getAttribute('target')).toBe('_blank');
       expect(anchor?.getAttribute('rel')).toBe('noopener noreferrer');
+    });
+
+    it('treats an absolute URL on the site host as an internal link', () => {
+      const { isClientSideTransition } = renderLink(
+        'https://wiki.example.com/Sandbox/日本語',
+      );
+      expect(isClientSideTransition).toBe(true);
+    });
+
+    it('falls back to a new tab for an absolute URL when the site url is unset', () => {
+      mocks.siteUrl = undefined;
+      const { isClientSideTransition, anchor } = renderLink(
+        'https://wiki.example.com/Sandbox/日本語',
+      );
+      expect(isClientSideTransition).toBe(false);
+      expect(anchor?.getAttribute('target')).toBe('_blank');
+    });
+
+    it('still routes a root-relative path when the site url is unset', () => {
+      mocks.siteUrl = undefined;
+      expect(renderLink('/Sandbox/日本語').isClientSideTransition).toBe(true);
     });
   });
 });

--- a/apps/app/src/components/ReactMarkdownComponents/NextLink.spec.tsx
+++ b/apps/app/src/components/ReactMarkdownComponents/NextLink.spec.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from 'react';
+import { render } from '@testing-library/react';
+
+import { NextLink } from './NextLink';
+
+// next/link reaches for the Pages-Router context, which is absent under test.
+// Render a marked anchor instead: whether a link goes through next/link is
+// exactly the contract under test (client-side transition vs. browser reload).
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    prefetch: _prefetch,
+    ...props
+  }: {
+    href: string;
+    children: ReactNode;
+    prefetch?: boolean;
+  }) => (
+    <a data-testid="next-link" href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('~/states/global', () => ({
+  useSiteUrl: () => 'https://wiki.example.com',
+}));
+
+const renderLink = (href: string) => {
+  const { container } = render(<NextLink href={href}>link text</NextLink>);
+  const anchor = container.querySelector('a');
+  return {
+    /** true when the link performs a client-side transition */
+    isClientSideTransition: anchor?.dataset.testid === 'next-link',
+    anchor,
+  };
+};
+
+describe('NextLink', () => {
+  describe('links that must transition client-side', () => {
+    it.each`
+      href                                                    | pathDescription
+      ${'/Sandbox/Bootstrap5'}                                | ${'ASCII page path'}
+      ${'/Sandbox/%E6%97%A5%E6%9C%AC%E8%AA%9E'}               | ${'percent-encoded non-ASCII page path'}
+      ${'/Sandbox/%E3%83%9A%E3%83%BC%E3%82%B8%20%E5%90%8D'}   | ${'percent-encoded path containing a space'}
+      ${'/Sandbox/%E6%97%A5%E6%9C%AC%E8%AA%9E?q=foo#heading'} | ${'percent-encoded path with query and hash'}
+      ${'/Sandbox/日本語'}                                    | ${'non-ASCII page path written literally'}
+    `('routes $pathDescription through next/link', ({ href }) => {
+      expect(renderLink(href).isClientSideTransition).toBe(true);
+    });
+  });
+
+  describe('links that must NOT transition client-side', () => {
+    it.each`
+      href                                   | reason
+      ${'#heading'}                          | ${'in-page anchor'}
+      ${'/attachment/653a1f1b'}              | ${'path served outside the page router'}
+      ${'/user/admin'}                       | ${'user homepage root'}
+      ${'/Sandbox/Bootstrap5/edit'}          | ${'path reserved by the editor'}
+      ${'/Sandbox/Bootstrap5.md'}            | ${'path reserved for the markdown endpoint'}
+      ${'/%E6%97%A5%E6%9C%AC%E8%AA%9E.md'}   | ${'reserved suffix hidden behind percent-encoding'}
+      ${'/user/%E6%97%A5%E6%9C%AC%E8%AA%9E'} | ${'user homepage root hidden behind percent-encoding'}
+      ${'/Sandbox/broken%ZZ'}                | ${'malformed percent-encoding'}
+      ${'/Sandbox/50%25off'}                 | ${'literal percent sign in the path'}
+    `('keeps $reason on a plain anchor', ({ href }) => {
+      const { isClientSideTransition, anchor } = renderLink(href);
+      expect(isClientSideTransition).toBe(false);
+      expect(anchor?.getAttribute('href')).toBe(href);
+    });
+  });
+
+  describe('external links', () => {
+    it('opens a link to another host in a new tab', () => {
+      const { isClientSideTransition, anchor } = renderLink(
+        'https://example.com/foo',
+      );
+      expect(isClientSideTransition).toBe(false);
+      expect(anchor?.getAttribute('target')).toBe('_blank');
+      expect(anchor?.getAttribute('rel')).toBe('noopener noreferrer');
+    });
+  });
+});

--- a/apps/app/src/components/ReactMarkdownComponents/NextLink.tsx
+++ b/apps/app/src/components/ReactMarkdownComponents/NextLink.tsx
@@ -27,8 +27,9 @@ const isCreatablePage = (href: string) => {
   try {
     const url = new URL(href, 'http://example.com');
     // URL.pathname is percent-encoded, and '%' itself is one of the characters
-    // isCreatablePage() forbids -- so every path holding a non-ASCII character
-    // or a space would be judged non-creatable unless it is decoded back first.
+    // pagePathUtils.isCreatablePage() forbids -- so every path holding a
+    // non-ASCII character or a space would be judged non-creatable unless it is
+    // decoded back first. Same treatment as getServerSideCommonProps().
     const pathName = decodeURIComponent(url.pathname);
     return pagePathUtils.isCreatablePage(pathName);
   } catch (err) {
@@ -101,6 +102,7 @@ export const NextLink = (props: Props): JSX.Element => {
   return (
     <Link
       {...rest}
+      id={id}
       href={href}
       prefetch={false}
       className={className}

--- a/apps/app/src/components/ReactMarkdownComponents/NextLink.tsx
+++ b/apps/app/src/components/ReactMarkdownComponents/NextLink.tsx
@@ -26,7 +26,10 @@ const isExternalLink = (href: string, siteUrl: string | undefined): boolean => {
 const isCreatablePage = (href: string) => {
   try {
     const url = new URL(href, 'http://example.com');
-    const pathName = url.pathname;
+    // URL.pathname is percent-encoded, and '%' itself is one of the characters
+    // isCreatablePage() forbids -- so every path holding a non-ASCII character
+    // or a space would be judged non-creatable unless it is decoded back first.
+    const pathName = decodeURIComponent(url.pathname);
     return pagePathUtils.isCreatablePage(pathName);
   } catch (err) {
     logger.debug(err);


### PR DESCRIPTION
## 症状

日本語などの ASCII 以外の文字を含むページ名へのリンクをクリックすると、Next のルーティングではなく、ブラウザがページ全体を読み込み直す遷移になっていました。ページ名が ASCII だけのときは Next のルーティングが効いています。

Pukiwiki 記法 `[[ページ名]]` は書いたページ名がそのままリンク先になるため、日本語で運用している wiki ではほぼすべてのリンクが該当します。Markdown 記法 `[表示名](/日本語ページ)` でも同じことが起きていました。

## 原因

`NextLink` が「このリンクを Next のルーティングに乗せてよいか」を判定するとき、`URL.pathname` を `isCreatablePage()` に渡していました。

1. `URL.pathname` は ASCII 以外の文字を `%XX` の形に変換した文字列を返します。`/Sandbox/日本語` は `/Sandbox/%E6%97%A5%E6%9C%AC%E8%AA%9E` になります。
2. `isCreatablePage()` は禁止文字の一覧に `%` を含んでいます（`packages/core/src/utils/page-path-utils/index.ts`）。そのため、変換後の文字列は「作成できないパス」と判定されます。
3. その結果、`next/link` ではなく素の `<a>` が描画され、ブラウザ標準の遷移になります。

この判定自体は #7863 で「Next のページではないパス（`/attachment/…` など）を Next のルーティングに乗せない」ために入ったもので、狙いは妥当です。文字の変換への対応だけが抜けていました。

リンクの href が `%XX` の形になること自体は正しい動きです（`relative-links.ts`）。直すべきは、受け取った側が元の文字に戻さずに判定していた点です。同じ構図は `getServerSideCommonProps()` にもあり、そちらは `decodeURIComponent(url.pathname)` を通しています（#7268）。今回の変更はその扱いを `NextLink` にも合わせるものです。

## 変更内容

1. 判定の直前で `decodeURIComponent()` を通す。
2. `next/link` を返す分岐にも `id` を渡す。3つある分岐のうちここだけ `id` が抜けており、1 の変更で ASCII 以外のパスがこの分岐へ移るため、そのままでは該当リンクから `id` 属性が消えてしまいます（生 HTML で書いた `<a id="…" href="/日本語ページ">` が該当。`id` は無害化の許可属性一覧に入っているので、実際に届きます）。

## デグレしないことの根拠

判定が変わるのは、`URL.pathname` に `%` が含まれる場合だけです。

- `%` を含まないパス：`decodeURIComponent()` は何も変換しないため、判定は変わりません。
- `%` を含むパス：変更前は必ず「作成できないパス」と判定されていました。

つまり、変更前に Next のルーティングを使っていたリンクが、変更後に使わなくなることは起こりません。変化は「ブラウザ標準の遷移 → Next のルーティング」の片方向だけです。360万件の href を使った総当たりでも、逆方向に落ちる例は 0 件でした。

`%` に隠れて判定できていなかったパスも、元の文字に戻したうえで正しく弾かれます。むしろ判定は厳しくなる方向で、`/%61ttachment/x`（`/attachment/x` の符号化）のような形も遮断されます。テストで次を固定しています。

- `/%E6%97%A5%E6%9C%AC%E8%AA%9E.md`（`.md` で終わるパス）→ 素の `<a>` のまま
- `/user/%E6%97%A5%E6%9C%AC%E8%AA%9E`（利用者ホーム）→ 素の `<a>` のまま
- `/%61ttachment/653a1f1b`（予約された接頭辞を符号化したもの）→ 素の `<a>` のまま
- `/Sandbox/broken%ZZ`（`%` の並びが壊れている）→ 例外を既存の `try/catch` が受け止めて素の `<a>`
- `/Sandbox/50%25off`（ページ名に `%` そのものが入る）→ 元に戻すと `%` なので、これまで通り素の `<a>`

新たに Next のルーティングに乗るようになる文字を U+0000〜U+02FF で全数調べたところ、ASCII 以外・空白・`"` `` ` `` `{` `}` ・制御文字だけで、Express が個別に処理する経路は1つも含まれていませんでした。#7908 で扱われた管理画面の権限にも影響しません（`/admin` 系は変更の前後とも素の `<a>` です）。

## 確認したこと

- `NextLink.spec.tsx` を新規追加（24件）。このファイルにはこれまでテストがありませんでした。
- 変異検査：修正を戻す／`decodeURI` に変える／`<Link>` の遷移先からクエリとハッシュを落とす／`<Link>` から `id` を外す／`target` の判定を外す、のいずれでもテストが失敗することを確認しました。
- e2e を新規追加（`page-link-transition.spec.ts`）。ASCII 以外のページパスを扱う e2e はこれまで1つもありませんでした。こちらも修正を戻すと失敗することを確認しています。
- `app-unit` と `app-components` の全テスト（376ファイル・4303件）が通過。
- e2e の `20-basic-features` は、この変更の前後で失敗するテストの顔ぶれが変わらないことを確認（元から失敗しているもの）。

## この PR では直さないもの

- `isCreatablePage()` は「ここにページを作ってよいか」を答える関数で、`NextLink` が知りたい「この URL を Next のページルータが描画するか」とは別の問いです。そのずれ自体は変更の前後で増減していないため、#11689 として起票しました。
- OpenTelemetry の匿名化にも同じ取り違えがあり、そちらは #11688 として起票しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdosQpVr1vdhuKmTn3BX4W
