### PR TITLE
fix: Reduce SSR payload on admin/ai, admin/vault, admin/app by dropping preloadAllLang

### DIFF
--- a/.kiro/specs/i18n/roadmap.md
+++ b/.kiro/specs/i18n/roadmap.md
@@ -70,7 +70,18 @@ SSR ペイロード肥大（`/me/*` で 513 KB、`/admin/{app,ai,vault}` で 347
 
 ## 直接実装（spec なし）
 
-- [ ] **`preloadAllLang` の是正** — 5 ファイル。SSR の `__NEXT_DATA__` に 200〜513 KB を注入しているが、他言語から実際に読んでいるキーは `meta.display_name` の 1 個だけ（言語ピッカーの表示名）。しかもそれは `translation` / `admin` / `commons` の全 3 namespace × 全 5 言語に既に存在する。`pages/admin/ai.page.tsx` と `pages/admin/vault.page.tsx` は言語ピッカー自体が無いのでフラグ削除だけでよい（347 KB → 62 KB）。残る `installer` / `me` / `admin/app` は表示名 5 件を props で渡す形に置き換える。翻訳ファイル構成の整理を待つ必要がなく、最小の工数で最大の削減が取れる。
+- [x] **`preloadAllLang` の是正（3/5 ファイル、2026-08-13 実施）** — SSR の `__NEXT_DATA__` に 200〜513 KB を注入していたが、他言語から実際に読んでいるキーは `meta.display_name` の 1 個だけ（言語ピッカーの表示名）だった。対応したのは `pages/admin/ai.page.tsx` / `pages/admin/vault.page.tsx`（言語ピッカー自体が無いのでフラグ削除のみ、347 KB → 62 KB）と `pages/admin/app.page.tsx`（表示名 5 件をサーバー側で読んで Jotai atom 経由で渡す形に変更）。
+
+### 訂正: `installer` と `me` は対象外（changeLanguage への依存を見落としていた）
+
+着手前の想定は「残る `installer` / `me` / `admin/app` も表示名 5 件を渡す形に置き換えれば済む」だったが、実装直前の確認で誤りだと分かった。この 2 ページの言語ピッカーは表示名を出すだけでなく、**その場でアプリ全体の言語を切り替える**（`i18n.changeLanguage(...)` を呼ぶ）:
+
+- `InstallerForm.tsx` — 言語ドロップダウンをクリックした瞬間に切り替える
+- `stores/personal-settings.tsx` の `useUpdateBasicInfo` — 「Me」ページで基本情報を保存した直後に、選んだ言語へ切り替える
+
+`i18n.changeLanguage()` は、切り替え先の言語のリソース（`translation` / `admin` / `commons` 各 namespace）が既にクライアント側に読み込まれていることを前提にしている。ところが本番環境では i18next のクライアント側に「読み込み元」(backend) が一つも登録されていない（`config/next-i18next.config.mjs` の `use: isDev ? (...) : []`）。つまり本番では、読み込まれていない言語に切り替えようとしても後から取りに行く手段が無く、`fallbackLng`（`en_US`）に静かに戻ってしまう。`preloadAllLang: true` を外すと、まさにこの「取りに行けない」状況を作ってしまう。
+
+このため `installer` / `me` は今回の是正から除外し、`admin/ai` / `admin/vault` / `admin/app` の 3 ファイルのみ実施した。この 2 ページ本来の対応は、本番でも i18next クライアントに読み込み元を持たせる（または別の切り替え方式にする）という、翻訳ファイル構成の整理と同じくらい重さのある別課題であり、本ロードマップの「進める順序」に別項目として積み残す。
 
 ## Specs (dependency order)
 
@@ -79,7 +90,7 @@ SSR ペイロード肥大（`/me/*` で 513 KB、`/admin/{app,ai,vault}` で 347
 
 ## 進める順序
 
-1. `preloadAllLang` の是正（直接実装、5 ファイル）
+1. `preloadAllLang` の是正（直接実装、3/5 ファイル、実施済み。残る `installer` / `me` は上記「訂正」の通り別課題として積み残し）
 2. `i18n-key-audit`（CI ゲート＋実バグ 2 件を狭く修正）
 3. `i18n-community-translation`（POEditor 申請と同期）
 

--- a/apps/app/src/client/components/Admin/App/AppSetting.jsx
+++ b/apps/app/src/client/components/Admin/App/AppSetting.jsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
-import { i18n, useTranslation } from 'next-i18next';
+import { useAtomValue } from 'jotai';
+import { useTranslation } from 'next-i18next';
 import PropTypes from 'prop-types';
 import { useForm } from 'react-hook-form';
 
@@ -7,6 +8,7 @@ import nextI18nConfig from '^/config/next-i18next.config.mjs';
 
 import AdminAppContainer from '~/client/services/AdminAppContainer';
 import { toastError, toastSuccess } from '~/client/util/toastr';
+import { langDisplayNamesAtom } from '~/states/server-configurations';
 import loggerFactory from '~/utils/logger';
 
 import { withUnstatedContainers } from '../../UnstatedUtils';
@@ -19,6 +21,7 @@ const logger = loggerFactory('growi:appSettings');
 const AppSetting = (props) => {
   const { adminAppContainer } = props;
   const { t } = useTranslation(['admin', 'commons']);
+  const langDisplayNames = useAtomValue(langDisplayNamesAtom);
 
   const { register, handleSubmit, reset } = useForm();
 
@@ -128,11 +131,6 @@ const AppSetting = (props) => {
         </span>
         <div className="col-md-6 py-2">
           {i18nConfig.locales.map((locale) => {
-            if (i18n == null) {
-              return null;
-            }
-            const fixedT = i18n.getFixedT(locale, 'admin');
-
             return (
               <div key={locale} className="form-check form-check-inline">
                 <input
@@ -146,7 +144,7 @@ const AppSetting = (props) => {
                   className="form-label form-check-label"
                   htmlFor={`radioLang${locale}`}
                 >
-                  {fixedT('meta.display_name')}
+                  {langDisplayNames[locale] ?? locale}
                 </label>
               </div>
             );

--- a/apps/app/src/pages/admin/ai.page.tsx
+++ b/apps/app/src/pages/admin/ai.page.tsx
@@ -25,7 +25,7 @@ AdminAiPage.getLayout = createAdminPageLayout<Props>({
 });
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  return getServerSideAdminCommonProps(context, { preloadAllLang: true });
+  return getServerSideAdminCommonProps(context);
 };
 
 export default AdminAiPage;

--- a/apps/app/src/pages/admin/app.page.tsx
+++ b/apps/app/src/pages/admin/app.page.tsx
@@ -1,7 +1,13 @@
-import type { GetServerSideProps } from 'next';
+import type { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import dynamic from 'next/dynamic';
+import { useHydrateAtoms } from 'jotai/utils';
+
+import { langDisplayNamesAtom } from '~/states/server-configurations';
 
 import type { NextPageWithLayout } from '../_app.page';
+import type { LangDisplayNames } from '../common-props/lang-display-names';
+import { getLangDisplayNames } from '../common-props/lang-display-names';
+import { mergeGetServerSidePropsResults } from '../utils/server-side-props';
 import type { AdminCommonProps } from './_shared';
 import {
   createAdminPageLayout,
@@ -14,11 +20,19 @@ const AppSettingsPageContents = dynamic(
   { ssr: false },
 );
 
-type Props = AdminCommonProps;
+type PageProps = {
+  langDisplayNames: LangDisplayNames;
+};
 
-const AdminAppPage: NextPageWithLayout<Props> = () => (
-  <AppSettingsPageContents />
-);
+type Props = AdminCommonProps & PageProps;
+
+const AdminAppPage: NextPageWithLayout<Props> = (props: Props) => {
+  useHydrateAtoms([[langDisplayNamesAtom, props.langDisplayNames]], {
+    dangerouslyForceHydrate: true,
+  });
+
+  return <AppSettingsPageContents />;
+};
 
 AdminAppPage.getLayout = createAdminPageLayout<Props>({
   title: (_p, t) => t('headers.app_settings', { ns: 'commons' }),
@@ -32,8 +46,16 @@ AdminAppPage.getLayout = createAdminPageLayout<Props>({
   ],
 });
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  return getServerSideAdminCommonProps(context, { preloadAllLang: true });
+export const getServerSideProps: GetServerSideProps<Props> = async (
+  context: GetServerSidePropsContext,
+) => {
+  const commonResult = await getServerSideAdminCommonProps(context);
+
+  const langDisplayNamesFragment = {
+    props: { langDisplayNames: getLangDisplayNames() },
+  } satisfies { props: PageProps };
+
+  return mergeGetServerSidePropsResults(commonResult, langDisplayNamesFragment);
 };
 
 export default AdminAppPage;

--- a/apps/app/src/pages/admin/vault.page.tsx
+++ b/apps/app/src/pages/admin/vault.page.tsx
@@ -27,7 +27,7 @@ AdminVaultPage.getLayout = createAdminPageLayout<Props>({
 });
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  return getServerSideAdminCommonProps(context, { preloadAllLang: true });
+  return getServerSideAdminCommonProps(context);
 };
 
 export default AdminVaultPage;

--- a/apps/app/src/pages/common-props/lang-display-names.ts
+++ b/apps/app/src/pages/common-props/lang-display-names.ts
@@ -1,0 +1,35 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { AllLang, type Lang } from '@growi/core';
+
+import nextI18NextConfig from '^/config/next-i18next.config.mjs';
+
+export type LangDisplayNames = Readonly<Partial<Record<Lang, string>>>;
+
+let cache: LangDisplayNames | undefined;
+
+// Reads only `meta.display_name` from the smallest namespace (commons) for every
+// supported language, instead of preloading every namespace for every language
+// into the client bundle (the `preloadAllLang` approach this replaces).
+export const getLangDisplayNames = (): LangDisplayNames => {
+  if (cache != null) {
+    return cache;
+  }
+
+  const { localePath } = nextI18NextConfig;
+  if (typeof localePath !== 'string') {
+    // next-i18next's UserConfig type also allows a per-namespace function, but
+    // this project's config always sets a static path.resolve(...) string.
+    throw new Error('next-i18next config localePath must be a string path');
+  }
+
+  cache = Object.fromEntries(
+    AllLang.map((lang) => {
+      const filePath = path.join(localePath, lang, 'commons.json');
+      const commons = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      return [lang, commons.meta.display_name];
+    }),
+  );
+
+  return cache;
+};

--- a/apps/app/src/states/server-configurations/server-configurations.ts
+++ b/apps/app/src/states/server-configurations/server-configurations.ts
@@ -1,3 +1,4 @@
+import type { Lang } from '@growi/core';
 import { atom, useAtomValue } from 'jotai';
 
 import type { SupportedActionType } from '~/interfaces/activity';
@@ -162,6 +163,13 @@ export const activityExpirationSecondsAtom = atom<number>(0);
  * Audit Log Available Actions atom
  */
 export const auditLogAvailableActionsAtom = atom<SupportedActionType[]>([]);
+
+/**
+ * Atom for the display name of each language, keyed by Lang.
+ * Hydrated from server-computed data instead of preloading every i18n
+ * namespace for every language into the client bundle.
+ */
+export const langDisplayNamesAtom = atom<Partial<Record<Lang, string>>>({});
 
 /**
  * Atom for renderer config


### PR DESCRIPTION
## Summary

- `admin/ai.page.tsx` と `admin/vault.page.tsx` は言語ピッカー自体が無いにもかかわらず、`preloadAllLang: true` で全5言語分の i18n リソースを `__NEXT_DATA__` に注入していた。フラグを削除するだけで済む。
- `admin/app.page.tsx` の言語ピッカーは各言語の表示名（`meta.display_name`）1個だけを必要としていた。サーバー側で5言語分の表示名だけを読んで Jotai atom に hydrate する方式に変更し、`preloadAllLang` を廃止した。
- 実測（devcontainer 上、ログイン後の `__NEXT_DATA__` サイズ）: 3ページとも 476 KB → 93 KB 前後。

## 対象外にした installer / me について

当初は `installer/index.page.tsx` と `me/[[...path]].page.tsx` も同様に直す想定だったが、実装直前の確認でこの2ページは対象外にした。理由:

- `InstallerForm.tsx` は言語ドロップダウンをクリックした瞬間に `i18n.changeLanguage()` を呼んでその場でUI言語を切り替える
- `me` ページの基本情報保存後処理（`stores/personal-settings.tsx` の `useUpdateBasicInfo`）も、保存直後に選択言語へ `i18n.changeLanguage()` する

`i18n.changeLanguage()` は切り替え先言語のリソースが既にクライアントに読み込まれていることを前提にしており、本番では i18next クライアントに読み込み元(backend)が登録されていないため、`preloadAllLang` を外すと未読み込みの言語に切り替えた瞬間に `fallbackLng`（en_US）へ静かに戻ってしまう。この2ページの本来の対応は別課題として `.kiro/specs/i18n/roadmap.md` に切り出した。

## Test plan

- [x] `pnpm run lint:typecheck` / `pnpm run lint:biome` — 変更ファイルにエラー無し
- [x] `pnpm run lint`（import-convention 含む）— exit 0
- [x] `pnpm vitest run common-props` — pass
- [x] `pnpm run test`（全体）— 5383 tests passed, 16 skipped（既知の vault-manager dist 未ビルドによる2件の失敗を除く。本PRの変更とは無関係）
- [x] devcontainer で dev サーバーを起動し、実際にログインして `/admin/app` `/admin/ai` `/admin/vault` の3ページの `__NEXT_DATA__` サイズを before/after 実測
- [x] `/admin/app` の言語ラジオボタンが `English / 日本語 / 简体中文 / Français / 한국어` と正しく表示されることを確認（初回ロード・SPA遷移後の両方）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XThHtwRn7Nhy9WQ4udiCSA