### PR TITLE
fix: Enforce access control on revision-by-id and attachment-by-id apiv3 routes

### DIFF
--- a/apps/app/src/server/routes/apiv3/attachment-access.integ.ts
+++ b/apps/app/src/server/routes/apiv3/attachment-access.integ.ts
@@ -53,6 +53,7 @@ describe("GET /attachment/:id — must check access to the attachment's owning p
   let privatePageId: string;
   let privateAttachmentId: string;
   let accessibleAttachmentId: string;
+  let profileImageAttachmentId: string;
 
   let currentUser: IUserHasId | undefined;
 
@@ -113,6 +114,15 @@ describe("GET /attachment/:id — must check access to the attachment's owning p
     accessibleAttachmentId = String(accessibleAttachment._id);
     privateAttachmentId = String(privateAttachment._id);
 
+    const profileImageAttachment = await Attachment.create({
+      creator: otherUser._id,
+      fileName: `attachment-access-integ-profile-image-${WORKER_ID}`,
+      fileFormat: 'image/png',
+      originalName: 'avatar.png',
+      attachmentType: AttachmentType.PROFILE_IMAGE,
+    });
+    profileImageAttachmentId = String(profileImageAttachment._id);
+
     const { setup } = await import('./attachment');
     const router = setup(crowi);
 
@@ -133,7 +143,13 @@ describe("GET /attachment/:id — must check access to the attachment's owning p
 
   afterAll(async () => {
     await Attachment.deleteMany({
-      _id: { $in: [accessibleAttachmentId, privateAttachmentId] },
+      _id: {
+        $in: [
+          accessibleAttachmentId,
+          privateAttachmentId,
+          profileImageAttachmentId,
+        ],
+      },
     });
     await crowi.models.Page.deleteMany({
       path: { $in: [ACCESSIBLE_PATH, PRIVATE_PATH] },
@@ -156,5 +172,12 @@ describe("GET /attachment/:id — must check access to the attachment's owning p
 
     expect(res.status).toBe(200);
     expect(res.body.data.attachment.originalName).toBe('accessible.txt');
+  });
+
+  it('returns metadata for a non-page-scoped attachment (e.g. PROFILE_IMAGE), which has no page to check', async () => {
+    const res = await getAttachment(profileImageAttachmentId, testUser);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.attachment.originalName).toBe('avatar.png');
   });
 });

--- a/apps/app/src/server/routes/apiv3/attachment-access.integ.ts
+++ b/apps/app/src/server/routes/apiv3/attachment-access.integ.ts
@@ -1,0 +1,160 @@
+/**
+ * Regression test for GET /attachment/:id — the handler must check the
+ * viewer's access to the attachment's owning page, mirroring the check
+ * /attachment/list already performs.
+ *
+ * Real MongoDB (Page/User/Attachment) + the real route handler exported
+ * from ./attachment. Only accessTokenParser / login-required are stubbed to
+ * a passthrough (auth is not what this test verifies); the real
+ * Page.isAccessiblePageByViewer and the real handler logic run unmodified,
+ * mirroring the attachment-add-activity.integ.ts precedent.
+ */
+
+import type { IUserHasId } from '@growi/core';
+import { PageGrant } from '@growi/core';
+import type { NextFunction, Request, Response } from 'express';
+import express from 'express';
+import request from 'supertest';
+
+import { getInstance } from '^/test/setup/crowi';
+
+import type Crowi from '~/server/crowi';
+import { AttachmentType } from '~/server/interfaces/attachment';
+import { Attachment } from '~/server/models/attachment';
+
+import type { ApiV3Response } from './interfaces/apiv3-response';
+
+const passthrough = (_req: Request, _res: Response, next: NextFunction) =>
+  next();
+
+vi.mock('~/server/middlewares/access-token-parser', () => ({
+  accessTokenParser: () => passthrough,
+}));
+vi.mock('~/server/middlewares/login-required', () => ({
+  default: () => passthrough,
+}));
+
+const WORKER_ID = process.env.VITEST_WORKER_ID ?? '1';
+const ACCESSIBLE_PATH = `/attachment-access-integ-accessible-${WORKER_ID}`;
+const PRIVATE_PATH = `/attachment-access-integ-private-${WORKER_ID}`;
+const MOUNT_PATH = '/attachment';
+
+interface AuthorizedRequest extends Request {
+  user?: IUserHasId;
+}
+
+describe("GET /attachment/:id — must check access to the attachment's owning page", () => {
+  let crowi: Crowi;
+  let app: express.Application;
+  let testUser: IUserHasId;
+  let otherUser: IUserHasId;
+
+  let accessiblePageId: string;
+  let privatePageId: string;
+  let privateAttachmentId: string;
+  let accessibleAttachmentId: string;
+
+  let currentUser: IUserHasId | undefined;
+
+  function getAttachment(attachmentId: string, user: IUserHasId | undefined) {
+    currentUser = user;
+    return request(app).get(`${MOUNT_PATH}/${attachmentId}`);
+  }
+
+  beforeAll(async () => {
+    crowi = await getInstance();
+    const { Page, User } = crowi.models;
+
+    await Page.deleteMany({ path: { $in: [ACCESSIBLE_PATH, PRIVATE_PATH] } });
+
+    testUser = await User.create({
+      name: 'Attachment Access Integ User',
+      username: `attachment-access-integ-user-${WORKER_ID}`,
+      email: `attachment-access-integ-user-${WORKER_ID}@example.com`,
+    });
+    otherUser = await User.create({
+      name: 'Attachment Access Integ Other User',
+      username: `attachment-access-integ-other-${WORKER_ID}`,
+      email: `attachment-access-integ-other-${WORKER_ID}@example.com`,
+    });
+
+    const accessiblePage = await Page.create({
+      path: ACCESSIBLE_PATH,
+      grant: PageGrant.GRANT_PUBLIC,
+      creator: testUser._id,
+      lastUpdateUser: testUser._id,
+    });
+    const privatePage = await Page.create({
+      path: PRIVATE_PATH,
+      grant: PageGrant.GRANT_OWNER,
+      grantedUsers: [otherUser._id],
+      creator: otherUser._id,
+      lastUpdateUser: otherUser._id,
+    });
+    accessiblePageId = String(accessiblePage._id);
+    privatePageId = String(privatePage._id);
+
+    const accessibleAttachment = await Attachment.create({
+      page: accessiblePageId,
+      creator: testUser._id,
+      fileName: `attachment-access-integ-accessible-${WORKER_ID}`,
+      fileFormat: 'text/plain',
+      originalName: 'accessible.txt',
+      attachmentType: AttachmentType.WIKI_PAGE,
+    });
+    const privateAttachment = await Attachment.create({
+      page: privatePageId,
+      creator: otherUser._id,
+      fileName: `attachment-access-integ-private-${WORKER_ID}`,
+      fileFormat: 'text/plain',
+      originalName: 'SECRET-ORIGINAL-NAME.txt',
+      attachmentType: AttachmentType.WIKI_PAGE,
+    });
+    accessibleAttachmentId = String(accessibleAttachment._id);
+    privateAttachmentId = String(privateAttachment._id);
+
+    const { setup } = await import('./attachment');
+    const router = setup(crowi);
+
+    app = express();
+    app.use((req: AuthorizedRequest, res: Response & ApiV3Response, next) => {
+      if (currentUser != null) {
+        req.user = currentUser;
+      }
+      // biome-ignore lint/suspicious/noExplicitAny: test helper shim
+      res.apiv3 = (data: any) => res.json({ ok: true, data });
+      // biome-ignore lint/suspicious/noExplicitAny: test helper shim
+      res.apiv3Err = (err: any, code = 400) =>
+        res.status(code).json({ ok: false, error: String(err) });
+      next();
+    });
+    app.use(MOUNT_PATH, router);
+  }, 60_000);
+
+  afterAll(async () => {
+    await Attachment.deleteMany({
+      _id: { $in: [accessibleAttachmentId, privateAttachmentId] },
+    });
+    await crowi.models.Page.deleteMany({
+      path: { $in: [ACCESSIBLE_PATH, PRIVATE_PATH] },
+    });
+    await crowi.models.User.deleteMany({
+      _id: { $in: [testUser._id, otherUser._id] },
+    });
+  }, 30_000);
+
+  it("rejects a viewer who cannot access the attachment's owning page", async () => {
+    const res = await getAttachment(privateAttachmentId, testUser);
+
+    expect(res.status).toBe(404);
+    // Metadata (original filename, etc.) must not leak alongside the rejection.
+    expect(JSON.stringify(res.body)).not.toContain('SECRET-ORIGINAL-NAME.txt');
+  });
+
+  it('returns the attachment metadata when the viewer can access the owning page', async () => {
+    const res = await getAttachment(accessibleAttachmentId, testUser);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.attachment.originalName).toBe('accessible.txt');
+  });
+});

--- a/apps/app/src/server/routes/apiv3/attachment.js
+++ b/apps/app/src/server/routes/apiv3/attachment.js
@@ -487,12 +487,22 @@ export const setup = (crowi) => {
     async (req, res) => {
       try {
         const attachmentId = req.params.id;
+        const { isSharedPage } = req;
 
         const attachment = await Attachment.findById(attachmentId)
           .populate('creator')
           .exec();
 
         if (attachment == null) {
+          const message = 'Attachment not found';
+          return res.apiv3Err(message, 404);
+        }
+
+        // check whether accessible
+        if (
+          !isSharedPage &&
+          !(await Page.isAccessiblePageByViewer(attachment.page, req.user))
+        ) {
           const message = 'Attachment not found';
           return res.apiv3Err(message, 404);
         }

--- a/apps/app/src/server/routes/apiv3/attachment.js
+++ b/apps/app/src/server/routes/apiv3/attachment.js
@@ -498,9 +498,13 @@ export const setup = (crowi) => {
           return res.apiv3Err(message, 404);
         }
 
-        // check whether accessible
+        // check whether accessible. Attachments not scoped to a page
+        // (PROFILE_IMAGE, BRAND_LOGO, PAGE_BULK_EXPORT, AUDIT_LOG_BULK_EXPORT)
+        // have no `page` to check against, so this only applies to
+        // page-scoped attachments (mirrors routes/attachment/get.ts).
         if (
           !isSharedPage &&
+          attachment.page != null &&
           !(await Page.isAccessiblePageByViewer(attachment.page, req.user))
         ) {
           const message = 'Attachment not found';

--- a/apps/app/src/server/routes/apiv3/revisions.integ.ts
+++ b/apps/app/src/server/routes/apiv3/revisions.integ.ts
@@ -1,0 +1,186 @@
+/**
+ * Regression test for GET /revisions/:id — the access check must be scoped
+ * to the revision actually fetched, not only to the `pageId` query param.
+ *
+ * Real MongoDB (Page/User) + real Prisma (revisions) + the real route
+ * handler exported from ./revisions. Only accessTokenParser / login-required
+ * are stubbed to a passthrough (auth is not what this test verifies); the
+ * real Page.isAccessiblePageByViewer and the real handler logic run
+ * unmodified, mirroring the attachment-add-activity.integ.ts precedent.
+ */
+
+import type { IUserHasId } from '@growi/core';
+import { PageGrant } from '@growi/core';
+import type { NextFunction, Request, Response } from 'express';
+import express from 'express';
+import request from 'supertest';
+
+import { getInstance } from '^/test/setup/crowi';
+
+import type Crowi from '~/server/crowi';
+import { prisma } from '~/utils/prisma';
+
+import type { ApiV3Response } from './interfaces/apiv3-response';
+
+const passthrough = (_req: Request, _res: Response, next: NextFunction) =>
+  next();
+
+vi.mock('~/server/middlewares/access-token-parser', () => ({
+  accessTokenParser: () => passthrough,
+}));
+vi.mock('~/server/middlewares/login-required', () => ({
+  default: () => passthrough,
+}));
+
+const WORKER_ID = process.env.VITEST_WORKER_ID ?? '1';
+const ACCESSIBLE_PATH = `/revisions-integ-accessible-${WORKER_ID}`;
+const PRIVATE_PATH = `/revisions-integ-private-${WORKER_ID}`;
+const MOUNT_PATH = '/revisions';
+
+interface AuthorizedRequest extends Request {
+  user?: IUserHasId;
+}
+
+describe('GET /revisions/:id — revision must belong to the checked pageId', () => {
+  let crowi: Crowi;
+  let app: express.Application;
+  let testUser: IUserHasId;
+  let otherUser: IUserHasId;
+
+  let accessiblePageId: string;
+  let accessibleRevisionId: string;
+  let privatePageId: string;
+  let privateRevisionId: string;
+
+  function getRevision(
+    revisionId: string,
+    pageId: string,
+    user: IUserHasId | undefined,
+  ) {
+    currentUser = user;
+    return request(app).get(`${MOUNT_PATH}/${revisionId}`).query({ pageId });
+  }
+
+  let currentUser: IUserHasId | undefined;
+
+  beforeAll(async () => {
+    crowi = await getInstance();
+    const { Page, User } = crowi.models;
+
+    await Page.deleteMany({ path: { $in: [ACCESSIBLE_PATH, PRIVATE_PATH] } });
+
+    testUser = await User.create({
+      name: 'Revisions Integ User',
+      username: `revisions-integ-user-${WORKER_ID}`,
+      email: `revisions-integ-user-${WORKER_ID}@example.com`,
+    });
+    otherUser = await User.create({
+      name: 'Revisions Integ Other User',
+      username: `revisions-integ-other-${WORKER_ID}`,
+      email: `revisions-integ-other-${WORKER_ID}@example.com`,
+    });
+
+    const accessiblePage = await Page.create({
+      path: ACCESSIBLE_PATH,
+      grant: PageGrant.GRANT_PUBLIC,
+      creator: testUser._id,
+      lastUpdateUser: testUser._id,
+    });
+    const privatePage = await Page.create({
+      path: PRIVATE_PATH,
+      grant: PageGrant.GRANT_OWNER,
+      grantedUsers: [otherUser._id],
+      creator: otherUser._id,
+      lastUpdateUser: otherUser._id,
+    });
+    accessiblePageId = String(accessiblePage._id);
+    privatePageId = String(privatePage._id);
+
+    const accessibleRevision = await prisma.revisions.create({
+      data: {
+        pageId: accessiblePageId,
+        body: 'ACCESSIBLE-PAGE-BODY',
+        format: 'markdown',
+        authorId: String(testUser._id),
+      },
+    });
+    const privateRevision = await prisma.revisions.create({
+      data: {
+        pageId: privatePageId,
+        body: 'PRIVATE-PAGE-BODY-MUST-NOT-LEAK',
+        format: 'markdown',
+        authorId: String(otherUser._id),
+      },
+    });
+    accessibleRevisionId = accessibleRevision.id;
+    privateRevisionId = privateRevision.id;
+
+    const { setup } = await import('./revisions');
+    const router = setup(crowi);
+
+    app = express();
+    app.use(express.json());
+    app.use((req: AuthorizedRequest, res: Response & ApiV3Response, next) => {
+      if (currentUser != null) {
+        req.user = currentUser;
+      }
+      // biome-ignore lint/suspicious/noExplicitAny: test helper shim
+      res.apiv3 = (data: any) => res.json({ ok: true, data });
+      // biome-ignore lint/suspicious/noExplicitAny: test helper shim
+      res.apiv3Err = (err: any, code = 400) =>
+        res.status(code).json({ ok: false, error: String(err) });
+      next();
+    });
+    app.use(MOUNT_PATH, router);
+  }, 60_000);
+
+  afterAll(async () => {
+    await prisma.revisions.deleteMany({
+      where: { pageId: { in: [accessiblePageId, privatePageId] } },
+    });
+    await crowi.models.Page.deleteMany({
+      path: { $in: [ACCESSIBLE_PATH, PRIVATE_PATH] },
+    });
+    await crowi.models.User.deleteMany({
+      _id: { $in: [testUser._id, otherUser._id] },
+    });
+  }, 30_000);
+
+  it('rejects a revisionId that belongs to a different page than the checked pageId', async () => {
+    // testUser can view accessiblePageId, but pairs it with a revisionId
+    // that actually belongs to the private page — the crossover this bug
+    // report described.
+    const res = await getRevision(
+      privateRevisionId,
+      accessiblePageId,
+      testUser,
+    );
+
+    expect(res.status).toBe(403);
+    expect(res.body.ok).toBe(false);
+    // Whatever the response is, it must not contain the private body.
+    expect(JSON.stringify(res.body)).not.toContain(
+      'PRIVATE-PAGE-BODY-MUST-NOT-LEAK',
+    );
+  });
+
+  it('returns the revision when pageId and revisionId genuinely match and are accessible', async () => {
+    const res = await getRevision(
+      accessibleRevisionId,
+      accessiblePageId,
+      testUser,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.revision.body).toBe('ACCESSIBLE-PAGE-BODY');
+  });
+
+  it('rejects when the checked pageId itself is not accessible to the viewer, even with a matching revisionId', async () => {
+    const res = await getRevision(privateRevisionId, privatePageId, testUser);
+
+    expect(res.status).toBe(403);
+    expect(JSON.stringify(res.body)).not.toContain(
+      'PRIVATE-PAGE-BODY-MUST-NOT-LEAK',
+    );
+  });
+});

--- a/apps/app/src/server/routes/apiv3/revisions.js
+++ b/apps/app/src/server/routes/apiv3/revisions.js
@@ -272,6 +272,21 @@ export const setup = (crowi) => {
           include: { author: true },
         });
 
+        // The pageId access check above only proves the caller may view the
+        // page identified by the query param — it says nothing about the
+        // revision fetched by the path param. Without this check, a caller
+        // could pair an accessible page's pageId with an arbitrary
+        // revisionId to read another page's revision.
+        if (revision == null || revision.pageId !== pageId) {
+          return res.apiv3Err(
+            new ErrorV3(
+              'Current user is not accessible to this page.',
+              'forbidden-page',
+            ),
+            403,
+          );
+        }
+
         if (revision.author != null) {
           revision.author = serializeUserSecurely(revision.author);
         }


### PR DESCRIPTION
## Summary

Two apiv3 GET endpoints were missing an access-control check that their sibling endpoints already perform correctly, allowing an authenticated user to read data from pages they cannot access:

- `GET /_api/v3/revisions/:id` checked page access against the `pageId` query param, but fetched the revision by the path `id` with no check that the two actually referred to the same page.
- `GET /_api/v3/attachment/:id` performed no page-access check at all.

Reported privately (not via a public GitHub issue).

## Changes

- `apps/app/src/server/routes/apiv3/revisions.js`: after fetching the revision, reject with 403 if it is missing or its `pageId` does not match the checked `pageId`.
- `apps/app/src/server/routes/apiv3/attachment.js`: check `Page.isAccessiblePageByViewer(attachment.page, req.user)` before returning attachment metadata, returning a uniform 404 on failure (per `apps/app/.claude/rules/page-write-action-403-404.md`).
- New integration tests: `revisions.integ.ts`, `attachment-access.integ.ts`.

## Test Plan

- [x] New tests confirmed RED against the pre-fix code, GREEN after the fix
- [x] Existing `apiv3`/`attachment` integration suites (17 files, 129 tests) pass unaffected
- [x] `lint:biome`, `lint:typecheck`, `lint:route-guard`, `lint:import-convention` all pass