### PR TITLE
ci: Fix check-changesets so it can resolve the PR base branch

### DIFF
--- a/.github/workflows/check-changesets.yml
+++ b/.github/workflows/check-changesets.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths:
       - .changeset/**
+      # Included so that a PR which only touches this workflow still runs it, and can
+      # therefore prove its own change instead of merging unexercised.
+      - .github/workflows/check-changesets.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,6 +19,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        # `changeset status` diffs against the base branch, so it needs the history
+        # both refs share. The default fetch-depth of 1 fetches only the merge ref.
+        fetch-depth: 0
 
     - uses: pnpm/action-setup@v6
 
@@ -30,7 +37,12 @@ jobs:
 
     - name: Reject changesets that can never be consumed
       run: |
-        pnpm changeset status --output status.json
+        # A CI checkout is a detached HEAD with remote-tracking refs only, so the bare
+        # branch name changesets uses by default (`git merge-base master HEAD`) does not
+        # resolve -- git looks up refs/remotes/master, not refs/remotes/origin/master.
+        # Passing the PR's own base rather than hardcoding master also keeps the check
+        # correct for PRs that target a release branch.
+        pnpm changeset status --since="origin/${{ github.base_ref }}" --output status.json
 
         # A changeset whose packages are all listed in the 'ignore' section of
         # .changeset/config.json bumps nothing, so `changeset version` neither releases


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/189025

Split out of #11513 at @yuki-takei's request ([review comment](https://github.com/growilabs/growi/pull/11513#issuecomment-5204829428)).

## Problem

`check-changesets` has failed on every PR that adds a changeset since it landed in 7eb29d1. It fails during setup, before it checks anything:

```
🦋  error Error: Failed to find where HEAD diverged from master. Does master exist?
🦋  error     at getDivergedCommit (@changesets/git/dist/changesets-git.cjs.js:66:11)
🦋  error     at async getChangedFilesSince (...:198:22)
🦋  error     at async Object.getChangedPackagesSinceRef (...:239:24)
```

Two causes, and the second is easy to miss:

1. `actions/checkout` defaults to `fetch-depth: 1`. On a `pull_request` event that fetches only the merge ref, so the base branch's history is not in the checkout and `git merge-base` has nothing to work with.
2. **`fetch-depth: 0` alone is still not enough.** A CI checkout is a detached HEAD with remote-tracking refs only, and changesets runs `git merge-base <config.baseBranch> HEAD` with the bare name. Git resolves `refs/remotes/<name>` but not `refs/remotes/origin/<name>`, so `master` does not fall back to `origin/master`.

## Fix

Full history plus an explicit ref. Using the PR's own base rather than hardcoding `master` also keeps the check correct for PRs that target a release branch.

`--since` does not change what the step examines: the default path already diffs against `config.baseBranch`, so the only difference is that the ref now resolves.

## Self-verification

`.github/workflows/check-changesets.yml` is added to the workflow's own `paths:`, so this PR triggers it. Without that, a workflow-only PR never runs it (`paths: .changeset/**`) and the fix would merge unexercised — which is how it has stayed broken.

Note this PR carries no changeset, so the run here proves the setup and the `jq` step complete successfully on a real CI checkout, with zero changesets to report. The behavior with changesets present is covered below and will get its real exercise on the next PR that adds one.

## Verification

Reproduced CI's exact state locally — a clone checked out at a detached HEAD with no local branches, only `origin/*` remote-tracking refs:

| Command | Result |
|---|---|
| `git merge-base master HEAD` | `fatal: Not a valid object name master` |
| `git merge-base origin/master HEAD` | `97c1c7043c…` — resolves |
| `changeset status --output status.json` (current) | `🦋 error Failed to find where HEAD diverged from master` — no `status.json` written |
| `changeset status --since="origin/master" --output status.json` (patched) | succeeds, writes `status.json` |
| the step's `jq` dead-changeset check, on that file | `DEAD_CHANGESETS=[]` → passes |

And the guard itself is not made vacuous by the change — committing a probe changeset that targets only an ignored package (`@growi/editor`) still trips it:

```
DEAD_CHANGESETS=zz-dead-probe
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)