### PR TITLE
test: Lint and integration tests fail on master after the revision model moved to Prisma

### DIFF
--- a/apps/app/src/server/routes/apiv3/pages/rename.integ.ts
+++ b/apps/app/src/server/routes/apiv3/pages/rename.integ.ts
@@ -49,7 +49,6 @@ import type { IOptionsForCreate } from '~/interfaces/page';
 import type Crowi from '~/server/crowi';
 import type { PageDocument } from '~/server/models/page';
 import PageOperation from '~/server/models/page-operation';
-import { Revision } from '~/server/models/revision';
 import addCustomFunctionToResponse from '~/server/routes/apiv3/response';
 import { prisma } from '~/utils/prisma';
 
@@ -167,8 +166,10 @@ describe('PUT /rename', () => {
 
     const fixturePageIds = (
       await Page.find({ path: fixturePathPattern }, { _id: 1 })
-    ).map((page) => page._id);
-    await Revision.deleteMany({ pageId: { $in: fixturePageIds } });
+    ).map((page) => page._id.toString());
+    await prisma.revisions.deleteMany({
+      where: { pageId: { in: fixturePageIds } },
+    });
     await Page.deleteMany({ path: fixturePathPattern });
     await PageOperation.deleteMany({ fromPath: fixturePathPattern });
     await prisma.activities.deleteMany({ where: { ip: TEST_IP } });


### PR DESCRIPTION
## 何が起きているか

いま master 単体で `pnpm run lint` が落ちます。

```
src/server/routes/apiv3/pages/rename.integ.ts(52,10): error TS2305:
  Module '"~/server/models/revision"' has no exported member 'Revision'.
```

結合テストも同じ理由で落ちます（`TypeError: Cannot read properties of undefined (reading 'deleteMany')`）。master が緑にならないため、いま出ている PR はすべて merge queue を通れません。

## なぜ起きたか

#11602（revision モデルの Prisma 移行）と #11680（rename の結合テスト追加）が同じ時期に queue に入っていたためです。

- #11602 は `~/server/models/revision` から `Revision` という named export を無くしました。現在この module が export するのは Prisma の `extension` だけです。
- #11680 が追加した `rename.integ.ts` は、後片付けでその `Revision` を import しています。

どちらの PR も相手の変更を見ていないので、それぞれ単体では緑でした。後からマージされた側が入った時点で master が壊れています。片方を直せば防げたという類のものではなく、queue が両者を突き合わせなかったことによるものです。

## 直し方

後片付けを Prisma 経由に置き換えました。master 側で移行済みの `comment.integ.ts` や `delete-completely-operation.ts` と同じ書き方です。

```diff
-import { Revision } from '~/server/models/revision';
-
-await Revision.deleteMany({ pageId: { $in: fixturePageIds } });
+await prisma.revisions.deleteMany({
+  where: { pageId: { in: fixturePageIds } },
+});
```

`prisma` は activity の後片付けで既に import 済みなので、import は1行減っています。Prisma schema では `revisions.pageId` は String なので、id を文字列にしてから渡しています。

なお mongoose 側の `Revision` モデル登録（`getOrCreateModel`）は #11602 の後も残っているので、`page.populate('revision')` や `isUpdatable` は従来どおり動きます。無くなったのは named export だけです。

## 検証

- `pnpm run lint` 通過（落ちていたもの。typecheck / biome / route-guard / openapi の生成と検証を含む）。
- `rename.integ` → 5 passed。

## 同じ原因のもの

#11684 でも追加した結合テスト2本が同じ import をしていて、merge queue で落ちていました。そちらは PR 側で直して push 済みです。

Refs #11602
