### PR TITLE
fix(attachment): Enforce page-viewer permission for guest requests too

### DIFF
--- a/apps/app/src/server/middlewares/certify-shared-page-attachment/certify-shared-page-attachment.spec.ts
+++ b/apps/app/src/server/middlewares/certify-shared-page-attachment/certify-shared-page-attachment.spec.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => {
     validateRefererMock: vi.fn(),
     retrieveValidShareLinkByRefererMock: vi.fn(),
     validateAttachmentMock: vi.fn(),
+    getConfigMock: vi.fn(),
   };
 });
 
@@ -26,10 +27,36 @@ vi.mock('./retrieve-valid-share-link', () => ({
 vi.mock('./validate-attachment', () => ({
   validateAttachment: mocks.validateAttachmentMock,
 }));
+vi.mock('~/server/service/config-manager', () => ({
+  configManager: { getConfig: mocks.getConfigMock },
+}));
 
 describe('certifySharedPageAttachmentMiddleware', () => {
   const res = mock<Response>();
   const next = vi.fn();
+
+  beforeEach(() => {
+    // link sharing enabled by default; individual tests override as needed
+    mocks.getConfigMock.mockReturnValue(false);
+  });
+
+  it('calls next() without certifying anything when link sharing is disabled', async () => {
+    // setup
+    mocks.getConfigMock.mockReturnValue(true);
+    const req = mock<RequestToAllowShareLink>();
+    req.params = { id: 'file id string' };
+    req.headers = { referer: 'referer string' };
+
+    // when
+    await certifySharedPageAttachmentMiddleware(req, res, next);
+
+    // then: no ShareLink lookup happens at all, and the existing (unexpired)
+    // ShareLink must not be able to certify the request anymore
+    expect(mocks.validateRefererMock).not.toHaveBeenCalled();
+    expect(mocks.retrieveValidShareLinkByRefererMock).not.toHaveBeenCalled();
+    expect(req.isSharedPage === true).toBeFalsy();
+    expect(next).toHaveBeenCalledOnce();
+  });
 
   describe('should called next() without req.isSharedPage set', () => {
     it('when the fileId param is null', async () => {

--- a/apps/app/src/server/middlewares/certify-shared-page-attachment/certify-shared-page-attachment.ts
+++ b/apps/app/src/server/middlewares/certify-shared-page-attachment/certify-shared-page-attachment.ts
@@ -1,5 +1,6 @@
 import type { NextFunction, Request, Response } from 'express';
 
+import { configManager } from '~/server/service/config-manager';
 import loggerFactory from '~/utils/logger';
 
 import { retrieveValidShareLinkByReferer } from './retrieve-valid-share-link';
@@ -17,6 +18,13 @@ export const certifySharedPageAttachmentMiddleware = async (
   res: Response,
   next: NextFunction,
 ): Promise<void> => {
+  // Link sharing was globally turned off: an existing, unexpired ShareLink
+  // document must not keep certifying attachment requests (see
+  // reject-link-sharing-disabled.ts for the same guard on the page-render path).
+  if (configManager.getConfig('security:disableLinkSharing')) {
+    return next();
+  }
+
   const fileId: string | undefined = req.params.id;
   const { referer } = req.headers;
 

--- a/apps/app/src/server/middlewares/certify-shared-page.js
+++ b/apps/app/src/server/middlewares/certify-shared-page.js
@@ -1,4 +1,5 @@
 import ShareLink from '~/server/models/share-link';
+import { configManager } from '~/server/service/config-manager';
 import loggerFactory from '~/utils/logger';
 
 const logger = loggerFactory('growi:middleware:certify-shared-page');
@@ -8,6 +9,13 @@ export const setup = (crowi) => {
   // Named function so the route-middleware snapshot tool can identify this
   // handler in the apiv3 auth chain.
   return async function certifySharedPage(req, res, next) {
+    // Link sharing was globally turned off: an existing, unexpired ShareLink
+    // document must not keep certifying requests (see
+    // reject-link-sharing-disabled.ts for the same guard on the page-render path).
+    if (configManager.getConfig('security:disableLinkSharing')) {
+      return next();
+    }
+
     // Accept both `pageId` (camelCase, used by /revisions, /page/info) and
     // `page_id` (snake_case, used by /comments.get) so this single shared
     // middleware can certify either route.

--- a/apps/app/src/server/routes/attachment/get.spec.ts
+++ b/apps/app/src/server/routes/attachment/get.spec.ts
@@ -1,0 +1,134 @@
+import type { IUser } from '@growi/core';
+import type { Request, Response } from 'express';
+import type { HydratedDocument } from 'mongoose';
+import mongoose from 'mongoose';
+import { mock } from 'vitest-mock-extended';
+
+import type { RequestToAllowShareLink } from '../../middlewares/certify-shared-page-attachment';
+import { Attachment, type IAttachmentDocument } from '../../models/attachment';
+import { retrieveAttachmentFromIdParam } from './get';
+
+type TestRequest = Request &
+  RequestToAllowShareLink & {
+    user?: HydratedDocument<IUser>;
+  };
+
+vi.mock('../../models/attachment', () => ({
+  Attachment: { findById: vi.fn() },
+}));
+
+describe('retrieveAttachmentFromIdParam', () => {
+  const pageId = '000000000000000000000001';
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const buildAttachment = (hasPage: boolean): IAttachmentDocument =>
+    mock<IAttachmentDocument>({
+      id: 'attachment1',
+      page: hasPage ? pageId : undefined,
+    });
+
+  const mockIsAccessiblePageByViewer = (isAccessible: boolean) => {
+    const isAccessiblePageByViewer = vi.fn().mockResolvedValue(isAccessible);
+    vi.spyOn(mongoose, 'model').mockReturnValue({
+      isAccessiblePageByViewer,
+    } as unknown as ReturnType<typeof mongoose.model>);
+    return isAccessiblePageByViewer;
+  };
+
+  const buildReqResNext = (overrides: {
+    user?: HydratedDocument<IUser>;
+    isSharedPage?: boolean;
+  }) => {
+    const req = mock<TestRequest>({
+      params: { id: 'attachment1' },
+      user: overrides.user,
+      isSharedPage: overrides.isSharedPage,
+    });
+    const res = mock<Response>();
+    res.locals = {} as never;
+    const next = vi.fn();
+    return { req, res, next };
+  };
+
+  it('denies a guest (no user, no share link) from downloading a private page attachment', async () => {
+    // Arrange: guest request, not via a certified share link, page denies anonymous viewers
+    vi.mocked(Attachment.findById).mockResolvedValue(buildAttachment(true));
+    const isAccessiblePageByViewer = mockIsAccessiblePageByViewer(false);
+    const { req, res, next } = buildReqResNext({
+      user: undefined,
+      isSharedPage: false,
+    });
+
+    // Act
+    await retrieveAttachmentFromIdParam(req as never, res as never, next);
+
+    // Assert: the viewer check ran for the guest and the request was rejected
+    expect(isAccessiblePageByViewer).toHaveBeenCalledWith(pageId, undefined);
+    expect(res.json).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows a guest through a certified share link without re-running the page-viewer check', async () => {
+    // Arrange: certifySharedPageAttachmentMiddleware already bound this fileId
+    // to the share link's page, so no separate viewer check should run.
+    vi.mocked(Attachment.findById).mockResolvedValue(buildAttachment(true));
+    const isAccessiblePageByViewer = mockIsAccessiblePageByViewer(false);
+    const { req, res, next } = buildReqResNext({
+      user: undefined,
+      isSharedPage: true,
+    });
+
+    // Act
+    await retrieveAttachmentFromIdParam(req as never, res as never, next);
+
+    // Assert
+    expect(isAccessiblePageByViewer).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('denies a logged-in user who is not a viewer of the owning page', async () => {
+    vi.mocked(Attachment.findById).mockResolvedValue(buildAttachment(true));
+    const isAccessiblePageByViewer = mockIsAccessiblePageByViewer(false);
+    const { req, res, next } = buildReqResNext({
+      user: mock<HydratedDocument<IUser>>(),
+      isSharedPage: false,
+    });
+
+    await retrieveAttachmentFromIdParam(req as never, res as never, next);
+
+    expect(isAccessiblePageByViewer).toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows a viewer who has access to the owning page', async () => {
+    vi.mocked(Attachment.findById).mockResolvedValue(buildAttachment(true));
+    mockIsAccessiblePageByViewer(true);
+    const { req, res, next } = buildReqResNext({
+      user: mock<HydratedDocument<IUser>>(),
+      isSharedPage: false,
+    });
+
+    await retrieveAttachmentFromIdParam(req as never, res as never, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.locals.attachment).toBeDefined();
+  });
+
+  it('skips the viewer check for an attachment with no owning page', async () => {
+    vi.mocked(Attachment.findById).mockResolvedValue(buildAttachment(false));
+    const modelSpy = vi.spyOn(mongoose, 'model');
+    const { req, res, next } = buildReqResNext({
+      user: undefined,
+      isSharedPage: false,
+    });
+
+    await retrieveAttachmentFromIdParam(req as never, res as never, next);
+
+    expect(modelSpy).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/server/routes/attachment/get.ts
+++ b/apps/app/src/server/routes/attachment/get.ts
@@ -19,7 +19,10 @@ import {
 import loggerFactory from '~/utils/logger';
 
 import type Crowi from '../../crowi';
-import { certifySharedPageAttachmentMiddleware } from '../../middlewares/certify-shared-page-attachment';
+import {
+  certifySharedPageAttachmentMiddleware,
+  type RequestToAllowShareLink,
+} from '../../middlewares/certify-shared-page-attachment';
 import { Attachment, type IAttachmentDocument } from '../../models/attachment';
 import ApiResponse from '../../util/apiResponse';
 
@@ -36,6 +39,7 @@ interface PageModel {
 type LocalsAfterDataInjection = { attachment: IAttachmentDocument };
 
 type RetrieveAttachmentFromIdParamRequest = CrowiProperties &
+  RequestToAllowShareLink &
   Request<{ id: string }, any, any, any, LocalsAfterDataInjection>;
 
 type RetrieveAttachmentFromIdParamResponse = Response<
@@ -58,8 +62,12 @@ export const retrieveAttachmentFromIdParam = async (
 
   const user = req.user;
 
-  // check viewer has permission
-  if (user != null && attachment.page != null) {
+  // Check viewer has permission, for both logged-in users and guests.
+  // Skip only when the request is already certified via a valid share link:
+  // certifySharedPageAttachmentMiddleware binds the fileId to that share
+  // link's page (see validateAttachment), so re-running the viewer check
+  // here would incorrectly reject a non-member share-link viewer.
+  if (!req.isSharedPage && attachment.page != null) {
     const Page = mongoose.model<IPage, PageModel>('Page');
     const isAccessible = await Page.isAccessiblePageByViewer(
       getIdStringForRef(attachment.page),


### PR DESCRIPTION
## Summary
- Fixes an access-control gap in `retrieveAttachmentFromIdParam` where the page-viewer permission check was skipped whenever the request had no authenticated user, letting a guest request reach `/attachment/:id` / `/download/:id` without the check.
- The permission check now runs regardless of authentication state, except when the request has already been certified through a valid share link (`req.isSharedPage`), since that path independently binds the requested file to the share link's page.
- While reviewing the share-link exception above, also closes a related gap: the share-link certification middlewares never checked whether link sharing had been globally disabled, so an already-issued share link kept working for attachment/comment/revision requests even after an admin turned the feature off.

## Details
- File: `apps/app/src/server/routes/attachment/get.ts`
- Guard changed from `user != null && attachment.page != null` to `!req.isSharedPage && attachment.page != null`.
- No change to the share-link flow's existing behavior; this only closes the guest-bypass gap while preserving legitimate share-link delivery.
- Files: `apps/app/src/server/middlewares/certify-shared-page-attachment/certify-shared-page-attachment.ts`, `apps/app/src/server/middlewares/certify-shared-page.js`
- Both middlewares now check the `security:disableLinkSharing` setting up front and skip certification (fail closed) when it's on, matching the existing guard used on the page-render path (`reject-link-sharing-disabled.ts`).

## Test plan
- [x] Added `apps/app/src/server/routes/attachment/get.spec.ts` (unit tests, TDD): confirmed RED against the pre-fix code, GREEN after the fix
- [x] Added a case to `certify-shared-page-attachment.spec.ts` for the disabled-link-sharing path (RED against pre-fix code, GREEN after)
- [x] Existing integration tests under `apps/app/src/server/routes/attachment/*.integ.ts`, `apps/app/src/server/routes/comment.integ.ts`, `apps/app/src/server/routes/apiv3/page/get-page-info.integ.ts` all still pass
- [x] `pnpm run lint:typecheck`
- [x] `pnpm run lint:biome`

🤖 Generated with [Claude Code](https://claude.com/claude-code)