### PR TITLE
fix: Guard array length before indexing in POST /pages/delete

### DIFF
--- a/apps/app/src/server/routes/apiv3/pages/delete-pages.integ.ts
+++ b/apps/app/src/server/routes/apiv3/pages/delete-pages.integ.ts
@@ -324,7 +324,14 @@ describe('POST /delete', () => {
 
     // Falls through to the same "nothing to delete" response every other
     // filtered-out case gets (see the 500 comment on the first test above) —
-    // not a crash, and not a distinguishable status for this pageId.
+    // not a crash, and not a distinguishable status for this pageId. Assert
+    // the message too: a naive `pagesToDelete[0]?.grant` rewrite of the fix
+    // would still return 500 here, but via the sibling "grant of the
+    // retrieved page is not restricted" branch instead of this fallthrough —
+    // a status-only assertion would not catch that.
     expect(response.status).toBe(500);
+    expect(response.body.errors).toEqual([
+      expect.objectContaining({ message: 'No pages can be deleted.' }),
+    ]);
   });
 });

--- a/apps/app/src/server/routes/apiv3/pages/delete-pages.integ.ts
+++ b/apps/app/src/server/routes/apiv3/pages/delete-pages.integ.ts
@@ -303,4 +303,28 @@ describe('POST /delete', () => {
     // fixture cleanup can't race it.
     await waitForAncestorCleanupToSettle(parentId);
   }, 20_000);
+
+  it('does not crash when isAnyoneWithTheLink is set and the page cannot be found', async () => {
+    // `pageIds.length !== 1` is rejected earlier when isAnyoneWithTheLink is
+    // set, so the viewer-filtered lookup below always resolves for a single
+    // id. Before the fix, a nonexistent (or unreadable) pageId left
+    // `pagesToDelete` empty and `pagesToDelete[0].grant` threw instead of
+    // answering cleanly.
+    const missingPageId = new Types.ObjectId();
+
+    const response = await request(app)
+      .post('/delete')
+      .set('X-Forwarded-For', TEST_IP)
+      .send({
+        pageIdToRevisionIdMap: {
+          [missingPageId.toString()]: new Types.ObjectId().toString(),
+        },
+        isAnyoneWithTheLink: true,
+      });
+
+    // Falls through to the same "nothing to delete" response every other
+    // filtered-out case gets (see the 500 comment on the first test above) —
+    // not a crash, and not a distinguishable status for this pageId.
+    expect(response.status).toBe(500);
+  });
 });

--- a/apps/app/src/server/routes/apiv3/pages/index.js
+++ b/apps/app/src/server/routes/apiv3/pages/index.js
@@ -1073,8 +1073,14 @@ export const setup = (crowi) => {
         logger.error('Failed to find pages to delete.', err);
         return res.apiv3Err(new ErrorV3('Failed to find pages to delete.'));
       }
+      // `findByIdsAndViewer` is viewer-filtered, so the requested page can come
+      // back missing from `pagesToDelete` (already deleted, or not readable by
+      // this user) — guard the length before indexing, or a nonexistent/
+      // unreadable pageId throws here instead of falling through to the
+      // generic "No pages can be deleted." response below.
       if (
         isAnyoneWithTheLink &&
+        pagesToDelete.length > 0 &&
         pagesToDelete[0].grant !== PageGrant.GRANT_RESTRICTED
       ) {
         return res.apiv3Err(


### PR DESCRIPTION
## 背景 / Background

`#11762`（apiv3のページ操作APIで403/404の出し分けを廃止する統一PR）のレビュー中に、同じ「viewer-filtered な問い合わせの結果を、配列の長さ／null チェックなしで参照する」という形のクラッシュがもう1箇所見つかりました（`share-links.js` の同種の箇所は、その後の敵対的レビューで #11762 側で先に修正済みです）。403/404の話とは別の問題のため、`#11762` には含めず、こちらのPRで対応します。

While reviewing `#11762` (unifying not-found/forbidden responses across apiv3 page routes to a plain 404), one more crash of the same shape turned up — a viewer-filtered lookup's result read without checking it could come back empty/null. (A similar one in `share-links.js` was found and fixed within `#11762` itself, during its own adversarial review.) This one is unrelated to the 403/404 policy, so it was left out of that PR and is fixed here instead.

## 変更内容 / Changes

- `POST /pages/delete`: `isAnyoneWithTheLink` が指定された場合、`pagesToDelete[0].grant` を配列の長さチェックなしで参照していた。対象ページが既に削除済み、または閲覧権限がない場合に `pagesToDelete` が空配列になり、クラッシュしていた。長さチェックを追加し、既存の「削除できるページがありません」(500) という汎用レスポンスに自然に合流するようにした。

## Test plan

- [x] `pnpm vitest run delete-pages.integ` — 全3件 pass（新規のクラッシュ回帰テスト含む）
- [x] 修正前のコードに戻すと、`TypeError: Cannot read properties of undefined (reading 'grant')` で red になることを確認済み
- [x] `pnpm run lint:biome` / `pnpm run lint:typecheck` — 新規エラーなし
