### PR TITLE
fix(file-uploader): Restore update button on FileUploadSetting for GROWI.cloud

### DIFF
--- a/apps/app/src/client/components/Admin/App/FileUploadSetting.spec.tsx
+++ b/apps/app/src/client/components/Admin/App/FileUploadSetting.spec.tsx
@@ -1,0 +1,80 @@
+/**
+ * FileUploadSetting.spec.tsx
+ *
+ * Regression test for PR #10941: the update button was hidden entirely
+ * on GROWI.cloud (`{!isCloud && <AdminUpdateButtonRow ... />}`), even though
+ * cloud admins can still edit fields that are not cloud-managed (e.g. the
+ * GCS/Azure file delivery relay-mode dropdown) and need a way to save them.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  return {
+    growiCloudUri: undefined as string | undefined,
+    growiAppIdForGrowiCloud: undefined as number | undefined,
+  };
+});
+
+vi.mock('~/states/global', () => ({
+  useGrowiCloudUri: () => mocks.growiCloudUri,
+  useGrowiAppIdForGrowiCloud: () => mocks.growiAppIdForGrowiCloud,
+}));
+
+vi.mock('next-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('./useFileUploadSettings', () => ({
+  useFileUploadSettings: () => ({
+    data: {
+      fileUploadType: 'gcs',
+      isFixedFileUploadByEnvVar: false,
+      s3Region: '',
+      s3CustomEndpoint: '',
+      s3Bucket: '',
+      s3AccessKeyId: '',
+      s3SecretAccessKey: '',
+      s3ReferenceFileWithRelayMode: false,
+      gcsApiKeyJsonPath: '',
+      gcsBucket: '',
+      gcsUploadNamespace: '',
+      gcsReferenceFileWithRelayMode: false,
+      gcsUseOnlyEnvVars: false,
+      azureTenantId: '',
+      azureClientId: '',
+      azureClientSecret: '',
+      azureStorageAccountName: '',
+      azureStorageContainerName: '',
+      azureReferenceFileWithRelayMode: false,
+      azureUseOnlyEnvVars: false,
+    },
+    isLoading: false,
+    error: null,
+    updateSettings: vi.fn(),
+  }),
+}));
+
+import FileUploadSetting from './FileUploadSetting';
+
+describe('FileUploadSetting', () => {
+  it('renders the update button when not on GROWI.cloud', () => {
+    mocks.growiCloudUri = undefined;
+    mocks.growiAppIdForGrowiCloud = undefined;
+
+    render(<FileUploadSetting />);
+
+    expect(screen.getByRole('button', { name: 'Update' })).toBeInTheDocument();
+  });
+
+  it('still renders the update button on GROWI.cloud, so cloud-editable fields (e.g. relay mode) can be saved', () => {
+    mocks.growiCloudUri = 'https://growi.cloud';
+    mocks.growiAppIdForGrowiCloud = 123;
+
+    render(<FileUploadSetting />);
+
+    expect(screen.getByRole('button', { name: 'Update' })).toBeInTheDocument();
+  });
+});

--- a/apps/app/src/client/components/Admin/App/FileUploadSetting.tsx
+++ b/apps/app/src/client/components/Admin/App/FileUploadSetting.tsx
@@ -207,7 +207,7 @@ const FileUploadSetting = (): JSX.Element => {
         />
       )}
 
-      {!isCloud && <AdminUpdateButtonRow type="submit" disabled={isLoading} />}
+      <AdminUpdateButtonRow type="submit" disabled={isLoading} />
     </form>
   );
 };

--- a/apps/app/src/client/components/Admin/App/GcsSetting.spec.tsx
+++ b/apps/app/src/client/components/Admin/App/GcsSetting.spec.tsx
@@ -1,0 +1,76 @@
+/**
+ * GcsSetting.spec.tsx
+ *
+ * Regression test: when GROWI.cloud provides GCS as a hosted (env-only)
+ * storage, `gcsUseOnlyEnvVars` is true and every GCS setting must be locked
+ * to the infra-provided env vars. The file-delivery (relay/redirect) mode
+ * dropdown was never gated by this flag, so a hosted-GCS admin could still
+ * change and persist it, unlike the other GCS fields.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { UseFormRegister } from 'react-hook-form';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+import type { FileUploadFormValues } from './FileUploadSetting.types';
+import { GcsSettingMolecule } from './GcsSetting';
+
+// GcsSettingMolecule only spreads `register(...)` onto plain text inputs
+// that this suite never queries, so an empty-object stub is sufficient.
+const register = vi
+  .fn()
+  .mockReturnValue({}) as unknown as UseFormRegister<FileUploadFormValues>;
+
+const baseProps = {
+  register,
+  gcsReferenceFileWithRelayMode: false,
+  gcsUseOnlyEnvVars: false,
+  isCloud: false,
+};
+
+describe('GcsSettingMolecule', () => {
+  it('allows changing the file-delivery mode when not env-only', () => {
+    const onChange = vi.fn();
+    render(
+      <GcsSettingMolecule
+        {...baseProps}
+        onChangeGcsReferenceFileWithRelayMode={onChange}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'admin:app_setting.file_delivery_method_relay',
+      }),
+    );
+
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('locks the file-delivery mode when GCS is env-only (hosted)', () => {
+    const onChange = vi.fn();
+    render(
+      <GcsSettingMolecule
+        {...baseProps}
+        gcsUseOnlyEnvVars
+        onChangeGcsReferenceFileWithRelayMode={onChange}
+      />,
+    );
+
+    const toggle = document.getElementById('ddGcsReferenceFileWithRelayMode');
+    expect(toggle).toBeDisabled();
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'admin:app_setting.file_delivery_method_relay',
+      }),
+    );
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/client/components/Admin/App/GcsSetting.tsx
+++ b/apps/app/src/client/components/Admin/App/GcsSetting.tsx
@@ -45,6 +45,7 @@ export const GcsSettingMolecule = (
               data-bs-toggle="dropdown"
               aria-haspopup="true"
               aria-expanded="true"
+              disabled={gcsUseOnlyEnvVars}
             >
               {gcsReferenceFileWithRelayMode &&
                 t('admin:app_setting.file_delivery_method_relay')}
@@ -55,6 +56,7 @@ export const GcsSettingMolecule = (
               <button
                 className="dropdown-item"
                 type="button"
+                disabled={gcsUseOnlyEnvVars}
                 onClick={() => {
                   props.onChangeGcsReferenceFileWithRelayMode(true);
                 }}
@@ -64,6 +66,7 @@ export const GcsSettingMolecule = (
               <button
                 className="dropdown-item"
                 type="button"
+                disabled={gcsUseOnlyEnvVars}
                 onClick={() => {
                   props.onChangeGcsReferenceFileWithRelayMode(false);
                 }}

--- a/apps/app/src/server/service/config-manager/config-definition.spec.ts
+++ b/apps/app/src/server/service/config-manager/config-definition.spec.ts
@@ -369,4 +369,27 @@ describe('config-definition multi-provider ai keys', () => {
       expect(aiGroup?.targetKeys).not.toContain('ai:allowedModels');
     });
   });
+
+  describe('env-only group env:useOnlyEnvVars:gcs', () => {
+    const gcsGroup = ENV_ONLY_GROUPS.find(
+      (group) => group.controlKey === 'env:useOnlyEnvVars:gcs',
+    );
+
+    it('is defined', () => {
+      expect(gcsGroup).toBeDefined();
+    });
+
+    // Regression: gcs:referenceFileWithRelayMode was omitted from this
+    // group, so a GROWI.cloud hosted-GCS admin could still change and
+    // persist the file-delivery method even though env-only mode is meant
+    // to lock every GCS setting to the infra-provided env vars.
+    it('targets the delivery-relay-mode key alongside the credential/bucket keys', () => {
+      expect(gcsGroup?.targetKeys).toEqual([
+        'gcs:apiKeyJsonPath',
+        'gcs:bucket',
+        'gcs:uploadNamespace',
+        'gcs:referenceFileWithRelayMode',
+      ]);
+    });
+  });
 });

--- a/apps/app/src/server/service/config-manager/config-definition.ts
+++ b/apps/app/src/server/service/config-manager/config-definition.ts
@@ -1620,8 +1620,20 @@ export const ENV_ONLY_GROUPS: EnvOnlyGroup[] = [
     ],
   },
   {
+    // gcs:referenceFileWithRelayMode is included alongside the
+    // credential/bucket keys: for a GROWI.cloud hosted-GCS tenant, the
+    // file-delivery method is infra-managed the same as the bucket itself,
+    // so it must not be overridable from the admin UI either.
+    // TODO: azure:referenceFileWithRelayMode has the same requirement but is
+    // not yet in the azure group below — see the GCS fix this comment
+    // shipped with.
     controlKey: 'env:useOnlyEnvVars:gcs',
-    targetKeys: ['gcs:apiKeyJsonPath', 'gcs:bucket', 'gcs:uploadNamespace'],
+    targetKeys: [
+      'gcs:apiKeyJsonPath',
+      'gcs:bucket',
+      'gcs:uploadNamespace',
+      'gcs:referenceFileWithRelayMode',
+    ],
   },
   {
     controlKey: 'env:useOnlyEnvVars:azure',

--- a/apps/app/src/server/service/config-manager/config-manager.spec.ts
+++ b/apps/app/src/server/service/config-manager/config-manager.spec.ts
@@ -440,5 +440,55 @@ describe('ConfigManager test', () => {
         expect(configManager.getConfig('app:title')).toBe('db-title');
       });
     });
+
+    describe('env-only mode for GCS settings (env:useOnlyEnvVars:gcs)', () => {
+      // GROWI.cloud's hosted GCS tenants set this control key so the
+      // infra-provided GCS settings (credentials, bucket, and — since this
+      // fix — the file-delivery relay/redirect mode) cannot be overridden
+      // from the admin UI. gcs:referenceFileWithRelayMode was missing from
+      // this group before this fix, so a hosted-GCS admin could still
+      // persist a DB value that getConfig would then honor.
+      const gcsEnvOnlyKeys = [
+        'gcs:apiKeyJsonPath',
+        'gcs:bucket',
+        'gcs:uploadNamespace',
+        'gcs:referenceFileWithRelayMode',
+      ] as const;
+
+      const dbValues: Partial<TestConfigData> = {
+        'gcs:apiKeyJsonPath': { value: 'db-key-path' },
+        'gcs:bucket': { value: 'db-bucket' },
+        'gcs:uploadNamespace': { value: 'db-namespace' },
+        'gcs:referenceFileWithRelayMode': { value: true },
+      };
+      const envValues: Partial<TestConfigData> = {
+        'gcs:apiKeyJsonPath': { value: 'env-key-path' },
+        'gcs:bucket': { value: 'env-bucket' },
+        'gcs:uploadNamespace': { value: 'env-namespace' },
+        'gcs:referenceFileWithRelayMode': { value: false },
+      };
+
+      test('returns env value only (ignoring db) for every GCS key when control key is true', () => {
+        setTestConfigs(dbValues, {
+          ...envValues,
+          'env:useOnlyEnvVars:gcs': { value: true },
+        });
+
+        for (const key of gcsEnvOnlyKeys) {
+          expect(configManager.getConfig(key)).toEqual(envValues[key]?.value);
+        }
+      });
+
+      test('returns db value (env as fallback default) for every GCS key when control key is false', () => {
+        setTestConfigs(dbValues, {
+          ...envValues,
+          'env:useOnlyEnvVars:gcs': { value: false },
+        });
+
+        for (const key of gcsEnvOnlyKeys) {
+          expect(configManager.getConfig(key)).toEqual(dbValues[key]?.value);
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
## 概要

PR #10941で `FileUploadSetting.tsx` の更新ボタン（`AdminUpdateButtonRow`）が `!isCloud` 条件で丸ごと非表示になっていました。GROWI.cloud環境では、GCS/Azureのファイル配信方式（relay/redirectモード）のドロップダウンは編集可能なままなのに保存する手段が無い、という不整合が生じていました。`!isCloud &&` を外し、更新ボタンを常時表示に戻します。

あわせて、この修正過程で見つかった関連の欠落も直しています。GROWI.cloudのhosted GCS（インフラがバケット等を管理し、ユーザーに変更させたくないモード。`env:useOnlyEnvVars:gcs` で判定）では、バケット名・APIキー・namespaceはすでに `ENV_ONLY_GROUPS` でDB値を無視してenv変数を優先する保護がかかっていましたが、`gcs:referenceFileWithRelayMode`（配信方式）だけこの保護から漏れていました。今回の更新ボタン復活でこの項目も保存できるようになるため、hosted環境で配信方式を書き換えてしまえる状態が顕在化します。`ENV_ONLY_GROUPS` のgcsグループに `gcs:referenceFileWithRelayMode` を追加し、`GcsSetting.tsx` のドロップダウンも `gcsUseOnlyEnvVars` のとき操作不可にしました。

## 変更内容

- `FileUploadSetting.tsx`: `!isCloud &&` を除去し、更新ボタンを常時表示
- `config-definition.ts`: `ENV_ONLY_GROUPS` のgcsグループに `gcs:referenceFileWithRelayMode` を追加（理由コメント付き）
- `GcsSetting.tsx`: relay/redirectドロップダウンを `gcsUseOnlyEnvVars` のとき disabled化
- テスト: `FileUploadSetting.spec.tsx`（新規）、`GcsSetting.spec.tsx`（新規）、`config-definition.spec.ts`・`config-manager.spec.ts`（拡充）— いずれもRED→GREEN確認済み

## レビュー

サブエージェント（Opus）による敵対的レビューを実施し、非cloud環境・owned GCSともにデグレなしを実測確認済み（別worktreeで変更前後のRED/GREENを比較）。

## Follow-up（別issueで対応予定）

- Azure（`azure:referenceFileWithRelayMode`）にも同型の欠落があるが、GROWI.cloudでは現状Azureを提供していないため本PRの対象外。AWS/GCS/Azure全体でhosted/owned対応を一貫させるissueを別途起票する。
- サーバー側（PUT /app-settings/file-upload-setting）にenv-onlyキーの書き込み拒否ガードが無い点も別途検討。

## Test plan

- [x] `pnpm vitest run FileUploadSetting.spec GcsSetting.spec config-definition.spec config-manager.spec` が全てGREEN
- [x] `pnpm run lint:biome` で対象ファイルにエラーなし
- [ ] レビュー後、hosted GCSテナントで `gcs:referenceFileWithRelayMode=true` のデータが残っていないか、GROWI.cloud側で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)