### PR TITLE
fix: use gh api REST instead of GraphQL-backed gh --json in flaky-CI skills

### DIFF
--- a/.claude/commands/flaky-ci-routine.md
+++ b/.claude/commands/flaky-ci-routine.md
@@ -12,40 +12,56 @@ self-contained skill usable on its own. Keeping the sequencing here (rather
 than inline in a cron prompt) means there is one place to read or edit the
 chain, whether it's triggered by cron or run by hand.
 
-## Step 0 — Ensure `gh` is available and authenticated
+## Step 0 — Ensure `gh` is available and can write via REST
 
 Every step below depends on `gh`. This command is designed to also run from
-an unattended cloud routine whose checkout may not have `gh` preinstalled
-(confirmed missing in this project's cloud environment during setup) — do
-not assume it's on `PATH`.
+an unattended cloud routine whose checkout may not have `gh` preinstalled.
 
 ```bash
 if ! command -v gh >/dev/null 2>&1; then
-  echo "gh not found, bootstrapping a static binary..."
-  GH_VERSION="$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest | grep -m1 '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')"
-  curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" -o /tmp/gh.tar.gz
-  tar -xzf /tmp/gh.tar.gz -C /tmp
-  export PATH="/tmp/gh_${GH_VERSION}_linux_amd64/bin:$PATH"
+  echo "gh not found — installing"
+  # Prefer the system package manager: a cloud routine's egress proxy may
+  # only allow GitHub access scoped to growilabs/growi, which blocks a
+  # direct download from github.com/cli/cli's releases (confirmed: 403/404
+  # in this project's cloud environment). apt's archive is a different host
+  # and is not subject to that restriction.
+  if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get install -y gh 2>&1 || apt-get install -y gh 2>&1
+  fi
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "apt-get unavailable or failed — falling back to a static binary from github.com/cli/cli"
+    GH_VERSION="$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest | grep -m1 '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')"
+    curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" -o /tmp/gh.tar.gz
+    tar -xzf /tmp/gh.tar.gz -C /tmp
+    export PATH="/tmp/gh_${GH_VERSION}_linux_amd64/bin:$PATH"
+  fi
 fi
 gh --version
 ```
 
-Then confirm write access — a read-only check (`gh issue list`) is not
-enough evidence, since it succeeds even without a token. Actually attempt a
-harmless write and clean it up:
+Then confirm actual write capability — **do not trust `gh auth status`
+alone**: a cloud routine's `gh` session showed an "Active account: true"
+with a token `gh auth status` itself calls invalid, which is confusing but
+not the real signal to gate on either way. The real constraint (confirmed
+empirically) is narrower and stranger than "authenticated or not": this
+environment's `gh` sits behind an egress proxy that serves plain REST calls
+to `repos/{owner}/{repo}/...` with real data, but rejects `gh`'s
+GraphQL-backed commands — which includes `--json` on `gh issue`/`gh label`/
+`gh pr` (NOT `gh run ...`, which is REST-only in GitHub's API regardless of
+`--json`, and unaffected). So probe with plain REST, since that's what
+every step in this routine actually uses (`detect-flaky-ci` and
+`investigate-flaky-test` were rewritten to use `gh api` for all
+issue/label/PR reads and writes for exactly this reason):
 
 ```bash
-gh auth status
-LABEL_TEST=$(gh label list --repo growilabs/growi --json name -q '.[0].name' 2>&1) \
-  && echo "read ok: $LABEL_TEST" || { echo "gh cannot read growilabs/growi — stopping"; exit 1; }
+gh api repos/growilabs/growi/labels -q '.[0].name' \
+  && echo "REST read ok" || { echo "gh api cannot read growilabs/growi via REST — stopping"; exit 1; }
 ```
 
-If `gh` cannot be installed, or `gh auth status` shows no authenticated
-account, or GitHub API calls fail with a permissions/auth error: **stop
-immediately and report this clearly** (this is exactly what happened the
-first time this routine ran unattended — treat a missing prerequisite as a
+If `gh` cannot be installed, or the REST probe above fails: **stop
+immediately and report this clearly** — treat a missing prerequisite as a
 stop condition, not something to route around by improvising a different
-approach). Do not proceed to Step 1 without confirmed write access, since
+approach. Do not proceed to Step 1 without confirmed REST access, since
 Step 1 onward creates issues/labels/PRs and a failure partway through is
 harder to clean up than a clean stop before starting.
 
@@ -61,13 +77,15 @@ List issues that are confirmed flaky AND not already past the "new" stage
 routine run is not re-processed):
 
 ```bash
-gh label list --repo growilabs/growi --json name --limit 100
+gh api repos/growilabs/growi/labels --paginate -q '.[].name'
 ```
 
+REST's `labels` query parameter is an AND filter on comma-separated names
+(an issue must carry every listed label), which is exactly "confirmed AND
+still new":
+
 ```bash
-gh issue list --repo growilabs/growi --state open \
-  --label "flaky/confirmed" --label "{EXACT_PHASE_NEW_LABEL}" \
-  --json number,title
+gh api repos/growilabs/growi/issues -f state=open -f labels="flaky/confirmed,{EXACT_PHASE_NEW_LABEL}" --paginate -q '.[] | {number,title}'
 ```
 
 If this list is empty, report that and stop — there is nothing to

--- a/.claude/skills/detect-flaky-ci/SKILL.md
+++ b/.claude/skills/detect-flaky-ci/SKILL.md
@@ -220,25 +220,36 @@ Title format (fixed):
 e.g. `flaky: vitest:src/features/external-user-group/server/service/external-user-group-sync.integ.ts:syncs groups and deletes groups that do not exist externally`
 or `flaky: playwright:firefox` (job-level fallback identity).
 
-Search for an existing tracking issue using the identity key as an exact
-title match:
+**Use `gh api` (REST), not `gh issue list --json` / `--search`.** This
+skill is expected to also run from a cloud routine whose `gh` session sits
+behind an egress proxy that blocks `gh`'s GraphQL-backed commands — in
+practice, every `gh` subcommand that accepts `--json` on issues/labels/PRs
+(confirmed: `gh issue list --json`, `gh label list --json`) — while plain
+REST calls (`gh api repos/{owner}/{repo}/...`) go through. GitHub's
+Actions API (used in Steps 1–2 above) has no GraphQL equivalent at all, so
+`gh run ...` commands are unaffected regardless of `--json`; this
+restriction is specific to Issues/Labels/PRs commands.
+
+Fetch every issue carrying either flaky label (both states, so a resolved-
+and-since-reopened issue is still found) and look for an exact title match
+client-side — this is also more precise than GitHub's fuzzy search
+tokenization would have been:
 
 ```bash
-gh issue list --repo growilabs/growi --search "in:title \"{IDENTITY_KEY}\"" --state all --json number,title,labels,state
+gh api repos/growilabs/growi/issues -f state=all -f labels="flaky/observing" --paginate -q '.[] | {number,title,state}'
+gh api repos/growilabs/growi/issues -f state=all -f labels="flaky/confirmed" --paginate -q '.[] | {number,title,state}'
 ```
 
-After the search returns, still confirm the match: `gh search` does
-substring/token matching, not exact — verify at least one returned issue's
-`title` is exactly `flaky: {IDENTITY_KEY}` before treating it as the same
-issue, in case the search surfaced a partial/unrelated match.
+Treat an issue as the same tracking issue only if its `title` is **exactly**
+`flaky: {IDENTITY_KEY}` — do not fuzzy-match.
 
 ### No existing issue found
 
 Create one. Fetch exact label names first (names carry emoji prefixes and
-drift — never hardcode):
+drift — never hardcode), via REST rather than `gh label list --json`:
 
 ```bash
-gh label list --repo growilabs/growi --json name --limit 100
+gh api repos/growilabs/growi/labels --paginate -q '.[].name'
 ```
 
 ```bash
@@ -327,6 +338,12 @@ This is the only user-facing output — do not create files.
 
 ## Error Handling
 
+- Any `gh issue`/`gh label`/`gh pr` command fails with a GraphQL/proxy error
+  (e.g. "This GraphQL query is not enabled for this session"): switch that
+  specific call to its `gh api` REST equivalent (`-X POST`/`-X PATCH` for
+  mutations, e.g. `gh api repos/growilabs/growi/issues -X POST -f title=... -f body=...`
+  in place of `gh issue create`) and continue — this is an environment
+  constraint, not a reason to stop the whole run.
 - `gh api` rate limit hit: report how far the scan got and stop; do not retry
   in a tight loop.
 - A job log too large to fit in context: use `--log-failed` (already filters

--- a/.claude/skills/investigate-flaky-test/SKILL.md
+++ b/.claude/skills/investigate-flaky-test/SKILL.md
@@ -32,10 +32,12 @@ Supports the same two execution modes as `investigate-issue`:
 issue number and mode the same way `investigate-issue` does.
 
 **Precondition**: the issue must carry the `flaky/confirmed` label (fetch
-exact label names with `gh label list --repo growilabs/growi --json name`
-before comparing — never hardcode). If it is still `flaky/observing`, stop
-and report that `detect-flaky-ci` has not gathered enough evidence yet; do
-not attempt to lower the bar by investigating early.
+exact label names with `gh api repos/growilabs/growi/labels --paginate -q '.[].name'`
+before comparing — never hardcode, and use REST here, not
+`gh label list --json`, which a cloud routine's proxy-restricted `gh`
+session rejects — see Error Handling). If it is still `flaky/observing`,
+stop and report that `detect-flaky-ci` has not gathered enough evidence
+yet; do not attempt to lower the bar by investigating early.
 
 ---
 
@@ -50,9 +52,18 @@ this skill: the fix-classification gate (Step 4) and the PR gate (Step 6).
 
 ## Step 1: Fetch Issue Evidence
 
+Use REST (`gh api`), not `gh issue view --json` — the latter is
+GraphQL-backed and rejected by a cloud routine's proxy-restricted `gh`
+session (see Error Handling):
+
 ```bash
-gh issue view {ISSUE_NUMBER} --repo growilabs/growi --json number,title,body,labels,comments,url
+gh api repos/growilabs/growi/issues/{ISSUE_NUMBER}
+gh api repos/growilabs/growi/issues/{ISSUE_NUMBER}/comments --paginate
 ```
+
+The first call gives `title`, `body`, `labels[].name`, `html_url`, `state`;
+the second gives every comment (each observation `detect-flaky-ci` appended
+after the first).
 
 The title is `flaky: {IDENTITY_KEY}` (set by `detect-flaky-ci`), where
 `IDENTITY_KEY` is one of:
@@ -357,6 +368,12 @@ top of the repeat-CI tally above.)
 
 ## Error Handling
 
+- Any `gh issue`/`gh label`/`gh pr` command fails with a GraphQL/proxy error
+  (e.g. "This GraphQL query is not enabled for this session"): switch that
+  specific call to its `gh api` REST equivalent and continue — see
+  `detect-flaky-ci`'s Error Handling for the same note and example mutation
+  form. `gh run ...` commands (Actions API) are never affected by this,
+  since Actions has no GraphQL API to begin with.
 - Issue is not `flaky/confirmed`: stop, do not investigate (see Precondition).
 - Reproduction impossible in devcontainer (e.g. browser deps missing): fall
   back to log-based analysis, note the limitation, and do not let this alone


### PR DESCRIPTION
## Summary

Follow-up to #11704. The first real cloud-cron run of `/flaky-ci-routine` (against master, post-merge) surfaced that the cloud CCR session's `gh` sits behind an egress proxy that serves plain REST calls (`gh api repos/{owner}/{repo}/...`) with real data, but rejects `gh`'s GraphQL-backed commands — confirmed for `gh issue list --json` and `gh label list --json` ("This GraphQL query is not enabled for this session — only the pinned set of PR-review operations is served. Use REST via `gh api repos/{owner}/{repo}/...` instead."). GitHub's Actions API has no GraphQL equivalent at all, so `gh run ...` commands (used for the CI-scanning parts of `detect-flaky-ci`) are unaffected regardless of `--json`.

## Changes

- `detect-flaky-ci`: issue/label lookups now use `gh api` REST instead of `gh issue list --search --json` / `gh label list --json`. The dedupe search is also more precise as a side effect — exact title match on issues fetched by label, instead of GitHub's fuzzy `in:title` search.
- `investigate-flaky-test`: issue fetch (title/body/labels/comments) and the `flaky/confirmed` precondition check now use `gh api` REST.
- `flaky-ci-routine`: the Step 0 write-access probe now checks REST access specifically (the actual thing every step relies on) instead of `gh auth status` (which reported a confusing "Active account: true" alongside an invalid-token error, without being the real signal to gate on). The `gh` bootstrap also now tries `apt-get install gh` first — the direct-download fallback to `github.com/cli/cli`'s releases hit 403/404 in this project's cloud environment, since its egress proxy scopes GitHub access to `growilabs/growi`; apt's archive is a different host and isn't subject to that restriction.
- All three files gained an Error Handling note: any `gh issue`/`gh label`/`gh pr` command hitting this GraphQL/proxy error should fall back to its `gh api` REST equivalent rather than stopping the whole run.

## Test Plan

- [x] First cloud run-now correctly identified and stopped at this exact failure mode rather than improvising a workaround (see prior run's summary)
- [ ] Re-run the cloud routine (`growi-flaky-ci-routine`) after this merges to confirm Step 0 passes and `detect-flaky-ci` completes a full scan without a GraphQL error