### PR TITLE
fix(test): fix three flaky-CI failures (#11722, #11744, #11751)

### DIFF
--- a/apps/app/.claude/rules/mongo-test-setup.md
+++ b/apps/app/.claude/rules/mongo-test-setup.md
@@ -1,0 +1,87 @@
+# MongoDB in Tests: Check `MONGO_URI` Before Spawning an Embedded Server
+
+A test file that needs a real MongoDB (not a mock) must not call
+`MongoMemoryServer.create()` / `MongoMemoryReplSet.create()` unconditionally.
+Check `process.env.MONGO_URI` first and connect to that; only fall back to an
+embedded server when it is unset. Origin: #11744, where two `.spec.ts` files
+skipped this check and flaked in CI.
+
+## Why
+
+The `ci-app-test` job (`test:unit test:components`, see `.github/workflows/`)
+already starts a real MongoDB replica set via `supercharge/mongodb-github-action`
+and exports `MONGO_URI` for that job — even plain `.spec.ts` unit tests can see
+it. A `beforeAll` that ignores this and calls `MongoMemoryServer.create()`
+anyway spawns a second, redundant `mongod`, downloaded from `mongodb-memory-server`'s
+default cache (`~/.cache/mongodb-binaries`), resolving whatever version it
+picks. This is a completely different cache/version path than the project's
+pinned `MONGOMS_BINARY_OPTS` (`apps/app/test/setup/mongo/utils.ts`), which the
+`app-integration` project's `global-setup.ts` pre-downloads once, before any
+worker starts, specifically to avoid concurrent workers racing to download the
+same binary and hitting lock-file contention. An unprotected, unplanned-for
+`MongoMemoryServer.create()` call reproduces exactly that race, and was the
+direct cause of #11744's `beforeAll` timeout flake.
+
+## Which shape applies depends on the Vitest project, not on "mocked vs real"
+
+`vitest.workspace.mts` routes `**/*.spec.{ts,js}` to `app-unit` (no Mongo
+setupFiles) and `**/*.integ.ts` to `app-integration` (has the shared
+`test/setup/mongo/index.ts` setupFile + global-setup pre-download). The
+`.spec.ts` vs `.integ.ts` choice is about whether a file needs the
+integration project's shared harness (Crowi wiring, Elasticsearch,
+migrate-mongo, and — critically — a **shared per-worker mongoose connection**
+that persists across files). It is not about whether the file is allowed to
+talk to a real database: a `.spec.ts` file can connect to a real embedded or
+external Mongo as long as it manages that connection itself, start to finish.
+
+### `.integ.ts` files (app-integration project)
+
+Do not manage your own connection at all. `test/setup/mongo/index.ts` already
+connects once per worker (it explicitly skips reconnecting when
+`mongoose.connection.readyState === 1`) and tears down in its own `afterAll`.
+Just `import mongoose` and use it once connected.
+
+### `.spec.ts` files that need their own self-contained real Mongo
+
+Do the `MONGO_URI` check inline, but keep the file's own connect/disconnect
+lifecycle — do not rename the file to `.integ.ts` as a shortcut to inherit the
+shared setup. That was considered and rejected for #11744: a self-contained
+file's `afterAll` calls `dropDatabase()` + `connection.close()`, which would
+tear down the shared per-worker connection out from under whichever
+`.integ.ts` file runs next in the same worker, and it would also pull in
+unrelated setupFiles (Elasticsearch, migrate-mongo, Prisma) the file doesn't
+need.
+
+Give the file its own stable database name via `replaceMongoDbName` so it
+can't collide with `app-integration`'s `growi_test_${workerId}` naming
+(`test/setup/mongo/test-db-config.ts`) on the same shared external MongoDB:
+
+```ts
+import { replaceMongoDbName } from '^/test/setup/mongo/utils';
+
+let mongod: MongoMemoryServer | undefined;
+
+beforeAll(async () => {
+  const mongoUri = process.env.MONGO_URI
+    ? replaceMongoDbName(process.env.MONGO_URI, 'growi_test_unit_<unique-name>')
+    : null;
+  if (mongoUri != null) {
+    await mongoose.connect(mongoUri);
+    return;
+  }
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.connection.dropDatabase();
+  await mongoose.connection.close();
+  await mongod?.stop();
+});
+```
+
+If the local (`MONGO_URI` unset) fallback branch is exercised often enough to
+matter, consider also passing `MONGOMS_BINARY_OPTS` to `MongoMemoryServer.create()`
+for cache consistency — but that is a secondary nicety. The `MONGO_URI`-first
+check is the actual rule; without it, the binary options never come into play
+in CI at all.

--- a/apps/app/.claude/rules/mongo-test-setup.md
+++ b/apps/app/.claude/rules/mongo-test-setup.md
@@ -52,36 +52,33 @@ tear down the shared per-worker connection out from under whichever
 unrelated setupFiles (Elasticsearch, migrate-mongo, Prisma) the file doesn't
 need.
 
-Give the file its own stable database name via `replaceMongoDbName` so it
-can't collide with `app-integration`'s `growi_test_${workerId}` naming
+Use `connectSelfContainedMongo` / `disconnectSelfContainedMongo`
+(`test/setup/mongo/self-contained-connection.ts`) rather than writing the
+`MONGO_URI` check inline — it already handles the fallback and gives the
+file its own stable database name via `replaceMongoDbName`, so it can't
+collide with `app-integration`'s `growi_test_${workerId}` naming
 (`test/setup/mongo/test-db-config.ts`) on the same shared external MongoDB:
 
 ```ts
-import { replaceMongoDbName } from '^/test/setup/mongo/utils';
+import type { MongoMemoryServer } from 'mongodb-memory-server-core';
+
+import {
+  connectSelfContainedMongo,
+  disconnectSelfContainedMongo,
+} from '^/test/setup/mongo/self-contained-connection';
 
 let mongod: MongoMemoryServer | undefined;
 
 beforeAll(async () => {
-  const mongoUri = process.env.MONGO_URI
-    ? replaceMongoDbName(process.env.MONGO_URI, 'growi_test_unit_<unique-name>')
-    : null;
-  if (mongoUri != null) {
-    await mongoose.connect(mongoUri);
-    return;
-  }
-  mongod = await MongoMemoryServer.create();
-  await mongoose.connect(mongod.getUri());
+  ({ mongod } = await connectSelfContainedMongo('growi_test_unit_<unique-name>'));
 });
 
 afterAll(async () => {
-  await mongoose.connection.dropDatabase();
-  await mongoose.connection.close();
-  await mongod?.stop();
+  await disconnectSelfContainedMongo(mongod);
 });
 ```
 
-If the local (`MONGO_URI` unset) fallback branch is exercised often enough to
-matter, consider also passing `MONGOMS_BINARY_OPTS` to `MongoMemoryServer.create()`
-for cache consistency — but that is a secondary nicety. The `MONGO_URI`-first
-check is the actual rule; without it, the binary options never come into play
-in CI at all.
+Pass a name that is unique to this file (or `describe` block, if two blocks
+in the same file must not share fixtures concurrently) — sequential
+`describe`s in one file can safely share a name since each `afterAll` drops
+the database before the next one connects.

--- a/apps/app/src/features/contribution-graph/server/routes/get-contributions.spec.ts
+++ b/apps/app/src/features/contribution-graph/server/routes/get-contributions.spec.ts
@@ -41,7 +41,7 @@ describe('getContributionsHandler', () => {
   beforeAll(async () => {
     mongod = await MongoMemoryServer.create();
     await mongoose.connect(mongod.getUri());
-  });
+  }, 30_000); // MongoMemoryServer.create() spawns a real mongod; the 10s default can be squeezed under CI load (see #11744)
 
   afterAll(async () => {
     await mongoose.connection.dropDatabase();

--- a/apps/app/src/features/contribution-graph/server/routes/get-contributions.spec.ts
+++ b/apps/app/src/features/contribution-graph/server/routes/get-contributions.spec.ts
@@ -4,6 +4,8 @@ import { MongoMemoryServer } from 'mongodb-memory-server-core';
 import mongoose from 'mongoose';
 import { mockClear, mockDeep } from 'vitest-mock-extended';
 
+import { replaceMongoDbName } from '^/test/setup/mongo/utils';
+
 import type { ApiV3Response } from '~/server/routes/apiv3/interfaces/apiv3-response';
 import { configManager } from '~/server/service/config-manager';
 
@@ -36,17 +38,32 @@ describe('getContributionsHandler', () => {
   const mockRes = mockDeep<ApiV3Response>();
   const targetUserId = new mongoose.Types.ObjectId();
 
-  let mongod: MongoMemoryServer;
+  let mongod: MongoMemoryServer | undefined;
 
   beforeAll(async () => {
+    // Reuse an already-running MongoDB (CI's ci-app-test job starts one via
+    // supercharge/mongodb-github-action and passes MONGO_URI) instead of
+    // spawning a redundant embedded mongod — see #11744.
+    const mongoUri = process.env.MONGO_URI
+      ? replaceMongoDbName(
+          process.env.MONGO_URI,
+          'growi_test_unit_get_contributions',
+        )
+      : null;
+
+    if (mongoUri != null) {
+      await mongoose.connect(mongoUri);
+      return;
+    }
+
     mongod = await MongoMemoryServer.create();
     await mongoose.connect(mongod.getUri());
-  }, 30_000); // MongoMemoryServer.create() spawns a real mongod; the 10s default can be squeezed under CI load (see #11744)
+  });
 
   afterAll(async () => {
     await mongoose.connection.dropDatabase();
     await mongoose.connection.close();
-    await mongod.stop();
+    await mongod?.stop();
   });
 
   beforeEach(async () => {

--- a/apps/app/src/features/contribution-graph/server/routes/get-contributions.spec.ts
+++ b/apps/app/src/features/contribution-graph/server/routes/get-contributions.spec.ts
@@ -1,10 +1,13 @@
 import type { IUser } from '@growi/core';
 import type { Request } from 'express';
-import { MongoMemoryServer } from 'mongodb-memory-server-core';
+import type { MongoMemoryServer } from 'mongodb-memory-server-core';
 import mongoose from 'mongoose';
 import { mockClear, mockDeep } from 'vitest-mock-extended';
 
-import { replaceMongoDbName } from '^/test/setup/mongo/utils';
+import {
+  connectSelfContainedMongo,
+  disconnectSelfContainedMongo,
+} from '^/test/setup/mongo/self-contained-connection';
 
 import type { ApiV3Response } from '~/server/routes/apiv3/interfaces/apiv3-response';
 import { configManager } from '~/server/service/config-manager';
@@ -41,29 +44,13 @@ describe('getContributionsHandler', () => {
   let mongod: MongoMemoryServer | undefined;
 
   beforeAll(async () => {
-    // Reuse an already-running MongoDB (CI's ci-app-test job starts one via
-    // supercharge/mongodb-github-action and passes MONGO_URI) instead of
-    // spawning a redundant embedded mongod — see #11744.
-    const mongoUri = process.env.MONGO_URI
-      ? replaceMongoDbName(
-          process.env.MONGO_URI,
-          'growi_test_unit_get_contributions',
-        )
-      : null;
-
-    if (mongoUri != null) {
-      await mongoose.connect(mongoUri);
-      return;
-    }
-
-    mongod = await MongoMemoryServer.create();
-    await mongoose.connect(mongod.getUri());
+    ({ mongod } = await connectSelfContainedMongo(
+      'growi_test_unit_get_contributions',
+    ));
   });
 
   afterAll(async () => {
-    await mongoose.connection.dropDatabase();
-    await mongoose.connection.close();
-    await mongod?.stop();
+    await disconnectSelfContainedMongo(mongod);
   });
 
   beforeEach(async () => {

--- a/apps/app/src/features/contribution-graph/server/services/contribution-service.spec.ts
+++ b/apps/app/src/features/contribution-graph/server/services/contribution-service.spec.ts
@@ -1,7 +1,10 @@
-import { MongoMemoryServer } from 'mongodb-memory-server-core';
+import type { MongoMemoryServer } from 'mongodb-memory-server-core';
 import mongoose from 'mongoose';
 
-import { replaceMongoDbName } from '^/test/setup/mongo/utils';
+import {
+  connectSelfContainedMongo,
+  disconnectSelfContainedMongo,
+} from '^/test/setup/mongo/self-contained-connection';
 
 import type { IContribution } from '../../interfaces/contribution';
 import Contribution from '../models/contribution-model';
@@ -13,23 +16,9 @@ describe('addContribution', () => {
   let mongod: MongoMemoryServer | undefined;
 
   beforeAll(async () => {
-    // Reuse an already-running MongoDB (CI's ci-app-test job starts one via
-    // supercharge/mongodb-github-action and passes MONGO_URI) instead of
-    // spawning a redundant embedded mongod — see #11744.
-    const mongoUri = process.env.MONGO_URI
-      ? replaceMongoDbName(
-          process.env.MONGO_URI,
-          'growi_test_unit_contribution_service',
-        )
-      : null;
-
-    if (mongoUri != null) {
-      await mongoose.connect(mongoUri);
-      return;
-    }
-
-    mongod = await MongoMemoryServer.create();
-    await mongoose.connect(mongod.getUri());
+    ({ mongod } = await connectSelfContainedMongo(
+      'growi_test_unit_contribution_service',
+    ));
   });
 
   beforeEach(async () => {
@@ -37,9 +26,7 @@ describe('addContribution', () => {
   });
 
   afterAll(async () => {
-    await mongoose.connection.dropDatabase();
-    await mongoose.connection.close();
-    await mongod?.stop();
+    await disconnectSelfContainedMongo(mongod);
   });
 
   it('should create a new contribution record if it does not exist (upsert)', async () => {
@@ -89,23 +76,9 @@ describe('getContributions', () => {
   let mongod: MongoMemoryServer | undefined;
 
   beforeAll(async () => {
-    // Reuse an already-running MongoDB (CI's ci-app-test job starts one via
-    // supercharge/mongodb-github-action and passes MONGO_URI) instead of
-    // spawning a redundant embedded mongod — see #11744.
-    const mongoUri = process.env.MONGO_URI
-      ? replaceMongoDbName(
-          process.env.MONGO_URI,
-          'growi_test_unit_contribution_service',
-        )
-      : null;
-
-    if (mongoUri != null) {
-      await mongoose.connect(mongoUri);
-      return;
-    }
-
-    mongod = await MongoMemoryServer.create();
-    await mongoose.connect(mongod.getUri());
+    ({ mongod } = await connectSelfContainedMongo(
+      'growi_test_unit_contribution_service',
+    ));
   });
 
   beforeEach(async () => {
@@ -113,9 +86,7 @@ describe('getContributions', () => {
   });
 
   afterAll(async () => {
-    await mongoose.connection.dropDatabase();
-    await mongoose.connection.close();
-    await mongod?.stop();
+    await disconnectSelfContainedMongo(mongod);
   });
 
   it('should return one year of contributions if they exist in the database', async () => {

--- a/apps/app/src/features/contribution-graph/server/services/contribution-service.spec.ts
+++ b/apps/app/src/features/contribution-graph/server/services/contribution-service.spec.ts
@@ -14,7 +14,7 @@ describe('addContribution', () => {
     mongod = await MongoMemoryServer.create();
     const uri = mongod.getUri();
     await mongoose.connect(uri);
-  });
+  }, 30_000); // MongoMemoryServer.create() spawns a real mongod; the 10s default can be squeezed under CI load (see #11744)
 
   beforeEach(async () => {
     await Contribution.deleteMany({});
@@ -76,7 +76,7 @@ describe('getContributions', () => {
     mongod = await MongoMemoryServer.create();
     const uri = mongod.getUri();
     await mongoose.connect(uri);
-  });
+  }, 30_000); // MongoMemoryServer.create() spawns a real mongod; the 10s default can be squeezed under CI load (see #11744)
 
   beforeEach(async () => {
     await Contribution.deleteMany({});

--- a/apps/app/src/features/contribution-graph/server/services/contribution-service.spec.ts
+++ b/apps/app/src/features/contribution-graph/server/services/contribution-service.spec.ts
@@ -1,6 +1,8 @@
 import { MongoMemoryServer } from 'mongodb-memory-server-core';
 import mongoose from 'mongoose';
 
+import { replaceMongoDbName } from '^/test/setup/mongo/utils';
+
 import type { IContribution } from '../../interfaces/contribution';
 import Contribution from '../models/contribution-model';
 import { addContribution, getContributions } from './contribution-service';
@@ -8,13 +10,27 @@ import { addContribution, getContributions } from './contribution-service';
 describe('addContribution', () => {
   const userId = new mongoose.Types.ObjectId().toString();
 
-  let mongod: MongoMemoryServer;
+  let mongod: MongoMemoryServer | undefined;
 
   beforeAll(async () => {
+    // Reuse an already-running MongoDB (CI's ci-app-test job starts one via
+    // supercharge/mongodb-github-action and passes MONGO_URI) instead of
+    // spawning a redundant embedded mongod — see #11744.
+    const mongoUri = process.env.MONGO_URI
+      ? replaceMongoDbName(
+          process.env.MONGO_URI,
+          'growi_test_unit_contribution_service',
+        )
+      : null;
+
+    if (mongoUri != null) {
+      await mongoose.connect(mongoUri);
+      return;
+    }
+
     mongod = await MongoMemoryServer.create();
-    const uri = mongod.getUri();
-    await mongoose.connect(uri);
-  }, 30_000); // MongoMemoryServer.create() spawns a real mongod; the 10s default can be squeezed under CI load (see #11744)
+    await mongoose.connect(mongod.getUri());
+  });
 
   beforeEach(async () => {
     await Contribution.deleteMany({});
@@ -23,7 +39,7 @@ describe('addContribution', () => {
   afterAll(async () => {
     await mongoose.connection.dropDatabase();
     await mongoose.connection.close();
-    await mongod.stop();
+    await mongod?.stop();
   });
 
   it('should create a new contribution record if it does not exist (upsert)', async () => {
@@ -70,13 +86,27 @@ describe('addContribution', () => {
 describe('getContributions', () => {
   const userId = new mongoose.Types.ObjectId().toString();
 
-  let mongod: MongoMemoryServer;
+  let mongod: MongoMemoryServer | undefined;
 
   beforeAll(async () => {
+    // Reuse an already-running MongoDB (CI's ci-app-test job starts one via
+    // supercharge/mongodb-github-action and passes MONGO_URI) instead of
+    // spawning a redundant embedded mongod — see #11744.
+    const mongoUri = process.env.MONGO_URI
+      ? replaceMongoDbName(
+          process.env.MONGO_URI,
+          'growi_test_unit_contribution_service',
+        )
+      : null;
+
+    if (mongoUri != null) {
+      await mongoose.connect(mongoUri);
+      return;
+    }
+
     mongod = await MongoMemoryServer.create();
-    const uri = mongod.getUri();
-    await mongoose.connect(uri);
-  }, 30_000); // MongoMemoryServer.create() spawns a real mongod; the 10s default can be squeezed under CI load (see #11744)
+    await mongoose.connect(mongod.getUri());
+  });
 
   beforeEach(async () => {
     await Contribution.deleteMany({});
@@ -85,7 +115,7 @@ describe('getContributions', () => {
   afterAll(async () => {
     await mongoose.connection.dropDatabase();
     await mongoose.connection.close();
-    await mongod.stop();
+    await mongod?.stop();
   });
 
   it('should return one year of contributions if they exist in the database', async () => {

--- a/apps/app/src/server/routes/apiv3/g2g-transfer-non-transferable.integ.ts
+++ b/apps/app/src/server/routes/apiv3/g2g-transfer-non-transferable.integ.ts
@@ -129,7 +129,12 @@ describe('non-transferable collections at the transfer routes', () => {
     await User.deleteMany({ _id: CLEAN_USER._id });
     const leftovers = await fs.readdir(importsDir);
     await Promise.all(
-      leftovers.map((fileName) => fs.rm(path.join(importsDir, fileName))),
+      // `{ force: true }`: the server's own `finally` block (g2g-transfer.ts)
+      // may have already deleted the same file by the time this runs, which
+      // is not an error here either (see #11722).
+      leftovers.map((fileName) =>
+        fs.rm(path.join(importsDir, fileName), { force: true }),
+      ),
     );
   };
 

--- a/apps/app/src/server/routes/apiv3/g2g-transfer-replace-targets.exclusive.integ.ts
+++ b/apps/app/src/server/routes/apiv3/g2g-transfer-replace-targets.exclusive.integ.ts
@@ -151,7 +151,12 @@ describe('receive route POST / — a replaced collection cannot conflict', () =>
     await UserGroup.deleteMany({});
     const leftovers = await fs.readdir(importsDir);
     await Promise.all(
-      leftovers.map((fileName) => fs.rm(path.join(importsDir, fileName))),
+      // `{ force: true }`: the server's own `finally` block (g2g-transfer.ts)
+      // may have already deleted the same file by the time this runs, which
+      // is not an error here either (see #11751).
+      leftovers.map((fileName) =>
+        fs.rm(path.join(importsDir, fileName), { force: true }),
+      ),
     );
   });
 

--- a/apps/app/test/setup/mongo/self-contained-connection.ts
+++ b/apps/app/test/setup/mongo/self-contained-connection.ts
@@ -1,0 +1,40 @@
+import { MongoMemoryServer } from 'mongodb-memory-server-core';
+import mongoose from 'mongoose';
+
+import { replaceMongoDbName } from './utils';
+
+/**
+ * Connect a self-contained test file — one that manages its own connection
+ * lifecycle from beforeAll to afterAll, as opposed to relying on the
+ * app-integration project's shared per-worker connection (test/setup/mongo/index.ts) —
+ * to a real MongoDB.
+ *
+ * Prefers the already-running MongoDB CI provides via MONGO_URI; only spawns
+ * an embedded MongoMemoryServer when it's unset. See
+ * apps/app/.claude/rules/mongo-test-setup.md for why this check matters.
+ */
+export async function connectSelfContainedMongo(
+  dbName: string,
+): Promise<{ mongod?: MongoMemoryServer }> {
+  const mongoUri = process.env.MONGO_URI
+    ? replaceMongoDbName(process.env.MONGO_URI, dbName)
+    : null;
+
+  if (mongoUri != null) {
+    await mongoose.connect(mongoUri);
+    return {};
+  }
+
+  const mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  return { mongod };
+}
+
+/** Counterpart to {@link connectSelfContainedMongo}; call from afterAll. */
+export async function disconnectSelfContainedMongo(
+  mongod?: MongoMemoryServer,
+): Promise<void> {
+  await mongoose.connection.dropDatabase();
+  await mongoose.connection.close();
+  await mongod?.stop();
+}


### PR DESCRIPTION
## Summary
- `g2g-transfer-non-transferable.integ.ts` and `g2g-transfer-replace-targets.exclusive.integ.ts`'s cleanup helpers raced against the receive route's own `finally`-block cleanup of the same uploaded archive; `fs.rm()` now tolerates the file already being gone (`{ force: true }`), mirroring the production code's own justification for the same flag.
- `get-contributions.spec.ts` / `contribution-service.spec.ts` called `MongoMemoryServer.create()` unconditionally, ignoring the real MongoDB CI's `ci-app-test` job already starts and exposes via `MONGO_URI`. That spawned a redundant, unprotected embedded `mongod` from a cache/version path unrelated to the project's pinned `MONGOMS_BINARY_OPTS` — confirmed by observing the actual spawned process while `MONGO_URI` pointed at a live MongoDB. Each `beforeAll` now uses a new shared helper (`test/setup/mongo/self-contained-connection.ts`) that checks `MONGO_URI` first and only falls back to `MongoMemoryServer` when it's unset (an initial timeout-bump-only commit was superseded once the real cause was found).
- Added `apps/app/.claude/rules/mongo-test-setup.md` codifying the `MONGO_URI`-first check so future Vitest files needing a real MongoDB don't repeat this flake.

All three root causes were originally identified by an earlier autonomous `investigate-flaky-test` pass, which could not open a fix PR in that environment (no `actions:write`/push access). This PR implements the fixes.

## Test plan
- [x] `pnpm vitest run contribution-service.spec get-contributions.spec g2g-transfer-non-transferable g2g-transfer-replace-targets.exclusive` — 15/15 passed
- [x] Re-ran the contribution-graph specs with `MONGO_URI` set to a live MongoDB — connects directly, no embedded `mongod` spawned (verified via `ps aux`)
- [x] `pnpm biome check` on all changed files — clean (one pre-existing unrelated unused-import warning left untouched)

Fixes #11722
Fixes #11744
Fixes #11751