### PR TITLE
chore: add flaky-CI detection and investigation skills

### DIFF
--- a/.claude/commands/detect-flaky-ci.md
+++ b/.claude/commands/detect-flaky-ci.md
@@ -1,0 +1,13 @@
+---
+name: detect-flaky-ci
+description: Scan recent CI runs for flaky failures and track them as GitHub issues (detection only, no code changes). Usage: /detect-flaky-ci [--lookback=N] [--vitest-threshold=N]
+---
+
+# /detect-flaky-ci
+
+Invoke the `detect-flaky-ci` skill with `$ARGUMENTS` passed through as-is.
+
+This only reads CI history and writes to GitHub issues/labels — it never
+touches source code. To act on what it finds, run `/investigate-flaky-test
+<issue>` on an issue it escalates to `flaky/confirmed`, or run
+`/flaky-ci-routine` to chain both steps automatically.

--- a/.claude/commands/flaky-ci-routine.md
+++ b/.claude/commands/flaky-ci-routine.md
@@ -1,0 +1,104 @@
+---
+name: flaky-ci-routine
+description: Full flaky-CI routine - detect flaky CI failures, then investigate/fix every newly-confirmed one. Designed to be run unattended from a cron schedule. Usage: /flaky-ci-routine [--lookback=N] [--vitest-threshold=N]
+---
+
+# /flaky-ci-routine
+
+Orchestrates the two flaky-CI skills in sequence. This command holds no
+detection or investigation logic of its own — it only sequences
+`detect-flaky-ci` and `investigate-flaky-test`, each of which is a
+self-contained skill usable on its own. Keeping the sequencing here (rather
+than inline in a cron prompt) means there is one place to read or edit the
+chain, whether it's triggered by cron or run by hand.
+
+## Step 0 — Ensure `gh` is available and authenticated
+
+Every step below depends on `gh`. This command is designed to also run from
+an unattended cloud routine whose checkout may not have `gh` preinstalled
+(confirmed missing in this project's cloud environment during setup) — do
+not assume it's on `PATH`.
+
+```bash
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh not found, bootstrapping a static binary..."
+  GH_VERSION="$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest | grep -m1 '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')"
+  curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" -o /tmp/gh.tar.gz
+  tar -xzf /tmp/gh.tar.gz -C /tmp
+  export PATH="/tmp/gh_${GH_VERSION}_linux_amd64/bin:$PATH"
+fi
+gh --version
+```
+
+Then confirm write access — a read-only check (`gh issue list`) is not
+enough evidence, since it succeeds even without a token. Actually attempt a
+harmless write and clean it up:
+
+```bash
+gh auth status
+LABEL_TEST=$(gh label list --repo growilabs/growi --json name -q '.[0].name' 2>&1) \
+  && echo "read ok: $LABEL_TEST" || { echo "gh cannot read growilabs/growi — stopping"; exit 1; }
+```
+
+If `gh` cannot be installed, or `gh auth status` shows no authenticated
+account, or GitHub API calls fail with a permissions/auth error: **stop
+immediately and report this clearly** (this is exactly what happened the
+first time this routine ran unattended — treat a missing prerequisite as a
+stop condition, not something to route around by improvising a different
+approach). Do not proceed to Step 1 without confirmed write access, since
+Step 1 onward creates issues/labels/PRs and a failure partway through is
+harder to clean up than a clean stop before starting.
+
+## Step 1 — Detect
+
+Invoke the `detect-flaky-ci` skill with `$ARGUMENTS` passed through
+(`--lookback`, `--vitest-threshold`). Let it finish and report its summary.
+
+## Step 2 — Select newly-actionable issues
+
+List issues that are confirmed flaky AND not already past the "new" stage
+(so an issue already mid-investigation, WIP, or resolved from a prior
+routine run is not re-processed):
+
+```bash
+gh label list --repo growilabs/growi --json name --limit 100
+```
+
+```bash
+gh issue list --repo growilabs/growi --state open \
+  --label "flaky/confirmed" --label "{EXACT_PHASE_NEW_LABEL}" \
+  --json number,title
+```
+
+If this list is empty, report that and stop — there is nothing to
+investigate this run.
+
+## Step 3 — Investigate each, autonomously
+
+For each issue number found, invoke the `investigate-flaky-test` skill with
+`--auto`:
+
+```
+investigate-flaky-test {ISSUE_NUMBER} --auto
+```
+
+Run these **sequentially, one issue at a time** — not in parallel. Each
+investigation may modify the working tree (branch, files, commits); running
+several concurrently in the same checkout would corrupt each other's work.
+If a genuinely parallel routine is ever needed, that requires per-issue
+worktree isolation, which is out of scope for this command as written.
+
+Autonomous mode means most issues resolve without stopping (HIGH-confidence
+gates cross automatically), but a MEDIUM/LOW gate inside
+`investigate-flaky-test` will still stop and ask — since this command may be
+running unattended from cron, treat any such stop as "pause this issue and
+move to the next one" rather than blocking the whole routine: note it in the
+final report as needing human attention and continue with the next issue in
+the list.
+
+## Step 4 — Report
+
+Summarize the run: how many issues were newly confirmed by Step 1, how many
+were investigated in Step 3, how many resulted in a PR, how many were left
+pending human decision (and why), and how many were quarantined. This is the
+routine's output — nothing else needs to be written.

--- a/.claude/commands/investigate-flaky-test.md
+++ b/.claude/commands/investigate-flaky-test.md
@@ -1,0 +1,19 @@
+---
+name: investigate-flaky-test
+description: Investigate a flaky-test tracking issue created by detect-flaky-ci - reproduce, find root cause, fix, and optionally PR. Usage: /investigate-flaky-test <issue-url-or-number> [--auto]
+---
+
+# /investigate-flaky-test
+
+Invoke the `investigate-flaky-test` skill in **interactive mode** with the
+given issue number or URL.
+
+Pass `$ARGUMENTS` as-is (issue number, URL, or URL with `--auto`).
+
+The issue must already carry the `flaky/confirmed` label (set by
+`detect-flaky-ci` once it has enough evidence) — running this against a
+`flaky/observing` issue will stop immediately rather than investigate on
+weak evidence.
+
+Append `--auto` for autonomous mode (stop gates crossed automatically at HIGH
+confidence, same semantics as `/investigate-issue --auto`).

--- a/.claude/skills/detect-flaky-ci/SKILL.md
+++ b/.claude/skills/detect-flaky-ci/SKILL.md
@@ -1,0 +1,338 @@
+---
+name: detect-flaky-ci
+description: Scan recent GROWI CI runs for flaky (non-deterministic) job/test failures and track them as GitHub issues. Detection only — never modifies source code. Usage - /detect-flaky-ci [--lookback=N] [--vitest-threshold=N]
+allowed-tools: Bash, Read, Grep
+argument-hint: "[--lookback=30] [--vitest-threshold=2]"
+---
+
+# detect-flaky-ci
+
+## Overview
+
+Scan a bounded window of recent CI runs on `growilabs/growi`, find failures that
+look non-deterministic (flaky) rather than a real regression or infrastructure
+noise, and record them as tracked GitHub issues.
+
+**This skill never touches source code, opens no branch, and creates no PR.**
+Its only outputs are: new issues, comments on existing issues, and label
+changes on issues it created. Fixing is a separate skill
+(`investigate-flaky-test`) invoked later, on a different issue, by the
+`/flaky-ci-routine` command.
+
+Because this is meant to run unattended from a cron routine (`schedule` skill)
+with no memory between runs, **all state lives in GitHub issues and labels** —
+this skill re-derives everything it needs by querying the tracker on each run.
+
+## Input
+
+`$ARGUMENTS` (all optional):
+- `--lookback=N` — how many most-recent completed runs of each watched
+  workflow to scan. Default `30`.
+- `--vitest-threshold=N` — number of separate-run observations of the same
+  vitest test failure required before escalating from `flaky/observing` to
+  `flaky/confirmed`. Default `2`. (Playwright-detected flakiness always
+  escalates on the first observation — see Step 3.)
+
+## Why vitest and Playwright are handled differently
+
+- **Playwright** runs with `retries: 2` in CI (`apps/app/playwright.config.ts`).
+  When a test fails and then passes on retry within the *same* job run, the
+  job log prints an unambiguous `N flaky` summary line and `Retry #N` blocks
+  for that spec. This is direct, single-run proof of non-determinism — no
+  accumulation needed.
+- **vitest** (`ci-app-test`, `ci-app-test-integration`) has no retry mechanism.
+  A single failure is indistinguishable from a real regression. The only
+  cheap, reliable signal is the same test failing across multiple *unrelated*
+  runs while the surrounding suite is otherwise green — which requires
+  accumulating observations over time via `--vitest-threshold`.
+
+  The gold-standard signal — the same commit SHA re-run failing then passing
+  (`run_attempt` N vs N+1) — does happen in this repo (confirmed via
+  `repos/{owner}/{repo}/actions/runs?per_page=100`, look for `run_attempt > 1`)
+  but is rare (manual reruns only) and cannot be the primary mechanism. When
+  you do find a same-SHA attempt flip during a scan, treat it exactly like a
+  Playwright signal — escalate immediately, no accumulation required.
+
+## Step 1: List Candidate Runs
+
+Watched workflows (by their GitHub Actions display name, not the file name):
+
+- `Node CI for app development` — hosts `ci-app-test`, `ci-app-test-integration`
+- `Node CI for app production` — hosts `run-playwright` (via the reusable
+  `Reusable build and test app for production` workflow)
+
+Query **each workflow separately** with `gh run list --workflow` — do not
+pull the unfiltered `actions/runs` list and filter client-side, the repo runs
+several other workflows (CodeQL, Auto-labeling, Auto approve PR, ...) and a
+generic `--lookback` window of recent runs across all of them can leave
+zero, or only a handful, of the two workflows actually being watched:
+
+```bash
+gh run list --repo growilabs/growi --workflow "Node CI for app development" \
+  --limit {LOOKBACK} --status completed \
+  --json databaseId,conclusion,headSha,createdAt,url,event,attempt
+
+gh run list --repo growilabs/growi --workflow "Node CI for app production" \
+  --limit {LOOKBACK} --status completed \
+  --json databaseId,conclusion,headSha,createdAt,url,event,attempt
+```
+
+This naturally includes pull_request and merge-queue-triggered runs (the
+merge queue is where today's investigation actually surfaced a failure — a
+scan that only looked at "PR checks" would have missed it).
+
+While you have this data, check for same-SHA reruns: group by `headSha`
+within each workflow's result set and look for a `headSha` that appears more
+than once with `attempt > 1` on the later one. If an earlier attempt for
+that `headSha` failed and a later attempt succeeded, every job that flipped
+between those two attempts is a confirmed flaky occurrence (see Step 3,
+"confirmed" path) — skip Step 2 classification for it, a same-SHA pass/fail
+flip has no infra-vs-product ambiguity to resolve. This is rare (confirmed
+via manual inspection: 2 occurrences in the most recent 100 runs across the
+whole repo) so do not spend excessive time hunting for it — a quick group-by
+over the JSON you already fetched is enough; skip it under time pressure.
+
+Keep only runs with `conclusion == "failure"` for the main Step 2 flow.
+
+## Step 2: Fetch Failed Jobs and Classify Noise
+
+`{RUN_ID}` below is the `databaseId` from Step 1.
+
+For each failed run, list its jobs and keep the ones with
+`conclusion == "failure"` (skip `cancelled` — those are pre-emptions by a
+newer push, not evidence of anything):
+
+```bash
+gh api repos/growilabs/growi/actions/runs/{RUN_ID}/jobs -q '.jobs[] | select(.conclusion == "failure") | {id, name}'
+```
+
+Fetch each failed job's log:
+
+```bash
+gh run view {RUN_ID} --repo growilabs/growi --job {JOB_ID} --log-failed
+```
+
+### Step 2b: also check successful `run-playwright` jobs for in-run flakes
+
+A shard where a test failed and then passed on retry ends the *job* as
+`success` — Playwright's own retries absorbed it before the job's exit code
+was decided. The failed-job scan above never sees these, so it misses most
+of Playwright's actual "free" flaky signal (the one case caught in this
+skill's initial design review only surfaced because a *different* test in
+the same shard genuinely failed). To catch these, additionally scan
+successful `run-playwright` jobs from runs in the Step 1 list (any
+conclusion, not just failed runs), grepping rather than reading the full log
+to keep this cheap:
+
+```bash
+gh run view {RUN_ID} --repo growilabs/growi --job {JOB_ID} --log \
+  | grep -iE "flaky|Retry #|^:*error file="
+```
+
+If this is empty, the shard had no flakiness — move on. If it has a
+` flaky` count > 0, proceed to Step 3's Playwright extraction using this
+grepped excerpt (it is sufficient; do not re-fetch the full log).
+
+**Classify infrastructure noise first — do not track these as flaky.** Match
+the log against this denylist (case-insensitive substring match). If any
+pattern matches, log it in this run's report as "infra noise, skipped" and
+move to the next job. This list is deliberately small and additive — extend
+it when a genuine false positive is found, don't broaden matches speculatively:
+
+- `ECONNREFUSED`
+- `getaddrinfo ENOTFOUND`
+- `No space left on device`
+- `SIGKILL` / `exit code 137` (OOM-killed)
+- `runner has received a shutdown signal` / `lost communication with the server`
+- `docker: Error response from daemon`
+- generic `curl` retry exhaustion (`--retry 60` blocks timing out, seen in
+  `ci-app.yml` / `reusable-app-prod.yml` service-wait steps)
+
+Everything that doesn't match is a candidate for Step 3.
+
+## Step 3: Extract Test Identity and Evidence
+
+### Playwright jobs (`run-playwright ...`)
+
+Job names carry a shard number and MongoDB version that are **not stable
+identity** — the same spec lands on a different shard number across runs
+(sharding is just parallelization, reassigned each run), so including it in
+the identity key would fragment one flaky spec into many never-deduped
+issues. The browser (`chromium`/`firefox`/`webkit`) IS meaningful — the same
+spec can be flaky in one engine and not another. Extract it from the job
+name, e.g. `run-playwright (firefox, 1/2, 8.0)` → browser = `firefox`.
+
+The reliable, structured signal is the trailing summary line (`N failed`,
+`N flaky`, `N passed`) and the `::error file=...,title=...` annotations for
+genuinely-failed specs. **Attributing a specific `flaky` count to a specific
+spec name from the raw log is not reliable** — the CI reporter's console
+output interleaves per-step Playwright debug traces (`pw:api ...`) with
+retry/attachment lines in a way that does not cleanly pair a `Retry #N`
+block with the spec it belongs to. Do not try to build a precise
+adjacency/pairing heuristic here; it will misattribute. Use a two-tier
+approach instead:
+
+1. **Precise identity** — only when unambiguous: if the log's `::error`
+   annotations account for exactly `N failed` and there is exactly one
+   distinct spec/title referenced anywhere in retry-attachment paths
+   (`playwright/output/{slug}.../test-failed-N.png`) that is **not** among
+   the `::error`-annotated titles, that leftover slug is the flaky one —
+   use `playwright:{SPEC_PATH}:{TEST_TITLE}` (recover the human title from
+   the slug by matching it against spec files under
+   `apps/app/playwright/` if needed).
+2. **Fallback (job-level)** — in every other case (multiple candidates,
+   nothing unambiguous), use `playwright:{BROWSER}` as the identity and say
+   so explicitly in the issue body: "flaky test detected in this shard's log
+   (see excerpt below) but the specific spec could not be isolated from the
+   log alone — see the linked run for the full report." This is intentional:
+   a coarser but honest identity beats a fabricated precise one.
+
+Either tier counts as a **confirmed** occurrence (see Step 4) — Playwright
+already retried in-run and still needed a retry to pass, regardless of
+whether this skill can name the exact spec.
+
+### Vitest jobs (`ci-app-test`, `ci-app-test-integration`)
+
+Search the log for Vitest's failure block format (seen directly in this
+repo's CI output):
+
+```
+FAIL {app-integration|...} {SPEC_PATH} > {SUITE} > {TEST_TITLE}
+{ErrorType}: {message}
+```
+
+Identity key: `vitest:{SPEC_PATH}:{TEST_TITLE}`.
+
+This is an **observation**, not a confirmation — proceed to Step 4 to decide
+whether it crosses the threshold.
+
+## Step 4: Reconcile Against Existing Issues
+
+**The issue title IS the identity key, verbatim** — this is deliberate: it
+guarantees the search below can never drift out of sync with what was
+written at creation time. Do not use a separately-worded human-friendly
+title with the identity key tucked into the body; a title/search mismatch
+there means every scan sees "no existing issue" and creates a duplicate.
+
+Title format (fixed):
+`flaky: {IDENTITY_KEY}`
+
+e.g. `flaky: vitest:src/features/external-user-group/server/service/external-user-group-sync.integ.ts:syncs groups and deletes groups that do not exist externally`
+or `flaky: playwright:firefox` (job-level fallback identity).
+
+Search for an existing tracking issue using the identity key as an exact
+title match:
+
+```bash
+gh issue list --repo growilabs/growi --search "in:title \"{IDENTITY_KEY}\"" --state all --json number,title,labels,state
+```
+
+After the search returns, still confirm the match: `gh search` does
+substring/token matching, not exact — verify at least one returned issue's
+`title` is exactly `flaky: {IDENTITY_KEY}` before treating it as the same
+issue, in case the search surfaced a partial/unrelated match.
+
+### No existing issue found
+
+Create one. Fetch exact label names first (names carry emoji prefixes and
+drift — never hardcode):
+
+```bash
+gh label list --repo growilabs/growi --json name --limit 100
+```
+
+```bash
+gh issue create --repo growilabs/growi \
+  --title "flaky: {IDENTITY_KEY}" \
+  --label "type/bug" --label "{EXACT_PHASE_NEW_LABEL}" \
+  --label "{flaky/confirmed if Step 3 evidence is already confirmed, else flaky/observing}" \
+  --body "$(cat <<'EOF'
+## Detected by detect-flaky-ci
+
+**Identity key**: `{IDENTITY_KEY}`
+**Kind**: {playwright | vitest} {(strong evidence: passed on in-run retry) if confirmed}
+
+### First observation
+
+- Run: {RUN_HTML_URL}
+- Job: {JOB_NAME}
+- Commit: {HEAD_SHA}
+- Date: {CREATED_AT}
+
+### Evidence
+
+```
+{relevant log excerpt — the FAIL block or the ::error annotation + retry blocks}
+```
+
+### Status
+
+{"Confirmed flaky from a single run (Playwright retry evidence)." if confirmed else "Observation 1/{VITEST_THRESHOLD} — needs {VITEST_THRESHOLD - 1} more independent occurrence(s) before this is handed to investigate-flaky-test."}
+EOF
+)"
+```
+
+### Existing OPEN issue found, currently `flaky/observing`
+
+Do not create a duplicate. Append an observation comment:
+
+```bash
+gh issue comment {NUMBER} --repo growilabs/growi --body "$(cat <<'EOF'
+### Additional observation
+
+- Run: {RUN_HTML_URL}
+- Job: {JOB_NAME}
+- Commit: {HEAD_SHA}
+- Date: {CREATED_AT}
+
+```
+{log excerpt}
+```
+EOF
+)"
+```
+
+Count observation comments (initial issue body counts as observation 1) plus
+this new one. If the count reaches `--vitest-threshold` (or this evidence
+item is itself a "confirmed" one per Step 3), escalate:
+
+```bash
+gh issue edit {NUMBER} --repo growilabs/growi --remove-label "flaky/observing" --add-label "flaky/confirmed"
+```
+
+### Existing OPEN issue found, already `flaky/confirmed`
+
+Still append the observation comment (useful evidence for
+`investigate-flaky-test`), but do not change labels — it is already queued
+for investigation or being investigated.
+
+### Existing CLOSED issue found
+
+The test regressed again after being marked resolved. Reopen it and add a
+comment explaining the new occurrence, plus the label `flaky/confirmed`
+(skip `flaky/observing` — a recurrence after a claimed fix is stronger
+evidence than a first-time observation):
+
+```bash
+gh issue reopen {NUMBER} --repo growilabs/growi
+gh issue edit {NUMBER} --repo growilabs/growi --add-label "flaky/confirmed" --remove-label "{EXACT_PHASE_RESOLVED_LABEL}" --add-label "{EXACT_PHASE_NEW_LABEL}"
+```
+
+## Step 5: Report
+
+Print a short summary of this run: how many runs/jobs scanned, how many
+classified as infra noise (with which pattern), how many new issues created,
+how many existing issues updated, how many escalated to `flaky/confirmed`.
+This is the only user-facing output — do not create files.
+
+## Error Handling
+
+- `gh api` rate limit hit: report how far the scan got and stop; do not retry
+  in a tight loop.
+- A job log too large to fit in context: use `--log-failed` (already filters
+  to failed steps) rather than `--log`; if still too large, grep for `FAIL `,
+  `::error`, and ` flaky` lines only instead of reading the full log.
+- Ambiguous identity (test title changed between occurrences of the same
+  underlying flake): do not attempt fuzzy matching — treat as a new issue.
+  False negatives here (a missed dedupe) are cheap; false positives (wrongly
+  merging two different flakes) are not.

--- a/.claude/skills/investigate-flaky-test/SKILL.md
+++ b/.claude/skills/investigate-flaky-test/SKILL.md
@@ -1,0 +1,366 @@
+---
+name: investigate-flaky-test
+description: Investigate a GROWI flaky-test tracking issue (created by detect-flaky-ci) - reproduce, find the root cause, decide test-fix vs product-fix vs quarantine, and optionally open a PR. Usage - /investigate-flaky-test <issue-url-or-number> [--auto]
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent, AskUserQuestion
+argument-hint: <issue-url-or-number> [--auto]
+---
+
+# investigate-flaky-test
+
+## Overview
+
+Investigate a GitHub issue created by `detect-flaky-ci` and labeled
+`flaky/confirmed`: reproduce the non-determinism, find the root cause,
+classify it, and — if approved — fix it and open a PR.
+
+This mirrors `investigate-issue`'s shape (confidence-gated stop points,
+`phase/*` label lifecycle, branch/PR conventions) so both skills feel like
+the same tool. **It is a separate skill, not a mode of `investigate-issue`**,
+because the actual investigation content is unrelated: no reported version to
+check, no browser reproduction of user-facing steps, and the fix taxonomy
+(test-side vs. product-side vs. quarantine) does not apply to ordinary bug
+reports.
+
+Supports the same two execution modes as `investigate-issue`:
+- **interactive** (default): stop at every decision gate
+- **autonomous** (`--auto`, or invoked from `/flaky-ci-routine`): cross a gate
+  automatically at HIGH confidence, stop at MEDIUM or LOW
+
+## Input
+
+`$ARGUMENTS` is an issue URL or number, optionally with `--auto`. Parse the
+issue number and mode the same way `investigate-issue` does.
+
+**Precondition**: the issue must carry the `flaky/confirmed` label (fetch
+exact label names with `gh label list --repo growilabs/growi --json name`
+before comparing — never hardcode). If it is still `flaky/observing`, stop
+and report that `detect-flaky-ci` has not gathered enough evidence yet; do
+not attempt to lower the bar by investigating early.
+
+---
+
+## Confidence Framework
+
+Same three levels and same autonomous/interactive behavior as
+`investigate-issue` (HIGH → proceed autonomously and state the evidence,
+MEDIUM/LOW → stop and ask with a recommendation). Applied at two gates in
+this skill: the fix-classification gate (Step 4) and the PR gate (Step 6).
+
+---
+
+## Step 1: Fetch Issue Evidence
+
+```bash
+gh issue view {ISSUE_NUMBER} --repo growilabs/growi --json number,title,body,labels,comments,url
+```
+
+The title is `flaky: {IDENTITY_KEY}` (set by `detect-flaky-ci`), where
+`IDENTITY_KEY` is one of:
+- `vitest:{SPEC_PATH}:{TEST_TITLE}` — reproduce with vitest, precise identity.
+- `playwright:{SPEC_PATH}:{TEST_TITLE}` — reproduce with Playwright, precise identity.
+- `playwright:{BROWSER}` — a **job-level fallback identity**: `detect-flaky-ci`
+  could not isolate which spec was flaky from the CI log alone. The issue
+  body's evidence section will say so explicitly. In this case, do not guess
+  a spec — read the linked run's full Playwright report first (the run URL
+  in the "First observation" section) to find the actual flaky spec before
+  attempting Step 2 reproduction. If the report is no longer available
+  (artifact retention expired), report LOW confidence at Step 4 rather than
+  guessing.
+
+Parse the identity key from the title (split on the first `:` and then on the
+last `:` to isolate `SPEC_PATH`/`TEST_TITLE` — `SPEC_PATH` values here are
+project-relative paths and never contain a bare `:`, so this is unambiguous).
+Collect every observation block from the body and comments (run URLs,
+commits, log excerpts) — later
+observations may show the failure mode drifting or repeating identically,
+which is itself evidence for Step 3.
+
+Mark as under investigation, same as `investigate-issue`:
+
+```bash
+gh issue edit {ISSUE_NUMBER} --repo growilabs/growi --remove-label "{EXACT_PHASE_NEW_LABEL}" --add-label "{EXACT_PHASE_UNDER_INVESTIGATION_LABEL}"
+```
+
+---
+
+## Step 2: Gather Evidence
+
+**Primary tier — CI log analysis (always available, no live services
+needed).** This skill is expected to run unattended, including from a cloud
+routine whose checkout has no MongoDB replica set, no Elasticsearch, and no
+browsers. Do not make CI-log analysis a fallback for when reproduction
+"isn't available" — treat it as the normal, primary path, and treat live
+reproduction (below) as a bonus when the current environment happens to
+support it.
+
+Pull more history than what's already in the issue, using the same tools
+`detect-flaky-ci` uses:
+
+```bash
+# Vitest: how often does this exact test appear as FAIL across recent runs
+# of the job that hosts it?
+gh run list --repo growilabs/growi --workflow "Node CI for app development" --limit 50 --status completed --json databaseId,conclusion,headSha,createdAt
+
+# Playwright: how often does this spec/browser show up in Retry#/flaky
+# evidence across recent run-playwright jobs?
+gh run list --repo growilabs/growi --workflow "Node CI for app production" --limit 50 --status completed --json databaseId,conclusion,headSha,createdAt
+```
+
+For each candidate run, fetch the relevant job's log (same commands as
+`detect-flaky-ci` Step 2/2b) and grep for the test title. Build a picture of:
+how often it fails, whether the failure mode is identical every time (points
+to a deterministic race, easier to fix) or varies (points to genuine timing
+noise), and — critically — read the **stack trace / error origin** in each
+occurrence: an error surfacing from a service/model file (not the spec
+itself) is your first clue toward a product-code race (see Step 3).
+
+Read the spec file and the code path it exercises. For Playwright specs,
+static-analyze for timing-dependent patterns (missing
+`await expect(...).toBeVisible()` before interaction, reliance on fixed
+`waitForTimeout`, selectors matching multiple elements — see the
+`comments.spec.ts` "strict mode violation: resolved to 2 elements" pattern,
+a real example already seen in this repo's CI).
+
+**Second tier — actively re-run the real CI job (always available, no local
+services needed, and stronger than local reproduction).** `detect-flaky-ci`
+noted that a same-SHA rerun flipping from failure to success is the
+gold-standard flaky signal, but treated it as rare because it only happens
+when a human manually reruns. This skill does not have to wait for that —
+it can trigger it directly, using GitHub Actions' own real MongoDB replica
+set / Elasticsearch / browsers instead of whatever local environment this
+skill happens to be running in:
+
+```bash
+gh run rerun {RUN_ID} --repo growilabs/growi --failed
+```
+
+where `{RUN_ID}` is a run cited in the issue's evidence. Wait for it to
+complete (`gh run watch {RUN_ID} --repo growilabs/growi`), then fetch the
+new attempt's job log exactly as in Step 1/`detect-flaky-ci` Step 2. Repeat
+2-3 times to build a same-commit pass/fail tally — e.g. "failed 1/4 reruns"
+is meaningfully different evidence from "failed 4/4 reruns" for both the
+root-cause read (the former looks like real non-determinism, the latter
+looks more like a deterministic bug that merely presents as CI-only) and
+for Step 4's confidence assessment. This costs CI minutes on the real repo,
+so do not loop indefinitely — 2-3 reruns is enough signal; stop earlier if a
+clear pattern emerges (e.g. it fails every single time — that increasingly
+looks like a real regression, not a flake, and is worth flagging as such
+even though `detect-flaky-ci` escalated it).
+
+**Bonus tier — live reproduction, only if the current environment supports
+it.** Probe rather than assume:
+
+```bash
+# vitest / integ tests need a real MongoDB replica set
+mongosh --eval "db.adminCommand('ping')" 2>/dev/null || echo "no mongo"
+# playwright needs installed browsers
+pnpm exec playwright --version 2>/dev/null && ls ~/.cache/ms-playwright 2>/dev/null
+```
+
+If available:
+
+```bash
+# vitest
+cd apps/app && pnpm vitest run {SPEC_PATH_PARTIAL} --repeat=20
+
+# playwright
+cd apps/app && pnpm playwright test {SPEC_PATH_PARTIAL} --repeat-each=10
+```
+
+A local reproduction (or local pass after a fix) is strictly additional
+confirmation on top of the CI-log evidence — never required to reach HIGH
+confidence, and its absence is never grounds to lower confidence below what
+the accumulated CI evidence alone supports.
+
+---
+
+## Step 3: Root-Cause and Classify
+
+Determine which category the flake belongs to — this decides the fix
+strategy in Step 4. Do not default to "just flaky, add a retry" — a race
+condition in product code surfaced by a test is a real bug, not a test
+problem, even though it *manifests* as flakiness.
+
+| Category | Signature | Fix belongs in |
+|---|---|---|
+| **Shared/leaked state** | Test passes alone, fails alongside siblings; order-dependent; touches DB/fixtures another test also mutates | Test (isolate fixtures, don't disable parallelism — see `feedback_integ_test_isolation_per_worker` precedent: per-worker isolation, not disabling parallel execution) |
+| **Missing await / race in the test** | Assertion runs before an async side effect completes; timing-dependent selector waits (Playwright) | Test |
+| **Race in product code** | A fire-and-forget or unsynchronized async operation in application code (not the test) can observably run after the test's cleanup/assertion — e.g. a post-write side effect racing the same request's response | Product code |
+| **Environment timing** | Legitimately slow CI runner, no logic bug, but still worth quarantine if disruptive | Quarantine only, do not "fix" nonexistent code |
+
+Use `git log --oneline -20 -- {SPEC_PATH}` and read the code under test to
+tell "shared state" from "product race" — a test that fails only when run
+after a specific sibling usually points at a fixture; a test that fails with
+an error surfaced from a service/model file (not the spec file itself) in
+the log's stack trace usually points at a product-code race worth reading
+carefully before dismissing as test flakiness.
+
+---
+
+## Step 4: Fix-Approach Decision Gate
+
+**Confidence assessment:**
+
+| Situation | Confidence |
+|---|---|
+| Root cause pinpointed (category from Step 3 is clear, consistent with the Step 2 rerun tally) + fix is surgical (1-2 files) | HIGH |
+| Root cause identified but fix touches product code with broader blast radius, or category is ambiguous between "shared state" and "product race" | MEDIUM |
+| Reruns failed 100% of the time (looks like a real regression, not a flake — see Step 2's note) | MEDIUM — flag this explicitly, do not silently treat it as a flaky-test fix |
+| CI evidence and reruns alone do not localize a cause | LOW |
+
+**In `autonomous` mode:**
+- **HIGH** → proceed to Step 5 automatically. State the category and planned fix.
+- **MEDIUM or LOW** → stop and ask, presenting: reproduction result, suspected
+  category, why confidence isn't HIGH, and a recommendation among: 1) proceed
+  with the best-guess fix, 2) quarantine with a comment linking this issue
+  (only ever a stop-gate outcome, never an autonomous default), 3) escalate
+  for human review of the product code, 4) close as unable to reproduce after
+  N cycles (only if reproduction attempts genuinely found nothing across
+  every method in Step 2).
+
+**In `interactive` mode:** always ask.
+
+**Quarantine guardrail**: never mark a test `.skip`/`.todo` as the
+autonomous-HIGH default outcome. Quarantine is legitimate only as an
+explicitly chosen MEDIUM/LOW-gate outcome (interactive approval, or
+autonomous only when the category is "Environment timing" with no code path
+to fix), and the quarantine commit must reference this issue number in a
+comment so it is discoverable later.
+
+---
+
+## Step 5: Implement
+
+### 5-A: Branch
+
+```bash
+git checkout -b fix/flaky-{ISSUE_NUMBER}-{short-description}
+```
+
+### 5-B: Fix
+
+Apply the fix matching the Step 3 category. Whatever the category, the
+verification bar is higher than a normal bug fix: a flaky test that "looks
+fixed" after one green run has not been shown to be fixed.
+
+Both essential-test-design and essential-test-patterns skills apply here —
+consult them if the fix touches test code, same as any other test change in
+this repo (`.claude/rules/testing.md`).
+
+Push the fix to the branch and open the PR (Step 6) *before* running
+verification — verification here means repeatedly re-running the PR's own
+real CI, which needs the PR to exist and its checks to have run at least
+once. If the environment happens to support local execution (probed in Step
+2), run that too as a fast pre-push sanity check, but it never substitutes
+for the PR-CI-based verification in Step 6.
+
+### 5-C: Commit
+
+```
+fix(scope): stabilize flaky test — {short root cause}
+
+Fixes #{ISSUE_NUMBER}
+```
+
+---
+
+## Step 6: Verify via Real CI, Then the PR Readiness Gate
+
+Verification needs the fix's own commit to run through GitHub Actions' real
+MongoDB/Elasticsearch/browsers — that only happens once the branch is
+pushed and a PR exists to run checks against. So the sequence here is
+**open as draft first, verify, then decide whether to mark it ready** —
+not the reverse.
+
+### 6-A: Open a draft PR
+
+```bash
+gh pr create --repo growilabs/growi --draft \
+  --title "fix: stabilize flaky test in {short scope}" \
+  --body "$(cat <<'EOF'
+## Summary
+
+{description of the fix}
+
+## Root Cause
+
+{category from Step 3 + specific mechanism}
+
+## Verification
+
+In progress — re-running CI to confirm the fix holds across repeated
+executions (see comments below). This PR stays draft until that completes.
+
+Fixes #{ISSUE_NUMBER}
+EOF
+)"
+```
+
+### 6-B: Re-run this PR's CI for a repeat-green tally
+
+Let the PR's initial CI run complete, then rerun the **whole run** (not
+`--failed` — it should already be green, you're building repeat-pass
+evidence, not chasing a failure) 2-3 times:
+
+```bash
+gh run rerun {PR_RUN_ID} --repo growilabs/growi
+gh run watch {PR_RUN_ID} --repo growilabs/growi
+```
+
+This is the direct equivalent of the old local `--repeat=20` /
+`--repeat-each=10`, except it runs on real CI infrastructure regardless of
+what this skill's own execution environment supports.
+
+### 6-C: Confidence Assessment
+
+| Situation | Confidence |
+|---|---|
+| All reruns green + lint passes + fix stayed in scope | HIGH |
+| All reruns green but fix touched product code beyond the originally suspected file | MEDIUM |
+| Any rerun still shows the original failure, or lint/type errors | LOW |
+
+**Autonomous**: HIGH → mark the PR ready and update its body with the
+verification tally (see 6-D). MEDIUM/LOW → stop and ask, leaving the PR in
+draft, presenting the rerun tally and a recommendation (same four-option
+shape as Step 4, plus "close the PR and downgrade to a comment on the
+issue" when a rerun shows the original failure recurring).
+
+**Interactive**: always ask, same options.
+
+### 6-D: Mark Ready and Update Labels (HIGH confidence, or after approval)
+
+```bash
+gh pr ready {PR_NUMBER} --repo growilabs/growi
+gh pr edit {PR_NUMBER} --repo growilabs/growi --body "$(cat <<'EOF'
+{same body as 6-A, with the Verification section replaced by:}
+
+## Verification
+
+- Re-ran this PR's CI {N} times after the initial pass — {N}/{N} green.
+{- local reproduction result, if the environment supported it (bonus tier)}
+
+Fixes #{ISSUE_NUMBER}
+EOF
+)"
+
+gh issue edit {ISSUE_NUMBER} --repo growilabs/growi --remove-label "{EXACT_PHASE_UNDER_INVESTIGATION_LABEL}" --add-label "{EXACT_PHASE_RESOLVED_LABEL}"
+```
+
+(`flaky/confirmed` stays — it is a permanent record that this issue was a
+real, confirmed flake, not something to remove on resolution. If the same
+identity key resurfaces after this merges, `detect-flaky-ci`'s "existing
+CLOSED issue found" path reopens it automatically — that recurrence check is
+the long-term backstop this skill's verification ultimately relies on, on
+top of the repeat-CI tally above.)
+
+---
+
+## Error Handling
+
+- Issue is not `flaky/confirmed`: stop, do not investigate (see Precondition).
+- Reproduction impossible in devcontainer (e.g. browser deps missing): fall
+  back to log-based analysis, note the limitation, and do not let this alone
+  push confidence below what the CI evidence already supports.
+- Fix requires product-code changes with security/auth/data implications:
+  treat as MEDIUM or LOW regardless of how clear the race looks — this skill
+  is not a substitute for `security-reviewer` on sensitive code paths.


### PR DESCRIPTION
## Summary

Adds tooling for finding and fixing non-deterministic ("flaky") CI failures automatically:

- `.claude/skills/detect-flaky-ci` — scans recent CI runs (`Node CI for app development`, `Node CI for app production`), classifies failures as infra noise vs. candidate flakiness, and tracks candidates as GitHub issues (labels `flaky/observing` → `flaky/confirmed`). Detection only — never touches source code.
- `.claude/skills/investigate-flaky-test` — investigates a `flaky/confirmed` issue, classifies the root cause (shared test state / missing await / product-code race / environment timing), fixes it, and opens a PR. Mirrors `investigate-issue`'s confidence-gated, `--auto`-capable shape.
- `.claude/commands/{detect-flaky-ci,investigate-flaky-test,flaky-ci-routine}.md` — thin manual-invocation wrappers; `/flaky-ci-routine` sequences the two skills for use from a cron routine.

Verification in `investigate-flaky-test` uses `gh run rerun` to re-execute the real CI job (real MongoDB/Elasticsearch/browsers) rather than local test execution, so the routine can run unattended from a cloud environment that has none of those services locally.

Two new labels were created on the repo: `flaky/observing`, `flaky/confirmed`.

A daily cron routine (`growi-flaky-ci-routine`) has been registered to run `/flaky-ci-routine`, currently pointed at this branch for validation before it's switched to track `master` post-merge.

## Test Plan

- [x] Design reviewed twice via `advisor` (architecture choice, then post-write review that caught a title/search dedup mismatch, an unfiltered workflow scan, and an over-claimed Playwright per-test attribution — all fixed)
- [x] First unattended cloud run correctly detected its own missing prerequisites (this PR's files not yet merged, `gh` not installed) and stopped without improvising — no false action taken
- [ ] Re-run the cloud routine against this branch after the `gh` bootstrap step (added in this PR) to confirm write access to issues/labels/PRs
- [ ] After merge, point the cron routine at `master` and confirm a full detect → issue → investigate cycle end-to-end