### PR TITLE
fix: stabilize flaky test in sticky-for-guest.spec.ts

### DIFF
--- a/apps/app/playwright/21-basic-features-for-guest/sticky-for-guest.spec.ts
+++ b/apps/app/playwright/21-basic-features-for-guest/sticky-for-guest.spec.ts
@@ -5,6 +5,19 @@ test('Sub navigation sticky changes when scrolling down and up', async ({
 }) => {
   await page.goto('/Sandbox');
 
+  // react-stickynode measures the wrapper's initial offset at mount time.
+  // Scrolling immediately after goto() races that measurement against
+  // client-side hydration and any post-load data fetches that affect
+  // layout, which intermittently leaves the very first scroll event
+  // checked against a stale/not-yet-computed trigger point. Waiting for
+  // the network to settle and the wrapper to actually be visible before
+  // scrolling lets that initial measurement complete first. Same
+  // mechanism as growilabs/growi#11780/#11797/#11798 in the sibling
+  // sticky-features.spec.ts (see PR #11801) — this spec has its own
+  // instance of the same race. See growilabs/growi#11782.
+  await page.waitForLoadState('networkidle');
+  await expect(page.locator('.sticky-outer-wrapper').first()).toBeVisible();
+
   // Wait until the page is scrollable
   await expect
     .poll(async () => {


### PR DESCRIPTION
## Summary

`playwright/21-basic-features-for-guest/sticky-for-guest.spec.ts` scrolled
immediately after `page.goto('/Sandbox')` (and a scrollability poll), without
waiting for hydration or layout-affecting data fetches to settle first —
same mechanism as #11780/#11797/#11798 in the sibling
`20-basic-features/sticky-features.spec.ts`, fixed in #11801.

## Root Cause

**Environment/timing race, test-side.** `react-stickynode` measures the
sticky wrapper's initial trigger offset at mount time. This spec's first
scroll can race ahead of that measurement settling, so `.sticky-outer-wrapper`
doesn't pick up the `active` class within the assertion's timeout — matching
this issue's evidence exactly (`Locator: locator('.sticky-outer-wrapper').first()`,
expected `/active/`, timeout, recovers on retry).

## Fix

Wait for the network to settle and for the sticky wrapper to actually be
visible before any scroll, mirroring PR #11801's fix to the sibling spec.

## Verification

- Basic CI (lint/build/launch-dev) green.
- `run-playwright` only executes in Mergify's merge queue (not on ordinary
  PR events, per `reusable-app-prod.yml`), so this PR's own CI cannot
  directly re-exercise the flaky spec — same limitation noted on #11791.
  Confidence comes from this being the identical, already-verified fix
  pattern from #11801 applied to the sibling file with the same
  `.sticky-outer-wrapper` mechanism.

Fixes #11782