### PR TITLE
fix(claude): cheap flaky suspicion mining + deterministic gh/MCP tool selection

### DIFF
--- a/.claude/commands/flaky-ci-routine.md
+++ b/.claude/commands/flaky-ci-routine.md
@@ -65,39 +65,70 @@ approach. Do not proceed to Step 1 without confirmed REST access, since
 Step 1 onward creates issues/labels/PRs and a failure partway through is
 harder to clean up than a clean stop before starting.
 
+### Job Log Fetch Method — decide once, for the whole run
+
+`detect-flaky-ci` and `investigate-flaky-test` both need to read CI job
+logs. `gh run view --log-failed` / `--log` works by following a signed
+redirect to a different domain (`results-receiver.actions.githubusercontent.com`
+/ `*.blob.core.windows.net`); a cloud routine's egress proxy blocks that
+redirect target regardless of whether the request comes from `gh` or a raw
+`gh api` call (confirmed empirically — this is a network policy on the
+redirect's destination domain, not a `gh`-vs-REST distinction). The GitHub
+MCP server's `mcp__github__get_job_logs` tool fetches the same content
+server-side and is not subject to that restriction.
+
+Decide the method **exactly once, here**, and pass it down rather than
+letting each skill probe (or worse, try-and-fall-back) independently per
+log fetch — the capability is a property of this environment for the whole
+run, not of any individual log:
+
+```
+if `mcp__github__get_job_logs` appears among your available tools: JOB_LOG_METHOD=mcp
+else: JOB_LOG_METHOD=gh
+```
+
+State `JOB_LOG_METHOD` explicitly when invoking `detect-flaky-ci` and
+`investigate-flaky-test` below (e.g. as a line in the prompt: "Job log
+fetch method for this run: {JOB_LOG_METHOD}"), and include it in this
+command's own Step 4 report.
+
 ## Step 1 — Detect
 
 Invoke the `detect-flaky-ci` skill with `$ARGUMENTS` passed through
-(`--lookback`, `--vitest-threshold`). Let it finish and report its summary.
+(`--lookback`, `--vitest-threshold`) plus the `JOB_LOG_METHOD` decided in
+Step 0. Let it finish and report its summary.
 
 ## Step 2 — Select newly-actionable issues
 
-List issues that are confirmed flaky AND not already past the "new" stage
-(so an issue already mid-investigation, WIP, or resolved from a prior
-routine run is not re-processed):
+List issues that are confirmed-or-suspected flaky AND not already past the
+"new" stage (so an issue already mid-investigation, WIP, or resolved from a
+prior routine run is not re-processed):
 
 ```bash
 gh api repos/growilabs/growi/labels --paginate -q '.[].name'
 ```
 
 REST's `labels` query parameter is an AND filter on comma-separated names
-(an issue must carry every listed label), which is exactly "confirmed AND
-still new":
+(an issue must carry every listed label), which is exactly "{tier} AND
+still new". Run it once per tier and merge the two lists — a single query
+can't OR two different tier labels together:
 
 ```bash
 gh api repos/growilabs/growi/issues -f state=open -f labels="flaky/confirmed,{EXACT_PHASE_NEW_LABEL}" --paginate -q '.[] | {number,title}'
+gh api repos/growilabs/growi/issues -f state=open -f labels="flaky/suspected,{EXACT_PHASE_NEW_LABEL}" --paginate -q '.[] | {number,title}'
 ```
 
-If this list is empty, report that and stop — there is nothing to
+If this combined list is empty, report that and stop — there is nothing to
 investigate this run.
 
 ## Step 3 — Investigate each, autonomously
 
 For each issue number found, invoke the `investigate-flaky-test` skill with
-`--auto`:
+`--auto`, passing the same `JOB_LOG_METHOD` decided in Step 0:
 
 ```
 investigate-flaky-test {ISSUE_NUMBER} --auto
+(Job log fetch method for this run: {JOB_LOG_METHOD})
 ```
 
 Run these **sequentially, one issue at a time** — not in parallel. Each
@@ -116,7 +147,10 @@ the list.
 
 ## Step 4 — Report
 
-Summarize the run: how many issues were newly confirmed by Step 1, how many
-were investigated in Step 3, how many resulted in a PR, how many were left
+Summarize the run: which `JOB_LOG_METHOD` Step 0 selected, how many issues
+were newly confirmed vs newly suspected by Step 1 (and, of the suspected
+ones, how many `investigate-flaky-test` promoted to confirmed via its
+one-time rerun vs left at suspected pending human review), how many were
+investigated in Step 3, how many resulted in a PR, how many were left
 pending human decision (and why), and how many were quarantined. This is the
 routine's output — nothing else needs to be written.

--- a/.claude/skills/detect-flaky-ci/SKILL.md
+++ b/.claude/skills/detect-flaky-ci/SKILL.md
@@ -33,6 +33,88 @@ this skill re-derives everything it needs by querying the tracker on each run.
   `flaky/confirmed`. Default `2`. (Playwright-detected flakiness always
   escalates on the first observation — see Step 3.)
 
+## Three Confidence Tiers
+
+Detection now produces one of three outcomes per candidate, cheapest evidence
+first:
+
+1. **`flaky/observing`** — a single vitest observation with no corroborating
+   signal (see "Cheap Suspicion Mining" below). Passive: waits for a future
+   run to repeat it (`--vitest-threshold`).
+2. **`flaky/suspected`** — a vitest observation that also matches one of the
+   three cheap, mechanical signals in "Cheap Suspicion Mining" (diff/PR
+   mismatch, sandwich pattern, or matrix divergence). No LLM judgment is
+   spent getting here — these are grep/diff-level checks against data this
+   skill already fetched. Handed to `investigate-flaky-test`, which spends
+   exactly one rerun to turn this into empirical proof.
+3. **`flaky/confirmed`** — either a Playwright in-run retry (unchanged from
+   before: the retry already IS the empirical proof, no further rerun
+   needed), or a `flaky/suspected` issue that `investigate-flaky-test`
+   reran once with no code change and watched pass.
+
+`detect-flaky-ci` only ever assigns tiers 1 and 3 (3 for Playwright only,
+unchanged). Tier 2 is new. `investigate-flaky-test` is the only skill that
+promotes tier 2 → tier 3 for vitest, because that promotion requires an
+actual rerun, which is an investigation action, not a detection action.
+
+## Cheap Suspicion Mining (vitest only)
+
+Before falling back to passive `--vitest-threshold` accumulation, check each
+vitest failure identity against three mechanical signals. All three are
+grep/diff/API-field comparisons — no log-content reasoning, no code reading.
+Run them in this order and stop at the first hit (cheapest first):
+
+**① Diff / PR-description mismatch.** Fetch the commit's associated PR (if
+any):
+
+```bash
+gh api repos/growilabs/growi/commits/{HEAD_SHA}/pulls -q '.[0].number'
+```
+
+If a PR exists, fetch its changed files and description:
+
+```bash
+gh api repos/growilabs/growi/pulls/{PR_NUMBER}/files --paginate -q '.[].filename'
+gh api repos/growilabs/growi/pulls/{PR_NUMBER} -q '.body'
+```
+
+If the failing spec's `SPEC_PATH` (and the module paths appearing in the
+failure's stack trace) are absent from the changed-files list, **and** the
+PR description does not mention the failing area, this failure is very
+likely unrelated to what the PR actually changed — suspicious. If the run
+has no associated PR (a direct push to `master`, e.g. a merge-queue commit),
+compare against that commit's own diff instead
+(`gh api repos/growilabs/growi/commits/{HEAD_SHA} -q '.files[].filename'`)
+and skip the description check.
+
+**② Sandwich pattern.** Within the `--lookback` window already fetched in
+Step 1, look for the same vitest identity key failing in two (or more) runs
+with a run of the *same job* in between that succeeded. A failure that
+disappears and reappears with an identical signature is stronger evidence of
+non-determinism than two failures with nothing but other failures between
+them (which looks more like an unfixed, ongoing regression). This does not
+require a new API call — it's a re-read of the Step 1 run list plus the
+Step 2 job results you already have from previous scans (this run's and, if
+available, prior observation comments on an existing `flaky/observing`
+issue, which already record run URLs/dates).
+
+**③ Matrix divergence.** `ci-app-test-integration` runs a
+node/MongoDB-version matrix (see any recent job name, e.g.
+`ci-app-test-integration (24.x, 8.0, 8, 8.19.16)`). If the same commit's
+other matrix cells for the same job **passed** while this one failed, that
+is a same-commit, zero-wait signal — no need to wait for a future run at
+all. Get sibling job results from the Step 2 jobs-list call you already made
+for this run (`gh api repos/growilabs/growi/actions/runs/{RUN_ID}/jobs`) —
+filter by job name prefix, compare conclusions.
+
+If none of the three hit, fall through to the existing passive
+`flaky/observing` / `--vitest-threshold` path unchanged — these mechanical
+checks are a fast lane on top of the old path, not a replacement for it.
+Genuinely subtle flakiness that doesn't show up in a diff/PR mismatch, a
+sandwich, or a matrix split still needs the old accumulation path (or a
+human/LLM eyeballing it later) — these three checks are deliberately not
+exhaustive.
+
 ## Why vitest and Playwright are handled differently
 
 - **Playwright** runs with `retries: 2` in CI (`apps/app/playwright.config.ts`).
@@ -61,21 +143,33 @@ Watched workflows (by their GitHub Actions display name, not the file name):
 - `Node CI for app production` — hosts `run-playwright` (via the reusable
   `Reusable build and test app for production` workflow)
 
-Query **each workflow separately** with `gh run list --workflow` — do not
-pull the unfiltered `actions/runs` list and filter client-side, the repo runs
-several other workflows (CodeQL, Auto-labeling, Auto approve PR, ...) and a
-generic `--lookback` window of recent runs across all of them can leave
-zero, or only a handful, of the two workflows actually being watched:
+Query **each workflow separately** — do not pull the unfiltered
+`actions/runs` list and filter client-side, the repo runs several other
+workflows (CodeQL, Auto-labeling, Auto approve PR, ...) and a generic
+`--lookback` window of recent runs across all of them can leave zero, or
+only a handful, of the two workflows actually being watched.
+
+**Use `gh api` against the workflow's own runs endpoint, not
+`gh run list --json`.** `gh run list --json` validates the requested fields
+against a fixed, gh-CLI-version-specific struct — this repo's cloud routine
+runs gh 2.45.0, which does not know the `attempt` field
+(`Unknown JSON field: "attempt"`) and fails the whole command outright, not
+just that field. `gh api` has no such client-side field allowlist — it is a
+thin passthrough to GitHub's REST response, which already includes
+`run_attempt` (among everything else) regardless of gh CLI version:
 
 ```bash
-gh run list --repo growilabs/growi --workflow "Node CI for app development" \
-  --limit {LOOKBACK} --status completed \
-  --json databaseId,conclusion,headSha,createdAt,url,event,attempt
+gh api "repos/growilabs/growi/actions/workflows/ci-app.yml/runs?per_page={LOOKBACK}&status=completed" \
+  -q '.workflow_runs[] | {databaseId: .id, conclusion, headSha: .head_sha, createdAt: .created_at, url: .html_url, event, attempt: .run_attempt}'
 
-gh run list --repo growilabs/growi --workflow "Node CI for app production" \
-  --limit {LOOKBACK} --status completed \
-  --json databaseId,conclusion,headSha,createdAt,url,event,attempt
+gh api "repos/growilabs/growi/actions/workflows/ci-app-prod.yml/runs?per_page={LOOKBACK}&status=completed" \
+  -q '.workflow_runs[] | {databaseId: .id, conclusion, headSha: .head_sha, createdAt: .created_at, url: .html_url, event, attempt: .run_attempt}'
 ```
+
+(`ci-app.yml` = "Node CI for app development", `ci-app-prod.yml` = "Node CI
+for app production" — confirm with
+`gh api repos/growilabs/growi/actions/workflows -q '.workflows[] | {name,path}'`
+if these file names ever change.)
 
 This naturally includes pull_request and merge-queue-triggered runs (the
 merge queue is where today's investigation actually surfaced a failure — a
@@ -106,10 +200,28 @@ newer push, not evidence of anything):
 gh api repos/growilabs/growi/actions/runs/{RUN_ID}/jobs -q '.jobs[] | select(.conclusion == "failure") | {id, name}'
 ```
 
-Fetch each failed job's log:
+Fetch each failed job's log using **whichever method Step 0 of
+`flaky-ci-routine.md` decided for this run** (see that command's "Job Log
+Fetch Method" probe — it is decided once, at the very start of the routine,
+not re-decided per log). If invoked standalone (not via `/flaky-ci-routine`),
+do that same one-time probe yourself before this step: check whether
+`mcp__github__get_job_logs` appears in your available tools; if so, use it
+for every job log fetch below; if not, use `gh run view --log-failed`. Do
+not try one and fall back to the other per log — that produces
+run-to-run-inconsistent behavior for no benefit, since the capability is a
+property of the environment, not of any individual log fetch.
 
 ```bash
+# gh path (devcontainer / any environment where the egress proxy allows
+# results-receiver.actions.githubusercontent.com and *.blob.core.windows.net)
 gh run view {RUN_ID} --repo growilabs/growi --job {JOB_ID} --log-failed
+```
+
+```
+# MCP path (cloud routine — the blob-storage redirect above is Forbidden
+# through this environment's egress proxy; the MCP tool fetches server-side
+# instead)
+mcp__github__get_job_logs(owner="growilabs", repo="growi", job_id={JOB_ID}, failed_only=true)
 ```
 
 ### Step 2b: also check successful `run-playwright` jobs for in-run flakes
@@ -125,9 +237,15 @@ conclusion, not just failed runs), grepping rather than reading the full log
 to keep this cheap:
 
 ```bash
+# gh path
 gh run view {RUN_ID} --repo growilabs/growi --job {JOB_ID} --log \
   | grep -iE "flaky|Retry #|^:*error file="
+
+# MCP path — fetch then grep the returned text the same way
+mcp__github__get_job_logs(owner="growilabs", repo="growi", job_id={JOB_ID}, failed_only=false)
 ```
+
+Use the same Step-0-decided method as the failed-job fetch above.
 
 If this is empty, the shard had no flakiness — move on. If it has a
 ` flaky` count > 0, proceed to Step 3's Playwright extraction using this
@@ -203,8 +321,10 @@ FAIL {app-integration|...} {SPEC_PATH} > {SUITE} > {TEST_TITLE}
 
 Identity key: `vitest:{SPEC_PATH}:{TEST_TITLE}`.
 
-This is an **observation**, not a confirmation — proceed to Step 4 to decide
-whether it crosses the threshold.
+This is an **observation**, not a confirmation. Before proceeding to Step 4,
+run it through "Cheap Suspicion Mining" above — a hit there makes this a
+**suspected** occurrence (tier 2) instead of a plain observation (tier 1).
+Either way, proceed to Step 4.
 
 ## Step 4: Reconcile Against Existing Issues
 
@@ -237,6 +357,7 @@ tokenization would have been:
 
 ```bash
 gh api repos/growilabs/growi/issues -f state=all -f labels="flaky/observing" --paginate -q '.[] | {number,title,state}'
+gh api repos/growilabs/growi/issues -f state=all -f labels="flaky/suspected" --paginate -q '.[] | {number,title,state}'
 gh api repos/growilabs/growi/issues -f state=all -f labels="flaky/confirmed" --paginate -q '.[] | {number,title,state}'
 ```
 
@@ -256,12 +377,12 @@ gh api repos/growilabs/growi/labels --paginate -q '.[].name'
 gh issue create --repo growilabs/growi \
   --title "flaky: {IDENTITY_KEY}" \
   --label "type/bug" --label "{EXACT_PHASE_NEW_LABEL}" \
-  --label "{flaky/confirmed if Step 3 evidence is already confirmed, else flaky/observing}" \
+  --label "{TIER_LABEL}" \
   --body "$(cat <<'EOF'
 ## Detected by detect-flaky-ci
 
 **Identity key**: `{IDENTITY_KEY}`
-**Kind**: {playwright | vitest} {(strong evidence: passed on in-run retry) if confirmed}
+**Kind**: {playwright | vitest} {(strong evidence: passed on in-run retry) if confirmed} {(cheap suspicion: {① diff/PR mismatch | ② sandwich pattern | ③ matrix divergence}) if suspected}
 
 ### First observation
 
@@ -276,12 +397,21 @@ gh issue create --repo growilabs/growi \
 {relevant log excerpt — the FAIL block or the ::error annotation + retry blocks}
 ```
 
+{if suspected, additionally include the specific mining evidence: e.g. "PR #{N} changed {files}, none overlap this spec's path or stack trace" / "same identity failed in run {A}, passed in intervening run {B}, failed again here" / "sibling matrix job {NAME} on the same commit passed"}
+
 ### Status
 
-{"Confirmed flaky from a single run (Playwright retry evidence)." if confirmed else "Observation 1/{VITEST_THRESHOLD} — needs {VITEST_THRESHOLD - 1} more independent occurrence(s) before this is handed to investigate-flaky-test."}
+{pick exactly one:
+ - confirmed (Playwright): "Confirmed flaky from a single run (Playwright retry evidence)."
+ - suspected (vitest, mining hit): "Suspected flaky ({① | ② | ③}) — handed directly to investigate-flaky-test for a one-time confirmation rerun, no threshold wait needed."
+ - observing (vitest, no mining hit): "Observation 1/{VITEST_THRESHOLD} — needs {VITEST_THRESHOLD - 1} more independent occurrence(s) before this is handed to investigate-flaky-test."}
 EOF
 )"
 ```
+
+`{TIER_LABEL}` is `flaky/confirmed` for Playwright, `flaky/suspected` for a
+vitest observation that hit one of the three mining checks, `flaky/observing`
+for a plain vitest observation with no mining hit.
 
 ### Existing OPEN issue found, currently `flaky/observing`
 
@@ -303,13 +433,30 @@ EOF
 )"
 ```
 
-Count observation comments (initial issue body counts as observation 1) plus
-this new one. If the count reaches `--vitest-threshold` (or this evidence
-item is itself a "confirmed" one per Step 3), escalate:
+Then check both escalation paths, in this order:
 
-```bash
-gh issue edit {NUMBER} --repo growilabs/growi --remove-label "flaky/observing" --add-label "flaky/confirmed"
-```
+1. **Does this new observation itself hit a mining check** (① / ② / ③,
+   re-run against the accumulated history now that there are 2+ occurrences
+   to compare)? If so, escalate straight to `flaky/suspected`, skipping the
+   threshold wait entirely:
+   ```bash
+   gh issue edit {NUMBER} --repo growilabs/growi --remove-label "flaky/observing" --add-label "flaky/suspected"
+   ```
+2. Otherwise, count observation comments (initial issue body counts as
+   observation 1) plus this new one. If the count reaches
+   `--vitest-threshold`, escalate the old way — straight to
+   `flaky/confirmed` (unchanged: two independent naturally-occurring
+   observations without any mining hit is already the passive path's own
+   confidence bar, no extra rerun gate added on top of it):
+   ```bash
+   gh issue edit {NUMBER} --repo growilabs/growi --remove-label "flaky/observing" --add-label "flaky/confirmed"
+   ```
+
+### Existing OPEN issue found, currently `flaky/suspected`
+
+Still append the observation comment (useful evidence for
+`investigate-flaky-test`'s confirmation rerun), but do not change labels —
+it is already queued for investigation.
 
 ### Existing OPEN issue found, already `flaky/confirmed`
 
@@ -331,10 +478,12 @@ gh issue edit {NUMBER} --repo growilabs/growi --add-label "flaky/confirmed" --re
 
 ## Step 5: Report
 
-Print a short summary of this run: how many runs/jobs scanned, how many
-classified as infra noise (with which pattern), how many new issues created,
-how many existing issues updated, how many escalated to `flaky/confirmed`.
-This is the only user-facing output — do not create files.
+Print a short summary of this run: which job-log fetch method Step 0 chose
+(`gh` or `mcp`), how many runs/jobs scanned, how many classified as infra
+noise (with which pattern), how many new issues created, how many existing
+issues updated, how many escalated to `flaky/suspected` (and via which of
+the three mining checks) vs `flaky/confirmed`. This is the only user-facing
+output — do not create files.
 
 ## Error Handling
 
@@ -353,3 +502,17 @@ This is the only user-facing output — do not create files.
   underlying flake): do not attempt fuzzy matching — treat as a new issue.
   False negatives here (a missed dedupe) are cheap; false positives (wrongly
   merging two different flakes) are not.
+- Job log content unreachable via either method (`gh run view --log*`
+  returns Forbidden, or `mcp__github__get_job_logs` is not among your
+  available tools): this is the known blob-storage-redirect restriction
+  (see the Job Log Fetch Method note in Steps 2/2b) — it means the Step 0
+  probe in `flaky-ci-routine.md` picked wrong, or this skill is running
+  standalone in an environment with neither path available. Report which
+  jobs could not be evidenced and continue with what you can read (run/job
+  metadata, conclusions) rather than stopping the whole scan; do not
+  silently skip affected runs without reporting them in Step 5.
+- Cheap suspicion mining (① / ② / ③) finds no clean signal either way
+  (e.g. a PR touches half the repo, or matrix siblings are also failing for
+  unrelated reasons): do not force a tier — fall through to
+  `flaky/observing` and let the passive threshold path handle it. These
+  checks are a fast lane, not a required gate.

--- a/.claude/skills/investigate-flaky-test/SKILL.md
+++ b/.claude/skills/investigate-flaky-test/SKILL.md
@@ -31,13 +31,29 @@ Supports the same two execution modes as `investigate-issue`:
 `$ARGUMENTS` is an issue URL or number, optionally with `--auto`. Parse the
 issue number and mode the same way `investigate-issue` does.
 
-**Precondition**: the issue must carry the `flaky/confirmed` label (fetch
-exact label names with `gh api repos/growilabs/growi/labels --paginate -q '.[].name'`
-before comparing — never hardcode, and use REST here, not
-`gh label list --json`, which a cloud routine's proxy-restricted `gh`
-session rejects — see Error Handling). If it is still `flaky/observing`,
-stop and report that `detect-flaky-ci` has not gathered enough evidence
-yet; do not attempt to lower the bar by investigating early.
+**Precondition**: the issue must carry `flaky/confirmed` **or**
+`flaky/suspected` (fetch exact label names with
+`gh api repos/growilabs/growi/labels --paginate -q '.[].name'` before
+comparing — never hardcode, and use REST here, not `gh label list --json`,
+which a cloud routine's proxy-restricted `gh` session rejects — see Error
+Handling). If it is still `flaky/observing`, stop and report that
+`detect-flaky-ci` has not gathered enough evidence yet; do not attempt to
+lower the bar by investigating early.
+
+These two accepted labels mean different things and change Step 2:
+
+- **`flaky/confirmed`** — already empirically proven (Playwright's in-run
+  retry already IS the proof, or a prior vitest threshold-accumulation
+  already reached two independent observations). No confirmation rerun is
+  owed here before proceeding to root-cause work — go straight into Step 2's
+  existing evidence-gathering.
+- **`flaky/suspected`** — `detect-flaky-ci`'s cheap mechanical mining (diff/
+  PR mismatch, sandwich pattern, or matrix divergence) found this, but
+  nothing has actually reproduced it live yet. This skill owes it exactly
+  **one** confirmation rerun (not the 2-3 tally used elsewhere in this
+  skill — that budget is for a different purpose, see Step 2) before
+  treating the flakiness itself as real. See "Step 2, `flaky/suspected`
+  path" below.
 
 ---
 
@@ -96,28 +112,67 @@ gh issue edit {ISSUE_NUMBER} --repo growilabs/growi --remove-label "{EXACT_PHASE
 
 ## Step 2: Gather Evidence
 
-**Primary tier — CI log analysis (always available, no live services
-needed).** This skill is expected to run unattended, including from a cloud
-routine whose checkout has no MongoDB replica set, no Elasticsearch, and no
+### `flaky/suspected` path: kick off the confirmation rerun first, in parallel
+
+If the issue's label is `flaky/suspected` (see Precondition), start its
+one-time confirmation rerun **before** doing anything else in this step, so
+it executes in the background while the static analysis below reads:
+
+```bash
+gh run rerun {RUN_ID} --repo growilabs/growi --failed
+```
+
+where `{RUN_ID}` is the run cited in the issue's "First observation" (or
+the mining evidence, if a later comment's observation is what triggered the
+mining hit). Do not wait for it here — proceed immediately to the static
+analysis below, and only come back to check this rerun's result at the end
+of this step, right before Step 3. This is a single rerun, not the 2-3
+tally used in the "second tier" below — that tally is a different budget
+for a different purpose (root-cause confidence), spent later, in Step 4/6.
+
+When you check back: if the rerun **passed** with no code change, that is
+empirical proof of flakiness — escalate the label before continuing:
+
+```bash
+gh issue edit {ISSUE_NUMBER} --repo growilabs/growi --remove-label "flaky/suspected" --add-label "flaky/confirmed"
+```
+
+If it **failed again**, you cannot yet tell "still flaky, unlucky twice"
+from "actually a real regression that only looks CI-specific" with a single
+data point — do not silently treat this as confirmed. Carry it into Step 4
+as an explicit caveat (same handling as "reruns failed 100% of the time" in
+that step's confidence table) rather than assuming the mining hit was
+correct.
+
+### Primary tier — CI log analysis (always available, no live services needed)
+
+This skill is expected to run unattended, including from a cloud routine
+whose checkout has no MongoDB replica set, no Elasticsearch, and no
 browsers. Do not make CI-log analysis a fallback for when reproduction
 "isn't available" — treat it as the normal, primary path, and treat live
 reproduction (below) as a bonus when the current environment happens to
 support it.
 
 Pull more history than what's already in the issue, using the same tools
-`detect-flaky-ci` uses:
+`detect-flaky-ci` uses (the `gh api .../actions/workflows/{file}/runs` REST
+calls from its Step 1 — not `gh run list --json`, for the same
+version-fragility reason given there):
 
 ```bash
 # Vitest: how often does this exact test appear as FAIL across recent runs
 # of the job that hosts it?
-gh run list --repo growilabs/growi --workflow "Node CI for app development" --limit 50 --status completed --json databaseId,conclusion,headSha,createdAt
+gh api "repos/growilabs/growi/actions/workflows/ci-app.yml/runs?per_page=50&status=completed" \
+  -q '.workflow_runs[] | {databaseId: .id, conclusion, headSha: .head_sha, createdAt: .created_at}'
 
 # Playwright: how often does this spec/browser show up in Retry#/flaky
 # evidence across recent run-playwright jobs?
-gh run list --repo growilabs/growi --workflow "Node CI for app production" --limit 50 --status completed --json databaseId,conclusion,headSha,createdAt
+gh api "repos/growilabs/growi/actions/workflows/ci-app-prod.yml/runs?per_page=50&status=completed" \
+  -q '.workflow_runs[] | {databaseId: .id, conclusion, headSha: .head_sha, createdAt: .created_at}'
 ```
 
-For each candidate run, fetch the relevant job's log (same commands as
+For each candidate run, fetch the relevant job's log (same method Step 0 of
+`flaky-ci-routine.md` decided — `gh run view --log*` or
+`mcp__github__get_job_logs`, whichever this run is using; see
 `detect-flaky-ci` Step 2/2b) and grep for the test title. Build a picture of:
 how often it fails, whether the failure mode is identical every time (points
 to a deterministic race, easier to fix) or varies (points to genuine timing
@@ -217,6 +272,7 @@ carefully before dismissing as test flakiness.
 | Root cause pinpointed (category from Step 3 is clear, consistent with the Step 2 rerun tally) + fix is surgical (1-2 files) | HIGH |
 | Root cause identified but fix touches product code with broader blast radius, or category is ambiguous between "shared state" and "product race" | MEDIUM |
 | Reruns failed 100% of the time (looks like a real regression, not a flake — see Step 2's note) | MEDIUM — flag this explicitly, do not silently treat it as a flaky-test fix |
+| Issue came in as `flaky/suspected` and its one confirmation rerun (Step 2) also failed | MEDIUM — the mining hit alone is not empirical proof; say explicitly that the confirmation rerun did not reproduce a pass, so this could be a real regression rather than a flake, and that only one rerun was budgeted (not the 100%-tally case above) |
 | CI evidence and reruns alone do not localize a cause | LOW |
 
 **In `autonomous` mode:**
@@ -374,7 +430,16 @@ top of the repeat-CI tally above.)
   `detect-flaky-ci`'s Error Handling for the same note and example mutation
   form. `gh run ...` commands (Actions API) are never affected by this,
   since Actions has no GraphQL API to begin with.
-- Issue is not `flaky/confirmed`: stop, do not investigate (see Precondition).
+- Issue is neither `flaky/confirmed` nor `flaky/suspected`: stop, do not
+  investigate (see Precondition).
+- A human approves proceeding with a best-guess fix at a MEDIUM gate for an
+  issue that came in as `flaky/suspected` and whose confirmation rerun
+  failed (Step 2/Step 4): the label is still `flaky/suspected` at that
+  point, not `flaky/confirmed` — do not silently promote it. Leave the
+  label as-is and let the PR body's Root Cause section carry the caveat
+  that this was never empirically reproduced; only Step 6-D's "reruns
+  green" evidence (a different, later rerun of the PR's own CI) is grounds
+  to also flip the label to `flaky/confirmed` at that point.
 - Reproduction impossible in devcontainer (e.g. browser deps missing): fall
   back to log-based analysis, note the limitation, and do not let this alone
   push confidence below what the CI evidence already supports.


### PR DESCRIPTION
## Summary

Follow-up to #11706. Two known-broken paths from that PR's real-world cloud
run (see session notes) are fixed, plus a new cheap detection tier is added.

### Fixed: deterministic tool selection

- `detect-flaky-ci` Step 1 used `gh run list --json ...,attempt`, which
  fails outright on the cloud routine's gh 2.45.0 (`Unknown JSON field:
  "attempt"`) — `gh`'s `--json` validates fields against a version-specific
  struct. Replaced with `gh api repos/.../actions/workflows/{file}/runs`, a
  version-independent REST passthrough. `investigate-flaky-test`'s
  equivalent history pull was updated the same way for consistency.
- Job log fetching (`gh run view --log-failed`/`--log`) follows a signed
  redirect to a different domain (blob storage), which the cloud routine's
  egress proxy blocks regardless of whether the request comes from `gh` or
  raw `gh api` — confirmed empirically, this is a redirect-target-domain
  restriction, not a gh-vs-REST distinction. The GitHub MCP server's
  `get_job_logs` tool fetches server-side and isn't subject to it. Rather
  than trying one method and falling back to the other per log fetch
  (non-deterministic, environment-dependent behavior decided repeatedly),
  `flaky-ci-routine.md` Step 0 now decides the method exactly once per run
  and threads it through both skills.

### New: cheap suspicion mining (flaky/suspected tier)

Vitest flakiness previously only escalated via `--vitest-threshold`
(passive accumulation across multiple days of cron runs). Three cheap,
mechanical checks — no LLM log-content reasoning — can now promote a single
observation straight to a new `flaky/suspected` label within the same scan:

1. **Diff/PR-description mismatch** — the failing spec/stack-trace paths
   aren't among the PR's (or commit's) changed files, and the PR
   description doesn't mention the failing area.
2. **Sandwich pattern** — the same identity failed, then passed, then
   failed again within the already-fetched lookback window.
3. **Matrix divergence** — sibling matrix cells (same commit, different
   node/mongo version) passed while this one failed.

`investigate-flaky-test` spends exactly one confirmation rerun on a
`flaky/suspected` issue (separate budget from its existing 2-3 rerun tally,
which serves a different purpose — root-cause confidence) before promoting
it to `flaky/confirmed`. If the rerun doesn't reproduce a pass, this is
surfaced as an explicit MEDIUM-confidence caveat rather than silently
treated as confirmed.

New label created: `flaky/suspected` (matches the existing `flaky/observing`
color).

## Test plan

- [ ] Next `/flaky-ci-routine` cron run (or a manual `run now`) exercises
      the new `gh api` run-listing path without the `attempt` field error
- [ ] Confirm the Step 0 job-log-fetch method decision shows up in the
      run's Step 5 report
- [ ] Watch for a `flaky/suspected` issue on the next run with real
      candidates, and confirm `investigate-flaky-test` promotes/caveats it
      correctly