### PR TITLE
fix: stabilize flaky test in create-page-button.spec.ts dropdown

### DIFF
--- a/apps/app/playwright/20-basic-features/create-page-button.spec.ts
+++ b/apps/app/playwright/20-basic-features/create-page-button.spec.ts
@@ -25,16 +25,30 @@ test.describe('Create page button dropdown menu', () => {
 
     // open dropdown menu
     await page.getByTestId('grw-page-create-button').hover();
-    await expect(
-      page
-        .getByTestId('grw-page-create-button')
-        .getByLabel('Open create page menu'),
-    ).toBeVisible();
-    await page
+    const toggle = page
       .getByTestId('grw-page-create-button')
-      .getByLabel('Open create page menu')
-      .dispatchEvent('click'); // simulate the click
-    await page.getByRole('menuitem', { name: 'Create today page' }).click();
+      .getByLabel('Open create page menu');
+    await expect(toggle).toBeVisible();
+    // `dispatchEvent` (not `.click()`) is required here: the toggle's
+    // clickable area overlaps the sibling create-button's SVG (Hexagon)
+    // shape, so a real click's hit-test resolves to that SVG's `<path>`
+    // instead of the toggle and fails deterministically (verified locally —
+    // switching this to `.click()` fails 10/10 with "subtree intercepts
+    // pointer events"). `dispatchEvent` bypasses hit-testing and dispatches
+    // straight to the toggle, which is safe here since it is a real,
+    // synchronous state change (dropdown opens immediately on click).
+    await toggle.dispatchEvent('click');
+    const menuItem = page.getByRole('menuitem', { name: 'Create today page' });
+    // Wait for the menu item to be visible *before* clicking it, as a
+    // separate step: reactstrap's Dropdown mounts/positions its menu (a
+    // `container="body"` portal) asynchronously after the toggle event, and
+    // queuing `.click()` immediately can catch a node that is still
+    // being replaced mid-mount — the "element was detached from the DOM,
+    // retrying" signature seen in growilabs/growi#11779. Resolving the
+    // locator fresh via `.click()`'s own actionability wait, only after
+    // this settles, avoids racing that mount.
+    await expect(menuItem).toBeVisible();
+    await menuItem.click();
 
     // should not be visible
     await expect(page.getByPlaceholder('Input page name')).not.toBeVisible();


### PR DESCRIPTION
## Summary

`playwright/20-basic-features/create-page-button.spec.ts`'s "open and create
today page" test intermittently failed clicking the "Create today page" menu
item — observed twice independently, same signature both times.

## Root Cause

**Missing await / race in the test.** reactstrap's Dropdown mounts its menu
(a `container="body"` portal) asynchronously after the toggle is clicked.
The test opened the dropdown then went straight into
`.click()` on the menu item with no intermediate wait — on a contended CI
runner, the click could queue against a menu-item node that was still being
replaced mid-mount, producing "element was detached from the DOM, retrying"
until the 30s test timeout.

Evidence (2 independent occurrences, identical signature):
- Run https://github.com/growilabs/growi/actions/runs/32851594909 (commit `ea6fded8`)
- Run https://github.com/growilabs/growi/actions/runs/32844634065 (commit `77cfabad`)

### A wrong first attempt, corrected by local reproduction

This environment doesn't normally have Firefox installed for Playwright, but
`playwright install-deps firefox && playwright install firefox` worked here,
which allowed empirical verification rather than a guess. The first attempt
also switched the *toggle's* `dispatchEvent('click')` to a real `.click()`,
reasoning that `dispatchEvent` itself was the race. That reproduced 10/10
failures locally — real click's hit-test resolves to the sibling create
button's overlapping SVG `<path>`, not the toggle
("subtree intercepts pointer events"). `dispatchEvent` on the toggle is
required and correct (same reason as the toggle in the sibling test, see
#11784) and was left unchanged.

## Fix

Add an explicit `await expect(menuItem).toBeVisible()` before clicking the
menu item, so the click only proceeds once the portal-mounted menu has
settled — same principle as PR #11801's sticky-features fix (wait for a
real postcondition, not a delay).

## Verification

- Local repro: reproduced the *wrong* fix's failure 10/10 (chromium+firefox,
  toggle `.click()` variant) — confirms the hit-test theory.
- Local repro of the actual fix: 22/22 passed (chromium+firefox,
  `-g "open and create today page"`, `--repeat-each=10`).
- `run-playwright` only executes in Mergify's merge queue, not on ordinary
  PR events, so this PR's own CI cannot re-exercise the original CI-only
  race directly — confidence here comes from local reproduction of both the
  wrong and correct fix, not from PR CI.

Fixes #11779