### PR TITLE
Bump @growi/core as major for the wipExpiredAt rename

### DIFF
--- a/.changeset/rename-ttl-timestamp-to-wip-expired-at.md
+++ b/.changeset/rename-ttl-timestamp-to-wip-expired-at.md
@@ -1,5 +1,5 @@
 ---
-"@growi/core": minor
+"@growi/core": major
 ---
 
 Rename `IPage.ttlTimestamp` to `IPage.wipExpiredAt` and change its meaning


### PR DESCRIPTION
## Summary
- PR #11793 (Version Packages) bumps `@growi/core` as minor (2.5.x → 2.6.0), even though the underlying changeset (from #11513, renaming `IPage.ttlTimestamp` to `IPage.wipExpiredAt`) is documented as `BREAKING:`.
- This repeats a prior instance (2.5.0 / #11267) where a breaking change was shipped as minor with a `BREAKING:` note instead of a major bump.
- Per discussion, strict SemVer should be followed instead: this PR changes the changeset's bump level from `minor` to `major`, so the pending Version Packages PR will publish `@growi/core@3.0.0` instead.

## Test plan
- [ ] Confirm the Changesets bot updates PR #11793 to reflect `@growi/core@3.0.0` after this merges