### PR TITLE
fix(page-bulk-export): ERR_MODULE_NOT_FOUND on production builds

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -102,7 +102,6 @@
     "@codemirror/merge": "^6.8.0",
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.42.1",
-    "@cspell/dynamic-import": "^8.15.4",
     "@elastic/elasticsearch8": "npm:@elastic/elasticsearch@^8.18.2",
     "@elastic/elasticsearch9": "npm:@elastic/elasticsearch@^9.0.3",
     "@godaddy/terminus": "^4.9.0",

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/markdown/bulk-export-markdown-renderer.spec.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/markdown/bulk-export-markdown-renderer.spec.ts
@@ -10,7 +10,7 @@ describe('BulkExportMarkdownRenderer', () => {
   let renderer: BulkExportMarkdownRenderer;
 
   beforeAll(() => {
-    renderer = createBulkExportMarkdownRenderer(__dirname);
+    renderer = createBulkExportMarkdownRenderer();
   });
 
   describe('GFM table rendering (Requirement 1.1)', () => {

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/markdown/bulk-export-markdown-renderer.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/markdown/bulk-export-markdown-renderer.ts
@@ -1,5 +1,3 @@
-import path from 'node:path';
-import { dynamicImport } from '@cspell/dynamic-import';
 import type * as HastUtilSanitize from 'hast-util-sanitize';
 
 import { loadPlugins } from './esm-plugin-loader';
@@ -39,33 +37,21 @@ let cachedProcessor: Awaited<ReturnType<typeof buildProcessor>> | undefined;
 
 /**
  * Build the sanitize schema by loading hast-util-sanitize and
- * services/renderer/recommended-whitelist.ts via dynamicImport so that the
- * bulk-export renderer shares a single source of truth with the web renderer.
+ * services/renderer/recommended-whitelist.ts so that the bulk-export renderer
+ * shares a single source of truth with the web renderer.
  *
  * Design: design.md § Security Considerations — "許可リストの単一出所"
- *
- * @param baseDir - Resolution base for dynamicImport (caller's __dirname).
  */
-async function buildSanitizeOptions(
-  baseDir: string,
-): Promise<HastUtilSanitize.Schema> {
-  const { defaultSchema } = await dynamicImport<typeof HastUtilSanitize>(
-    'hast-util-sanitize',
-    baseDir,
+async function buildSanitizeOptions(): Promise<HastUtilSanitize.Schema> {
+  const { defaultSchema }: typeof HastUtilSanitize = await import(
+    'hast-util-sanitize'
   );
 
   // Single source of truth: load tagNames and attributes from the web
-  // renderer's whitelist. dynamicImport (via import-meta-resolve + statSync)
-  // requires the full path including extension for TypeScript source files.
-  // ts-node handles the actual transpilation at import time.
-  const whitelistPath = path.resolve(
-    baseDir,
-    '../../../../../../services/renderer/recommended-whitelist.ts',
+  // renderer's whitelist.
+  const { tagNames, attributes } = await import(
+    '~/services/renderer/recommended-whitelist'
   );
-  const { tagNames, attributes } = await dynamicImport<{
-    tagNames: string[];
-    attributes: NonNullable<HastUtilSanitize.Schema['attributes']>;
-  }>(whitelistPath, baseDir);
 
   return {
     ...defaultSchema,
@@ -77,18 +63,18 @@ async function buildSanitizeOptions(
 /**
  * Build the unified processor by iterating the plugins declared in
  * plugin-set.ts (the single source of truth) in order. The pipeline — including
- * the reused web `add-class` plugin (loaded by relative path) — is fully data
- * driven; nothing is wired by hand here, so adding/removing/reordering a plugin
- * is a one-file change in plugin-set.ts.
+ * the reused web `add-class` plugin (loaded via a dynamic import() thunk) — is
+ * fully data driven; nothing is wired by hand here, so adding/removing/reordering
+ * a plugin is a one-file change in plugin-set.ts.
  *
  * The one runtime-computed input is rehype-sanitize's schema (buildSanitizeOptions),
  * which the renderer supplies as that plugin's options.
  *
  * Design: design.md § System Flows
  */
-async function buildProcessor(baseDir: string) {
-  const { unified, plugins } = await loadPlugins(baseDir, ADOPTED_PLUGINS);
-  const sanitizeOptions = await buildSanitizeOptions(baseDir);
+async function buildProcessor() {
+  const { unified, plugins } = await loadPlugins(ADOPTED_PLUGINS);
+  const sanitizeOptions = await buildSanitizeOptions();
 
   // unified().use() mutates the processor in place and returns `this`, so we
   // call it for its side effect on a single instance. (Reassigning would force
@@ -113,13 +99,8 @@ async function buildProcessor(baseDir: string) {
  *
  * The unified pipeline is built once on first call to renderToHtml and cached
  * at module level for reuse across all pages in a bulk-export job.
- *
- * @param baseDir - Resolution base for dynamicImport; pass __dirname from the
- *                  call site so that module resolution is anchored correctly.
  */
-export function createBulkExportMarkdownRenderer(
-  baseDir: string,
-): BulkExportMarkdownRenderer {
+export function createBulkExportMarkdownRenderer(): BulkExportMarkdownRenderer {
   const styleProvider = createBulkExportStyleProvider();
   return {
     getCss(): string {
@@ -127,7 +108,7 @@ export function createBulkExportMarkdownRenderer(
     },
     async renderToHtml(markdownBody: string, cssHref: string): Promise<string> {
       if (cachedProcessor == null) {
-        cachedProcessor = await buildProcessor(baseDir);
+        cachedProcessor = await buildProcessor();
       }
       const htmlFragment = String(await cachedProcessor.process(markdownBody));
       return styleProvider.wrap(htmlFragment, cssHref);

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/markdown/esm-plugin-loader.spec.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/markdown/esm-plugin-loader.spec.ts
@@ -5,29 +5,25 @@ import { ADOPTED_PLUGINS } from './plugin-set';
 
 /**
  * Verifies that EsmPluginLoader loads `unified` and every *declaration it is
- * given* via dynamicImport without triggering ERR_REQUIRE_ESM in the current CJS
- * runtime.
+ * given* correctly, in both the npm-bare-specifier and local `load`-thunk forms.
  *
- * This is an observable-contract test (Requirement 5.4): the loader must work in
- * the existing server runtime without a full ESM migration. The loader's only
+ * This is an observable-contract test (Requirement 1.6): the loader's only
  * responsibility is loading — the caller supplies *what* to load (the canonical
  * set lives in plugin-set.ts), so these tests pass declarations in explicitly.
  */
 describe('EsmPluginLoader', () => {
-  describe('loadPlugins(baseDir, declarations)', () => {
-    it('loads all plugins without ERR_REQUIRE_ESM', async () => {
-      await expect(
-        loadPlugins(__dirname, ADOPTED_PLUGINS),
-      ).resolves.toBeDefined();
+  describe('loadPlugins(declarations)', () => {
+    it('loads all plugins', async () => {
+      await expect(loadPlugins(ADOPTED_PLUGINS)).resolves.toBeDefined();
     });
 
     it('returns unified as a callable function', async () => {
-      const { unified } = await loadPlugins(__dirname, ADOPTED_PLUGINS);
+      const { unified } = await loadPlugins(ADOPTED_PLUGINS);
       expect(typeof unified).toBe('function');
     });
 
     it('returns one loaded plugin per declaration, in the given order', async () => {
-      const { plugins } = await loadPlugins(__dirname, ADOPTED_PLUGINS);
+      const { plugins } = await loadPlugins(ADOPTED_PLUGINS);
       // The loader preserves the caller's declaration order verbatim.
       expect(plugins.map((p) => p.name)).toEqual(
         ADOPTED_PLUGINS.map((p) => p.name),
@@ -35,7 +31,7 @@ describe('EsmPluginLoader', () => {
     });
 
     it('returns every plugin as a callable function carrying its declared options', async () => {
-      const { plugins } = await loadPlugins(__dirname, ADOPTED_PLUGINS);
+      const { plugins } = await loadPlugins(ADOPTED_PLUGINS);
       for (const loaded of plugins) {
         expect(typeof loaded.plugin).toBe('function');
       }
@@ -43,11 +39,11 @@ describe('EsmPluginLoader', () => {
       expect(remarkRehype?.options).toEqual({ allowDangerousHtml: true });
     });
 
-    it('resolves a relative specifier + named export (reused local plugin)', async () => {
-      // The add-class declaration loads a local GROWI .ts plugin by relative path
-      // and a non-default export — exercising the loader's specifier/exportName
-      // resolution independently of the npm bare-specifier path.
-      const { plugins } = await loadPlugins(__dirname, ADOPTED_PLUGINS);
+    it('resolves a local `load` thunk + named export (reused local plugin)', async () => {
+      // The add-class declaration loads a local GROWI plugin via a dynamic
+      // import() thunk and a non-default export — exercising the loader's
+      // load/exportName resolution independently of the npm bare-specifier path.
+      const { plugins } = await loadPlugins(ADOPTED_PLUGINS);
       const addClass = plugins.find((p) => p.name === 'add-class');
       expect(addClass).toBeDefined();
       expect(typeof addClass?.plugin).toBe('function');
@@ -56,17 +52,12 @@ describe('EsmPluginLoader', () => {
 
     it('throws a clear error when a declared export is missing', async () => {
       await expect(
-        loadPlugins(__dirname, [
-          { name: 'remark-gfm', exportName: 'doesNotExist' },
-        ]),
+        loadPlugins([{ name: 'remark-gfm', exportName: 'doesNotExist' }]),
       ).rejects.toThrow(/has no export "doesNotExist"/);
     });
 
     it('the loaded plugins assemble into a working unified pipeline', async () => {
-      const { unified, plugins } = await loadPlugins(
-        __dirname,
-        ADOPTED_PLUGINS,
-      );
+      const { unified, plugins } = await loadPlugins(ADOPTED_PLUGINS);
       // Assemble as the renderer does: iterate in order. use() mutates in place
       // and returns `this`, so call it for side effect.
       const processor = unified();

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/markdown/esm-plugin-loader.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/markdown/esm-plugin-loader.ts
@@ -1,5 +1,3 @@
-import path from 'node:path';
-import { dynamicImport } from '@cspell/dynamic-import';
 import type * as Unified from 'unified';
 
 import type { PluginDeclaration } from './plugin-set';
@@ -17,7 +15,7 @@ type AnyPlugin = Unified.Plugin<[unknown?]>;
  * wiring required.
  */
 export interface LoadedPlugin {
-  /** Canonical name from the declaration (npm specifier or local short name). */
+  /** Canonical name from the declaration (npm package name or local short name). */
   readonly name: string;
   /** The resolved plugin export, ready to hand to `processor.use(...)`. */
   readonly plugin: AnyPlugin;
@@ -28,8 +26,6 @@ export interface LoadedPlugin {
 /**
  * The `unified` factory plus the ordered, loaded plugin list.
  *
- * Requirement 5.4: operates in the current CJS server runtime without ESM
- * migration (all modules read via dynamicImport).
  * Requirement 1.6: structural alignment with the GROWI web renderer plugin set.
  */
 export interface LoadedPipeline {
@@ -38,8 +34,7 @@ export interface LoadedPipeline {
 }
 
 /**
- * Load `unified` and every declared plugin via dynamicImport (the only way to
- * consume ESM from the CJS server runtime).
+ * Load `unified` and every declared plugin.
  *
  * This loader's single responsibility is *loading*: the caller decides *what* to
  * load and passes the declarations in (the canonical set lives in plugin-set.ts).
@@ -47,38 +42,33 @@ export interface LoadedPipeline {
  * processor (see BulkExportMarkdownRenderer).
  *
  * Each declaration is resolved as:
- *  - `specifier ?? name` — bare npm specifier, or a relative path (resolved
- *    against `baseDir`) for a reused local GROWI plugin.
+ *  - `load ?? (() => import(name))` — an explicit dynamic-import thunk for a
+ *    reused local GROWI plugin, or a bare npm package import by `name`.
  *  - `exportName ?? 'default'` — which export to use as the plugin.
  *
- * @param baseDir - Resolution base for `dynamicImport` (caller's `__dirname`).
+ * A `load` thunk must use a real `import()` (never a runtime-built string path):
+ * only a literal specifier is rewritten to the correct emitted extension by
+ * `bin/add-js-extensions.ts` and checked by `bin/verify-dist-resolution.ts` in
+ * the production build (see `.claude/rules/import-convention.md`).
+ *
  * @param declarations - Ordered plugin declarations to load.
  */
 export async function loadPlugins(
-  baseDir: string,
   declarations: readonly PluginDeclaration[],
 ): Promise<LoadedPipeline> {
-  const unifiedModule = await dynamicImport<typeof Unified>('unified', baseDir);
+  const unifiedModule = await import('unified');
 
   const plugins = await Promise.all(
     declarations.map(async (declaration): Promise<LoadedPlugin> => {
-      const specifier = declaration.specifier ?? declaration.name;
-      // Relative specifiers point to reused local GROWI plugins; resolve them
-      // against baseDir. Bare specifiers are npm packages dynamicImport resolves.
-      const target = specifier.startsWith('.')
-        ? path.resolve(baseDir, specifier)
-        : specifier;
+      const load = declaration.load ?? (() => import(declaration.name));
       const exportName = declaration.exportName ?? 'default';
 
-      const module = await dynamicImport<Record<string, AnyPlugin>>(
-        target,
-        baseDir,
-      );
+      const module: Record<string, AnyPlugin> = await load();
       const plugin = module[exportName];
       if (plugin == null) {
         throw new Error(
-          `[EsmPluginLoader] "${specifier}" has no export "${exportName}" ` +
-            `(declared for plugin "${declaration.name}" in plugin-set.ts).`,
+          `[EsmPluginLoader] "${declaration.name}" has no export "${exportName}" ` +
+            `(declared in plugin-set.ts).`,
         );
       }
 

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/markdown/plugin-set.spec.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/markdown/plugin-set.spec.ts
@@ -142,19 +142,17 @@ describe('plugin-set declaration module', () => {
       expect(xsvIndex).toBeLessThan(names.indexOf('remark-rehype'));
     });
 
-    it('emoji, echo-directive and xsv-to-table declare relative specifiers and named exports', () => {
+    it('emoji, echo-directive and xsv-to-table declare a load thunk and named export', () => {
       for (const name of ['emoji', 'echo-directive', 'xsv-to-table']) {
         const entry = ADOPTED_PLUGINS.find((p) => p.name === name);
-        expect(entry?.specifier, `${name} specifier`).toMatch(
-          /remark-plugins\/.+\.ts$/,
-        );
+        expect(typeof entry?.load, `${name} load`).toBe('function');
         expect(entry?.exportName, `${name} exportName`).toBe('remarkPlugin');
       }
     });
 
-    it('add-class declares a relative specifier, named export, and table additions', () => {
+    it('add-class declares a load thunk, named export, and table additions', () => {
       const addClass = ADOPTED_PLUGINS.find((p) => p.name === 'add-class');
-      expect(addClass?.specifier).toMatch(/add-class\.ts$/);
+      expect(typeof addClass?.load).toBe('function');
       expect(addClass?.exportName).toBe('rehypePlugin');
       expect(addClass?.options).toEqual({ table: 'table table-bordered' });
     });

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/markdown/plugin-set.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/markdown/plugin-set.ts
@@ -3,7 +3,7 @@
  * bulk-export Markdown → HTML pipeline.
  *
  * This module is the single source of truth used by:
- *  - EsmPluginLoader (task 3.x) — which plugins to dynamicImport and in what order
+ *  - EsmPluginLoader (task 3.x) — which plugins to load and in what order
  *  - RendererParityGuard (task 6.1) — drift test comparing this set against
  *    generateCommonOptions / generateSSRViewOptions from the web renderer
  *
@@ -15,8 +15,8 @@
  *   → rehype plugins (raw, slug, sanitize, katex, add-class, stringify)
  *
  * Entries are loaded by EsmPluginLoader generically: npm plugins by bare
- * specifier, reused local plugins (emoji, echo-directive, xsv-to-table, add-class)
- * by relative path + named export.
+ * `import(name)`, reused local plugins (emoji, echo-directive, xsv-to-table,
+ * add-class) via an explicit `load` thunk + named export.
  */
 
 /** A declared plugin entry: how to load it, its pipeline options, and its
@@ -24,16 +24,19 @@
 export interface PluginDeclaration {
   /**
    * Canonical name — the npm package name for npm plugins (also used as the
-   * import specifier), or the short name the web renderer / parity test use for
-   * a reused local plugin (e.g. "add-class").
+   * default import target via `import(name)`), or the short name the web
+   * renderer / parity test use for a reused local plugin (e.g. "add-class").
    */
   readonly name: string;
   /**
-   * Module to import when it differs from `name` — e.g. a relative path (from
-   * the markdown/ dir) to a reused local GROWI plugin. Defaults to `name`,
-   * treated as a bare npm specifier.
+   * Dynamic-import thunk to use when the module differs from a bare
+   * `import(name)` — e.g. a reused local GROWI plugin. Must wrap a real
+   * `import('~/...')` (a literal specifier, not a runtime-built path) so the
+   * production build's `add-js-extensions` / `verify-dist-resolution` tooling
+   * can rewrite and verify it (see `.claude/rules/import-convention.md`).
+   * Defaults to `() => import(name)`.
    */
-  readonly specifier?: string;
+  readonly load?: () => Promise<Record<string, unknown>>;
   /** Named export to use as the plugin. Defaults to "default". */
   readonly exportName?: string;
   /**
@@ -52,7 +55,7 @@ export interface PluginDeclaration {
  *   rehype-sanitize, rehype-katex, rehype-stringify
  *
  * Note: remark-parse is the implicit unified base processor entry point;
- * it is listed first for completeness and traceability but is not dynamicImport-ed
+ * it is listed first for completeness and traceability but is not dynamically imported
  * as a separate plugin (it is part of unified itself via remark()).
  */
 export const ADOPTED_PLUGINS: ReadonlyArray<PluginDeclaration> = [
@@ -61,10 +64,10 @@ export const ADOPTED_PLUGINS: ReadonlyArray<PluginDeclaration> = [
   // Reused GROWI web plugin: emoji converts `:smile:` shortcodes to native emoji
   // glyphs (req 1.7). Placed right after gfm and BEFORE remark-directive so that
   // `:smile:` is consumed as an emoji, not parsed as a text directive (mirrors the
-  // web renderer order). React/DOM-free mdast transform; loaded by relative path.
+  // web renderer order). React/DOM-free mdast transform; loaded via a dynamic import() thunk.
   {
     name: 'emoji',
-    specifier: '../../../../../../services/renderer/remark-plugins/emoji.ts',
+    load: () => import('~/services/renderer/remark-plugins/emoji'),
     exportName: 'remarkPlugin',
     options: undefined,
   },
@@ -74,11 +77,10 @@ export const ADOPTED_PLUGINS: ReadonlyArray<PluginDeclaration> = [
   // Reused GROWI web plugin: echo-directive degrades text/leaf directives to readable
   // text (`<span>`/`<div>` showing the directive name), without leaking the `{...}`
   // attribute syntax (req 3.1a). Container directives are callout's domain (not adopted)
-  // and degrade to a plain text-preserving block. React/DOM-free; loaded by relative path.
+  // and degrade to a plain text-preserving block. React/DOM-free; loaded via a dynamic import() thunk.
   {
     name: 'echo-directive',
-    specifier:
-      '../../../../../../services/renderer/remark-plugins/echo-directive.ts',
+    load: () => import('~/services/renderer/remark-plugins/echo-directive'),
     exportName: 'remarkPlugin',
     options: undefined,
   },
@@ -87,11 +89,10 @@ export const ADOPTED_PLUGINS: ReadonlyArray<PluginDeclaration> = [
   // Reused GROWI web plugin: xsv-to-table converts csv/csv-h/tsv/tsv-h fenced code
   // blocks to GFM tables (req 1.8). Placed after math (mirrors the web view order
   // `push(math, xsvToTable)`) and before remark-rehype so the produced <table> later
-  // receives `table table-bordered` from add-class. React/DOM-free; loaded by relative path.
+  // receives `table table-bordered` from add-class. React/DOM-free; loaded via a dynamic import() thunk.
   {
     name: 'xsv-to-table',
-    specifier:
-      '../../../../../../services/renderer/remark-plugins/xsv-to-table.ts',
+    load: () => import('~/services/renderer/remark-plugins/xsv-to-table'),
     exportName: 'remarkPlugin',
     options: undefined,
   },
@@ -108,13 +109,12 @@ export const ADOPTED_PLUGINS: ReadonlyArray<PluginDeclaration> = [
   { name: 'rehype-katex', options: undefined },
   // Reused GROWI web plugin: add-class adds `table table-bordered` so the design
   // system's .table/.table-bordered borders apply (mirrors generateCommonOptions).
-  // Loaded via dynamicImport from a relative path; its only runtime dependency
+  // Loaded via a dynamic import() thunk; its only runtime dependency
   // (hast-util-select) is ESM. Placed after sanitize (trusted, static class
   // values), before stringify.
   {
     name: 'add-class',
-    specifier:
-      '../../../../../../services/renderer/rehype-plugins/add-class.ts',
+    load: () => import('~/services/renderer/rehype-plugins/add-class'),
     exportName: 'rehypePlugin',
     options: { table: 'table table-bordered' },
   },
@@ -129,7 +129,7 @@ export const ADOPTED_PLUGINS: ReadonlyArray<PluginDeclaration> = [
  * generateSSRViewOptions) that this pipeline consciously omits. NOTE (改訂 5):
  * exclusion is NOT because "local .ts plugins can't be loaded" — that earlier claim
  * (research.md I2) was disproven by add-class and corrected; any React/DOM-free AST
- * transform loads fine via the same relative-path dynamicImport pattern. The real
+ * transform loads fine via the same dynamic import() pattern. The real
  * reasons, by group:
  *  - Degrades WORSE without callout (research.md I7):
  *      github-admonitions — converts `> [!NOTE]` to a `:::note` container directive,

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/export-pages-to-fs-async.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/export-pages-to-fs-async.ts
@@ -68,7 +68,7 @@ export async function getPageWritable(
 
   // Build renderer once — reused for every page in the job.
   // BulkExportMarkdownRenderer caches the unified pipeline at module level.
-  const renderer = createBulkExportMarkdownRenderer(import.meta.dirname);
+  const renderer = createBulkExportMarkdownRenderer();
 
   // For pdf format, write the shared stylesheet once per job. Every page links
   // to it relatively, so the (~MB) CSS is not duplicated into each page's HTML.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,9 +224,6 @@ importers:
       '@codemirror/view':
         specifier: ^6.42.1
         version: 6.43.6
-      '@cspell/dynamic-import':
-        specifier: ^8.15.4
-        version: 8.15.4
       '@elastic/elasticsearch8':
         specifier: npm:@elastic/elasticsearch@^8.18.2
         version: '@elastic/elasticsearch@8.19.0'
@@ -3015,10 +3012,6 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
-
-  '@cspell/dynamic-import@8.15.4':
-    resolution: {integrity: sha512-tr0F6EYN6qtniNvt1Uib+PgYQHeo4dQHXE2Optap+hYTOoQ2VoQ+SwBVjZ+Q2bmSAB0fmOyf0AvgsUtnWIpavw==}
-    engines: {node: '>=18.0'}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -10899,6 +10892,7 @@ packages:
     resolution: {integrity: sha512-Quz3MvAwHxVYNXsOByL7xI5EB2WYOeFswqaHIA3qOK3isRWTxiplBEocmmru6XmxDB2L7jDNYtYA4FyimoAFEw==}
     engines: {node: '>=8.17.0'}
     hasBin: true
+    bundledDependencies: []
 
   jsonfile@3.0.1:
     resolution: {integrity: sha512-oBko6ZHlubVB5mRFkur5vgYR1UyqX+S6Y/oCfLhqNdcc2fYFlDpIoNc7AfKS1KOGcnNAkvsr0grLck9ANM815w==}
@@ -17857,10 +17851,6 @@ snapshots:
 
   '@colors/colors@1.5.0':
     optional: true
-
-  '@cspell/dynamic-import@8.15.4':
-    dependencies:
-      import-meta-resolve: 4.2.0
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:


### PR DESCRIPTION
## Summary

- `plugin-set.ts` / `bulk-export-markdown-renderer.ts` hardcoded a `.ts` extension in five relative paths passed as **string data** to `@cspell/dynamic-import`. That library does a literal `statSync` with no extension fallback, so it resolves against `src/` in dev but not against the compiled `dist/` in a production build, where only `.js` exists.
- Result: page bulk export (PDF conversion) failed with `ERR_MODULE_NOT_FOUND` in any production/Docker deployment, and `pdf-converter` subsequently failed with `ENOENT` because no HTML was ever written.
- The five string paths were invisible to the repo's existing production-build guarantees (`bin/add-js-extensions.ts`, `bin/verify-dist-resolution.ts`), which is why this shipped without CI catching it.

## Root Cause

`esm-plugin-loader.ts`'s `loadPlugins()` resolved `PluginDeclaration.specifier` (a plain string, e.g. `'../../../../../../services/renderer/remark-plugins/emoji.ts'`) against `baseDir` and handed it to `dynamicImport()`. In dev, `baseDir` resolves under `src/`, where `emoji.ts` exists. In a production build, `baseDir` resolves under `dist/`, where only `emoji.js` exists — `dynamicImport` never retries with a different extension.

The `@cspell/dynamic-import` dependency itself dated from when the server ran as CJS; `apps/app` has since moved to native ESM (`"type": "module"`), so a plain `import()` works for all of these modules.

## Changes

- `plugin-set.ts`: `PluginDeclaration.specifier: string` → `PluginDeclaration.load?: () => Promise<...>`. The four reused local plugins (`emoji`, `echo-directive`, `xsv-to-table`, `add-class`) now declare a `load: () => import('~/services/renderer/...')` thunk instead of a string path.
- `esm-plugin-loader.ts`: loads via `declaration.load ?? (() => import(declaration.name))` and a plain `await import('unified')` — no longer depends on `@cspell/dynamic-import`.
- `bulk-export-markdown-renderer.ts`: `buildSanitizeOptions()` loads `hast-util-sanitize` and the shared `recommended-whitelist` via plain dynamic imports; dropped the `baseDir` threading that is no longer needed (also removes an existing depth-fragility, since `baseDir` was actually `steps/`'s `import.meta.dirname`, not `markdown/`, and only worked by coincidence).
- `package.json` / lockfile: removed `@cspell/dynamic-import` (its only consumer in the repo).
- Updated the three spec files whose assertions referenced the removed `specifier` field / `baseDir` parameter; behavior-level assertions are unchanged.

Because the local plugins are now loaded via real `import('~/...')` specifiers (not string data), they are automatically covered by `bin/add-js-extensions.ts` (extension rewrite) and `bin/verify-dist-resolution.ts` (CI resolution check) going forward — closing the gap that let this ship undetected.

## Test Plan

- [x] `pnpm run lint:typecheck` — pass
- [x] `pnpm run lint:biome` (feature dir) — pass
- [x] `pnpm run lint:import-convention` — pass
- [x] `pnpm vitest run src/features/page-bulk-export` — 9 files / 121 tests pass
- [x] `pnpm run build:server` — 0 unresolved specifiers (`add-js-extensions`)
- [x] `node bin/verify-dist-resolution.ts dist` — 2457 specifiers checked, 0 unresolved
- [x] Manually invoked `createBulkExportMarkdownRenderer()` from the **compiled `dist/`** output (the exact failure mode reported) — renders emoji, tables, etc. with no `ERR_MODULE_NOT_FOUND`

Closes #11726