### PR TITLE
fix(growi-vault): remove flaky race in reconcile-flow completed-audit wait

### DIFF
--- a/apps/app/src/features/growi-vault/server/services/reconcile/__tests__/reconcile-flow.integ.ts
+++ b/apps/app/src/features/growi-vault/server/services/reconcile/__tests__/reconcile-flow.integ.ts
@@ -153,6 +153,35 @@ function waitForReconcileStatus(
   });
 }
 
+/**
+ * Poll `auditEvents` until it contains `action`. The orchestrator emits its
+ * final audit event *after* writing the terminal status to the DB, so
+ * waiting only for the DB status (as `waitForReconcileStatus` does) does not
+ * guarantee the corresponding audit event has been pushed yet — a fixed
+ * sleep is not a reliable substitute for actually observing the event.
+ */
+function waitForAuditEvent(
+  auditEvents: string[],
+  action: string,
+  timeoutMs = 10000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      if (auditEvents.includes(action)) {
+        resolve();
+        return;
+      }
+      if (Date.now() >= deadline) {
+        reject(new Error(`Timeout waiting for audit event "${action}"`));
+        return;
+      }
+      setTimeout(tick, 50);
+    };
+    tick();
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
@@ -356,9 +385,10 @@ describe('Scenario (b): user sub-tree + partial ACL exclusion → partial-acl-fi
 
     await waitForReconcileStatus(reconcileId, ['completed']);
     // The DB status update and the final emitAudit('completed') are sequential
-    // awaits in the orchestrator. The polling above resolves on the DB write;
-    // give the audit emit a short window to complete before asserting.
-    await new Promise((r) => setTimeout(r, 100));
+    // awaits in the orchestrator, so the DB write is observable slightly
+    // before the audit event is pushed. Wait for the event itself rather
+    // than an arbitrary fixed delay.
+    await waitForAuditEvent(auditEvents, 'vault.reconcile.completed');
 
     expect(auditEvents).toContain('vault.reconcile.partial-acl-filtered');
     expect(auditEvents).toContain('vault.reconcile.completed');


### PR DESCRIPTION
## Summary

- `reconcile-flow.integ.ts` scenario (b) (`emits partial-acl-filtered audit event when ACL restricts eligible pages`) was flaky in CI (#11736): it polled the DB for `status: 'completed'`, then slept a **fixed 100ms** before asserting the audit-events array contained `'vault.reconcile.completed'`.
- In `reconcile-orchestrator.ts`'s `run()`, the terminal `'vault.reconcile.completed'` audit event is emitted *after* the DB write that sets `status: 'completed'` (two sequential `await`s). The DB-status poll used by the test resolves the instant the DB write lands — before the subsequent audit emit is guaranteed to have completed — so the fixed 100ms margin was not a reliable substitute for actually observing the event, and could be exceeded under CI load (event-loop contention, GC pauses).
- This matches the observed CI failure exactly: `auditEvents` contained `['vault.reconcile.started', 'vault.reconcile.partial-acl-filtered']` (both emitted *before* the DB write) but was missing `'vault.reconcile.completed'` (emitted *after* it) when the assertion ran.

## Root Cause

Test-only race condition — not a product bug. See `reconcile-orchestrator.ts` Step 8/Step 9 ordering (partial-acl-filtered audit → DB write: completed → completed audit) vs. the test's fixed-delay assumption.

## Changes

- `reconcile-flow.integ.ts`: added a `waitForAuditEvent()` poll helper (mirrors the existing `waitForReconcileStatus()` pattern already used in the same file) that waits until the audit-events array actually contains the expected action, bounded by a generous timeout.
- Replaced the fixed `await new Promise((r) => setTimeout(r, 100))` with `await waitForAuditEvent(auditEvents, 'vault.reconcile.completed')` before the assertions.

No product code changes — the orchestrator's write-then-audit ordering is intentional and untouched.

## Test Plan

- [ ] `pnpm vitest run reconcile-flow.integ` (scenario (b) in particular) — **could not be executed in this sandbox**: `mongodb-memory-server` needs to download a MongoDB binary from `fastdl.mongodb.org`, which returned `403` through this environment's egress policy. Root cause and fix were validated via code-level analysis of the exact async ordering in `reconcile-orchestrator.ts`, plus `biome check` and `tsgo --noEmit` on the changed file (both clean; the only reported warning is pre-existing and unrelated to this change). Please confirm green in CI, where the previous fixed-delay flake reproduced.
- [ ] Re-run the full `reconcile-flow.integ.ts` suite a few times in CI to confirm the flake no longer reproduces.

Fixes #11736

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNkQEyvwCtbCawKKUk5HBA)_