### PR TITLE
fix(NextLink): decide client-side routing from an explicit route list

### DIFF
--- a/apps/app/.claude/skills/next-express-route-consistency/SKILL.md
+++ b/apps/app/.claude/skills/next-express-route-consistency/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: next-express-route-consistency
+description: Cross-check the Express-exclusive path list in src/utils/is-next-page-route.ts against the real route registrations in server/routes/index.js and the page files under src/pages/**. Auto-invoked when editing server/routes/index.js, src/utils/is-next-page-route.ts, or src/components/ReactMarkdownComponents/NextLink.tsx, or when asked to check whether NextLink's routing predicate is stale.
+user-invocable: true
+---
+
+# Next/Express Route Consistency Check
+
+`src/utils/is-next-page-route.ts` decides whether `NextLink` may hand a path to
+Next's client-side router or must fall back to a full page load. It answers
+this correctly only as long as its `EXPRESS_EXCLUSIVE_PATH_PATTERNS` list
+stays in sync with two things that can each drift independently:
+
+1. What `server/routes/index.js` actually registers (adding/removing an
+   Express-only route without touching the list).
+2. What page files exist under `src/pages/**` (adding a new Next.js page for
+   a path that used to be Express-exclusive, without removing it from the
+   list).
+
+There is no automated test for this today (the two source-of-truth files are
+read by an LLM at review time, not diffed programmatically) — this skill is
+the manual substitute. See issue #11689 for the background: `NextLink` used
+to reuse `pagePathUtils.isCreatablePage()` (a "can I create a wiki page here"
+predicate) for this unrelated "is this a Next.js page route" question, and
+the two answers silently diverged over time.
+
+## When to run this
+
+- Whenever `server/routes/index.js` gains or loses a top-level `app.get` /
+  `app.use` registration.
+- Whenever `src/utils/is-next-page-route.ts` is edited.
+- Whenever a new file is added under `src/pages/**` (a new page can turn a
+  previously Express-exclusive path into a real Next.js page).
+- On request, to answer "is NextLink's routing predicate still accurate?".
+
+## Procedure
+
+1. **Read `EXPRESS_EXCLUSIVE_PATH_PATTERNS`** in
+   `apps/app/src/utils/is-next-page-route.ts`. This is the list under test.
+
+2. **Enumerate what Express actually claims**, from
+   `apps/app/src/server/routes/index.js`: every top-level `app.get(...)` /
+   `app.use(...)` registration whose handler chain does **not** end in
+   `next.delegateToNext` (or `pageMarkdown.respond`, which only intercepts
+   markdown-flavored requests and falls through otherwise). Note the path
+   prefix each one claims.
+
+3. **Enumerate real Next.js pages**, from `apps/app/src/pages/**/*.page.tsx`
+   (top-level directory/file names, including dynamic segments like
+   `[[...path]]`). Anything not claimed by step 2 ends up served by the
+   trailing catch-all `app.get('/*', ..., next.delegateToNext)` — i.e. it is
+   a Next.js page route regardless of whether a literal page file exists for
+   that exact path (the `[[...path]]` catch-all renders it, even if the
+   result is "page not found").
+
+4. **Diff against the list**:
+   - A prefix from step 2 that is **not** in `EXPRESS_EXCLUSIVE_PATH_PATTERNS`
+     → NextLink will wrongly attempt a client-side transition to a path with
+     no Next.js page (issue #11689's "Case A").
+   - An entry in `EXPRESS_EXCLUSIVE_PATH_PATTERNS` that no longer matches
+     anything Express claims (its route was removed, or a page file now
+     exists for it) → NextLink wrongly forces a full page reload where a
+     client-side transition would now work (issue #11689's "Case B").
+
+5. Report any drift found, file:line evidence for both sides, and the exact
+   list edit needed. Do not silently "fix" the list without surfacing the
+   diff — a config path might legitimately want the conservative (full
+   reload) behavior for other reasons (see the `UNSAFE_PATH_PATTERNS` list in
+   the same file, which is unrelated to this check and answers a different
+   question: "is this path safe to hand to next/link at all").
+
+## Out of scope
+
+This skill only checks the `EXPRESS_EXCLUSIVE_PATH_PATTERNS` half of
+`is-next-page-route.ts`. It does not review `UNSAFE_PATH_PATTERNS` (malformed
+paths, `/edit` suffix, path traversal guards) — those are not about
+Express-vs-Next.js routing and do not go stale the same way.

--- a/apps/app/src/components/ReactMarkdownComponents/NextLink.spec.tsx
+++ b/apps/app/src/components/ReactMarkdownComponents/NextLink.spec.tsx
@@ -67,6 +67,14 @@ describe('NextLink', () => {
       ${'/Sandbox/日本語'}                                    | ${'non-ASCII page path written literally'}
       ${'/Sandbox/mail%40example'}                            | ${'percent-encoded reserved character'}
       ${'/Sandbox/a%2Fb'}                                     | ${'percent-encoded path separator'}
+      ${'/user/admin'}                                        | ${'user homepage root'}
+      ${'/tags'}                                              | ${'the tags page'}
+      ${'/trash'}                                             | ${'the trash page'}
+      ${'/_search'}                                           | ${'the search page'}
+      ${'/share/abc'}                                         | ${'a shared-link page'}
+      ${'/admin'}                                             | ${'the admin top page'}
+      ${'/me'}                                                | ${'the user settings page'}
+      ${'/user/%E6%97%A5%E6%9C%AC%E8%AA%9E'}                  | ${'user homepage root hidden behind percent-encoding'}
     `('routes $pathDescription through next/link', ({ href }) => {
       const { isClientSideTransition, anchor } = renderLink(href);
       expect(isClientSideTransition).toBe(true);
@@ -77,17 +85,20 @@ describe('NextLink', () => {
 
   describe('links that must NOT transition client-side', () => {
     it.each`
-      href                                   | reason
-      ${'#heading'}                          | ${'in-page anchor'}
-      ${'/attachment/653a1f1b'}              | ${'path served outside the page router'}
-      ${'/user/admin'}                       | ${'user homepage root'}
-      ${'/Sandbox/Bootstrap5/edit'}          | ${'path reserved by the editor'}
-      ${'/Sandbox/Bootstrap5.md'}            | ${'path reserved for the markdown endpoint'}
-      ${'/%E6%97%A5%E6%9C%AC%E8%AA%9E.md'}   | ${'reserved suffix hidden behind percent-encoding'}
-      ${'/user/%E6%97%A5%E6%9C%AC%E8%AA%9E'} | ${'user homepage root hidden behind percent-encoding'}
-      ${'/%61ttachment/653a1f1b'}            | ${'reserved prefix hidden behind percent-encoding'}
-      ${'/Sandbox/broken%ZZ'}                | ${'malformed percent-encoding'}
-      ${'/Sandbox/50%25off'}                 | ${'literal percent sign in the path'}
+      href                                 | reason
+      ${'#heading'}                        | ${'in-page anchor'}
+      ${'/attachment/653a1f1b'}            | ${'path served outside the page router'}
+      ${'/vault.git/info/refs'}            | ${'GROWI Vault git gateway, served outside the page router'}
+      ${'/passport/google'}                | ${'an OAuth entry point, served outside the page router'}
+      ${'/ogp/653a1f1b'}                   | ${'OGP image rendering, served outside the page router'}
+      ${'/download/653a1f1b'}              | ${'an attachment download, served outside the page router'}
+      ${'/uploads/653a1f1b.png'}           | ${'a raw upload path, served outside the page router'}
+      ${'/Sandbox/Bootstrap5/edit'}        | ${'path reserved by the editor'}
+      ${'/Sandbox/Bootstrap5.md'}          | ${'path reserved for the markdown endpoint'}
+      ${'/%E6%97%A5%E6%9C%AC%E8%AA%9E.md'} | ${'reserved suffix hidden behind percent-encoding'}
+      ${'/%61ttachment/653a1f1b'}          | ${'reserved prefix hidden behind percent-encoding'}
+      ${'/Sandbox/broken%ZZ'}              | ${'malformed percent-encoding'}
+      ${'/Sandbox/50%25off'}               | ${'literal percent sign in the path'}
     `('keeps $reason on a plain anchor', ({ href }) => {
       const { isClientSideTransition, anchor } = renderLink(href);
       expect(isClientSideTransition).toBe(false);

--- a/apps/app/src/components/ReactMarkdownComponents/NextLink.tsx
+++ b/apps/app/src/components/ReactMarkdownComponents/NextLink.tsx
@@ -1,9 +1,11 @@
 import type { AnchorHTMLAttributes, JSX } from 'react';
 import type { LinkProps } from 'next/link';
 import Link from 'next/link';
-import { pagePathUtils } from '@growi/core/dist/utils';
 
 import { useSiteUrl } from '~/states/global';
+// isNextPageRoute's Express-exclusive path list can drift from server/routes/index.js --
+// see the next-express-route-consistency skill (apps/app/.claude/skills).
+import { isNextPageRoute } from '~/utils/is-next-page-route';
 import loggerFactory from '~/utils/logger';
 
 const logger = loggerFactory('growi:components:NextLink');
@@ -23,15 +25,15 @@ const isExternalLink = (href: string, siteUrl: string | undefined): boolean => {
   }
 };
 
-const isCreatablePage = (href: string) => {
+const isRoutableByNext = (href: string) => {
   try {
     const url = new URL(href, 'http://example.com');
     // URL.pathname is percent-encoded, and '%' itself is one of the characters
-    // pagePathUtils.isCreatablePage() forbids -- so every path holding a
-    // non-ASCII character or a space would be judged non-creatable unless it is
-    // decoded back first. Same treatment as getServerSideCommonProps().
+    // isNextPageRoute() treats as unsafe -- so every path holding a non-ASCII
+    // character or a space would be misjudged unless it is decoded back first.
+    // Same treatment as getServerSideCommonProps().
     const pathName = decodeURIComponent(url.pathname);
-    return pagePathUtils.isCreatablePage(pathName);
+    return isNextPageRoute(pathName);
   } catch (err) {
     logger.debug(err);
     return false;
@@ -83,8 +85,8 @@ export const NextLink = (props: Props): JSX.Element => {
     );
   }
 
-  // when href is an anchor link or not-creatable path
-  if (hasAnchorLink(href) || !isCreatablePage(href) || target != null) {
+  // when href is an anchor link or not routable by Next's page router
+  if (hasAnchorLink(href) || !isRoutableByNext(href) || target != null) {
     return (
       <a
         id={id}

--- a/apps/app/src/utils/is-next-page-route.spec.ts
+++ b/apps/app/src/utils/is-next-page-route.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { isNextPageRoute } from './is-next-page-route';
+
+describe('isNextPageRoute', () => {
+  describe('Express-exclusive paths with no corresponding Next.js page', () => {
+    it.each([
+      '/vault.git/info/refs',
+      '/passport/google',
+      '/passport/github/callback',
+      '/ogp/abc123',
+      '/download/abc123',
+      '/attachment/abc123',
+      '/uploads/abc123.png',
+      '/_drawio-assets/stencils/foo.xml',
+      '/Sandbox/Bootstrap5.md',
+    ])('returns false for %s', (path) => {
+      expect(isNextPageRoute(path)).toBe(false);
+    });
+  });
+
+  describe('real Next.js page routes -- must not be denylisted just because a legacy predicate treated them as non-creatable page names', () => {
+    it.each([
+      '/tags',
+      '/trash',
+      '/user/alice',
+      '/me',
+      '/_search',
+      '/_private-legacy-pages',
+      '/_news',
+      '/share/abc',
+      '/admin',
+      '/admin/app',
+      '/login',
+      '/installer',
+      '/nonexistent/wiki/page/path',
+    ])('returns true for %s', (path) => {
+      expect(isNextPageRoute(path)).toBe(true);
+    });
+  });
+
+  it('does not false-positive-match a path that merely starts with an excluded prefix', () => {
+    // '/downloads' is a page path (e.g. a wiki page named "downloads"), not the
+    // '/download' attachment-download endpoint.
+    expect(isNextPageRoute('/downloads')).toBe(true);
+  });
+
+  describe('unsafe/malformed paths, unrelated to Express-vs-Next.js routing', () => {
+    it.each([
+      '/Sandbox/Bootstrap5/edit',
+      '/Sandbox/50%off',
+      '/../etc/passwd',
+    ])('returns false for %s', (path) => {
+      expect(isNextPageRoute(path)).toBe(false);
+    });
+  });
+});

--- a/apps/app/src/utils/is-next-page-route.ts
+++ b/apps/app/src/utils/is-next-page-route.ts
@@ -1,0 +1,61 @@
+import { DRAWIO_ASSET_PROXY_PATH } from '~/features/drawio/consts';
+
+/**
+ * Path patterns that Express serves directly, with no corresponding Next.js
+ * page under `apps/app/src/pages/**`. Kept in sync with the route
+ * registrations in `server/routes/index.js` -- when a route is added or
+ * removed there, check whether this list needs the same change. See the
+ * `next-express-route-consistency` skill (apps/app/.claude/skills) for a
+ * cross-check against the real route table and page files.
+ */
+const EXPRESS_EXCLUSIVE_PATH_PATTERNS: readonly RegExp[] = [
+  /^\/vault\.git(\/.*)?$/,
+  /^\/passport(\/.*)?$/,
+  /^\/ogp(\/.*)?$/,
+  /^\/download(\/.*)?$/,
+  /^\/attachment(\/.*)?$/,
+  /^\/uploads(\/.*)?$/,
+  new RegExp(`^${DRAWIO_ASSET_PROXY_PATH}(/.*)?$`),
+  /^\/_apix?(\/.*)?$/,
+  // The page-markdown endpoint (server/routes/index.js) intercepts any GET
+  // path ending in `.md` before the page router ever sees it.
+  /\.md$/,
+  // Legacy reserved segments with neither a page file nor an active Express
+  // route today; excluded conservatively since nothing is served there.
+  /^\/(register|logout|files|paste|comments)(\/.*|$)/,
+];
+
+/**
+ * Paths that are never a valid navigation target regardless of routing --
+ * malformed, reserved-looking, or path-traversal-shaped. This is unrelated
+ * to the Express-vs-Next.js distinction above; it is a safety net so
+ * NextLink never hands a garbage href to next/link.
+ */
+const UNSAFE_PATH_PATTERNS: readonly RegExp[] = [
+  /\^|\$|\*|\+|#|<|>|%|\?/,
+  /^\/-\/.*/,
+  /^\/?https?:\/\/.+$/,
+  /\/{2,}/,
+  /\s+\/\s+/,
+  /\\/,
+  /^(\.\.)$/,
+  /(\/\.\.)\/?/,
+  /\/edit$/,
+  /^(\/.+){130,}$/,
+];
+
+const NON_NEXT_PAGE_PATTERNS: readonly RegExp[] = [
+  ...EXPRESS_EXCLUSIVE_PATH_PATTERNS,
+  ...UNSAFE_PATH_PATTERNS,
+];
+
+/**
+ * Whether `pathname` is rendered by a Next.js page route, as opposed to a
+ * path Express serves directly with no corresponding page (e.g. an OAuth
+ * callback or an attachment download) or a malformed/unsafe path. Used to
+ * decide whether a link can use Next's client-side router or must fall back
+ * to a full page load.
+ */
+export const isNextPageRoute = (pathname: string): boolean => {
+  return !NON_NEXT_PAGE_PATTERNS.some((pattern) => pattern.test(pathname));
+};


### PR DESCRIPTION
## Summary

`NextLink` decided whether a link could use Next.js's client-side router by calling `pagePathUtils.isCreatablePage()` -- a predicate that answers "can a wiki page be created here", not "does Next's page router render this URL". The two questions had drifted apart in both directions:

- Real Next.js pages (`/tags`, `/trash`, `/share/*`, `/admin*`, `/me`, `/_search`, user homepages) were forced into a full page reload on every click, even though a client-side transition works fine.
- Express-only paths with no Next.js page (`/vault.git/*`, `/passport/*`, `/ogp/*`, `/download/*`, `/uploads/*`) were wrongly handed to the client-side router.

This predicate was originally introduced in #7863 to keep `/attachment/...`-style paths off the Next.js router, and `isCreatablePage()` happened to work for that one purpose, but it was only ever an approximation.

## Root Cause

See the investigation comment on #11689 for the file:line evidence.

## Changes

- Added `apps/app/src/utils/is-next-page-route.ts`: `isNextPageRoute()` decides routability from an explicit `EXPRESS_EXCLUSIVE_PATH_PATTERNS` list (kept in sync with `server/routes/index.js`), plus an unrelated `UNSAFE_PATH_PATTERNS` safety net (malformed paths, `/edit` suffix, `.md` suffix, path traversal) that answers a different question and is preserved as-is.
- `NextLink.tsx` now calls `isNextPageRoute()` instead of `pagePathUtils.isCreatablePage()`.
- Added `apps/app/.claude/skills/next-express-route-consistency/SKILL.md`: a manual cross-check procedure against `server/routes/index.js` and `src/pages/**`, to catch future drift between the declared list and the real route table. Referenced from both `is-next-page-route.ts` and `NextLink.tsx`.
- Updated `NextLink.spec.tsx` and added `is-next-page-route.spec.ts` covering both the previously-broken cases and the existing safety-net behavior.

## Test Plan

- [x] `pnpm vitest run is-next-page-route.spec` -- 26 passing
- [x] `pnpm vitest run NextLink.spec` -- 35 passing (includes the fixed `/tags`, `/trash`, `/share/abc`, `/admin`, `/me`, `/_search`, `/user/<name>` cases, and the newly-covered `/vault.git`, `/passport`, `/ogp`, `/download`, `/uploads` cases)
- [x] `pnpm run lint:typecheck`
- [x] `pnpm run lint:biome`
- [x] `pnpm run lint:import-convention`

Closes #11689