### PR TITLE
fix: bound app-integration worker concurrency instead of widening hookTimeout

### DIFF
--- a/.claude/skills/investigate-flaky-test/SKILL.md
+++ b/.claude/skills/investigate-flaky-test/SKILL.md
@@ -302,30 +302,48 @@ redesign opportunity, not an environment-timing dead end:
 - This turns an O(N) cost into an O(1) cost, which removes the test's
   sensitivity to CI load rather than buying temporary headroom against it.
 
-**Driver 2 — the cost scales with concurrent worker count, not a test-local
-parameter.** A `beforeAll`/`afterAll` in a `setupFiles` entry (migration
-replay, a singleton service cold-init, etc.) runs once per Vitest
-**worker**, and its timeout applies to every spec file that worker happens
-to run — not to one test. "This hook's own cost doesn't loop over
-anything, so there's nothing to redesign" sounds like it forces driver 1's
-dead end, but it doesn't: the cost still scales with **how many workers
-pay it at the same moment**, since sibling workers on the same CI runner
-compete for the same CPU while each does its own heavy cold-start work
-(spawning a migration subprocess, initializing a singleton, etc.). A
-same-commit failure across several unrelated spec files that all timed out
-on the identical `beforeAll` line, with no code change near that line, is
-the signature of this shape (see `test/setup/crowi.ts`'s `getInstance()` /
+**Driver 2 — the cost scales with how much concurrent setup work is in
+flight, not a test-local parameter.** A `beforeAll`/`afterAll` in a
+`setupFiles` entry (migration replay, a singleton service cold-init, etc.)
+looks like it should run once per Vitest worker — the code usually
+memoizes a module-level singleton to make it look that way — but **verify
+that before trusting it**: Vitest's `forks` pool resets the module
+registry per test file under the default `isolate: true`, so a
+"per-worker singleton" comment can be describing intent, not actual
+behavior, and the cost can really be recurring on nearly every file all
+run long (confirm with a throwaway `console.log` inside the memoized
+branch and count how many times it fires across a few files — do not
+assume from the comment). Either way — once per worker or once per file —
+"this hook's own cost doesn't loop over anything, so there's nothing to
+redesign" sounds like it forces driver 1's dead end, but it doesn't: the
+cost still scales with **how many files/workers pay it at the same
+moment**, since anything else running on the same CI runner competes for
+the same CPU while each pays its own heavy setup cost (spawning a
+migration subprocess, initializing a singleton, etc.). A same-commit
+failure across several unrelated spec files that all timed out on the
+identical `beforeAll` line, with no code change near that line, is the
+signature of this shape (see `test/setup/crowi.ts`'s `getInstance()` /
 `test/setup/migrate-mongo.ts` in GROWI's own `apps/app` for a worked
-example — PR #11824 misclassified exactly this as "nothing to redesign,
-so a bump is fine"). Where this applies:
+example — PR #11824 misclassified this as "nothing to redesign, so a bump
+is fine," and the fix that replaced it, PR #11826, initially misclassified
+it too, asserting the *same* per-worker premise without checking it before
+publishing — a `console.log` count across a few files falsified it and
+changed the story that shipped). Where this applies:
 
-- **Measure the unloaded baseline.** Run the failing spec(s) alone (no
-  sibling workers contending) and read the hook's own duration off the
-  reporter. If it already sits close to the current limit, a larger
-  timeout may be warranted — state the measured number. If it sits well
-  under the limit (e.g. under a fifth of it), the limit was never the
-  problem; contention pushed a normally-fast hook past it, and a bigger
-  number just delays the same failure to a heavier-load day.
+- **Measure the unloaded baseline, and don't stop at the number — check
+  the model it's measuring.** Run the failing spec(s) alone (no sibling
+  workers contending) and read the hook's own duration off the reporter.
+  If it already sits close to the current limit, a larger timeout may be
+  warranted — state the measured number. If it sits well under the limit
+  (e.g. under a fifth of it), the limit was never the problem; contention
+  pushed a normally-fast hook past it. But a low unloaded number only says
+  the hook is fast *once* — it does not tell you whether it pays that cost
+  once per worker or once per file. Confirm which, per the paragraph
+  above, before describing the mechanism in a fix or a doc: "once per
+  worker" and "once per file, many times over" call for the same lever
+  (bound concurrency) but very different claims about how much it helps,
+  and an unverified "once per worker" claim is exactly the kind of
+  plausible-but-unchecked assertion this whole guardrail exists to catch.
 - **Check for a same-project precedent that a bump already failed.** If a
   *different* hook sharing the same `setupFiles`/project already had its
   timeout raised for the same "environment timing" reason and still
@@ -334,7 +352,7 @@ so a bump is fine"). Where this applies:
   single hook's deadline — proposing another bump for a second hook in
   the same project repeats a fix this repo's own history already falsified.
 - **Prefer bounding worker concurrency over widening the deadline.** When
-  the mechanism is "N workers cold-initializing at once fight for the
+  the mechanism is "N workers/files doing cold-init at once fight for the
   runner's cores," the fix that addresses the mechanism is capping
   concurrent workers (Vitest `poolOptions.forks.maxForks` /
   `poolOptions.threads.maxThreads`, sized off `availableParallelism()`

--- a/.claude/skills/investigate-flaky-test/SKILL.md
+++ b/.claude/skills/investigate-flaky-test/SKILL.md
@@ -263,22 +263,29 @@ an error surfaced from a service/model file (not the spec file itself) in
 the log's stack trace usually points at a product-code race worth reading
 carefully before dismissing as test flakiness.
 
-### Guardrail — a bare timeout increase is a last resort, not the default "Environment timing" fix
+### Guardrail — a bare timeout increase is a stopgap; find what's actually driving the cost first
 
 A numeric timeout bump (`}, 15_000)` → `}, 20_000)` and so on) is the
-cheapest possible edit, which is exactly why it is easy to reach for
-without checking whether it actually addresses the cause. Before proposing
-one, check whether the test's own wall time **scales with a parameter of
-the test** (a loop count, a data size, an iteration count) rather than
-being a fixed cost that merely got unlucky under load. A bump over a
-scaling cost does not fix anything — it raises the load level at which the
-test starts failing again, and the next CI-busy period trips it once more.
-Concretely: read the test body, not just the failing assertion. If it
-issues `N` real round-trips (network, DB, filesystem) where `N` is
-`maxRequests`, a loop bound, or similar, and the assertions of interest
-only concern the *boundary* (a limit being reached/exceeded, a count
-saturating, a last-element condition), that is a redesign opportunity, not
-an environment-timing dead end:
+cheapest possible edit, and that is exactly the problem: it is easy to
+reach for as *the* fix without ever asking what made the operation slow.
+Left unexamined, it tends to become the default "Environment timing" fix —
+and because it never touches the actual driver of the cost, it is usually
+a way of avoiding the root-cause work rather than doing it. It doesn't
+remove the underlying slowness; it just moves the load level at which the
+test starts failing again a bit higher, and the next CI-busy period trips
+it once more. Treat a bare bump as a **last resort**, not a first move —
+before proposing one, identify what is actually driving the observed
+duration. Two drivers show up repeatedly in this codebase; neither is
+fixed by a bigger number:
+
+**Driver 1 — the test's own wall time scales with a parameter of the
+test** (a loop count, a data size, an iteration count) rather than being a
+fixed cost that merely got unlucky under load. Read the test body, not
+just the failing assertion. If it issues `N` real round-trips (network,
+DB, filesystem) where `N` is `maxRequests`, a loop bound, or similar, and
+the assertions of interest only concern the *boundary* (a limit being
+reached/exceeded, a count saturating, a last-element condition), that is a
+redesign opportunity, not an environment-timing dead end:
 
 - Seed the precondition directly instead of looping to it — many
   libraries expose a lower-level primitive that reaches the same state in
@@ -295,20 +302,73 @@ an environment-timing dead end:
 - This turns an O(N) cost into an O(1) cost, which removes the test's
   sensitivity to CI load rather than buying temporary headroom against it.
 
+**Driver 2 — the cost scales with concurrent worker count, not a test-local
+parameter.** A `beforeAll`/`afterAll` in a `setupFiles` entry (migration
+replay, a singleton service cold-init, etc.) runs once per Vitest
+**worker**, and its timeout applies to every spec file that worker happens
+to run — not to one test. "This hook's own cost doesn't loop over
+anything, so there's nothing to redesign" sounds like it forces driver 1's
+dead end, but it doesn't: the cost still scales with **how many workers
+pay it at the same moment**, since sibling workers on the same CI runner
+compete for the same CPU while each does its own heavy cold-start work
+(spawning a migration subprocess, initializing a singleton, etc.). A
+same-commit failure across several unrelated spec files that all timed out
+on the identical `beforeAll` line, with no code change near that line, is
+the signature of this shape (see `test/setup/crowi.ts`'s `getInstance()` /
+`test/setup/migrate-mongo.ts` in GROWI's own `apps/app` for a worked
+example — PR #11824 misclassified exactly this as "nothing to redesign,
+so a bump is fine"). Where this applies:
+
+- **Measure the unloaded baseline.** Run the failing spec(s) alone (no
+  sibling workers contending) and read the hook's own duration off the
+  reporter. If it already sits close to the current limit, a larger
+  timeout may be warranted — state the measured number. If it sits well
+  under the limit (e.g. under a fifth of it), the limit was never the
+  problem; contention pushed a normally-fast hook past it, and a bigger
+  number just delays the same failure to a heavier-load day.
+- **Check for a same-project precedent that a bump already failed.** If a
+  *different* hook sharing the same `setupFiles`/project already had its
+  timeout raised for the same "environment timing" reason and still
+  flaked afterward (grep prior flaky-test issues/PRs for the project
+  name), that is direct evidence the bottleneck is concurrency, not any
+  single hook's deadline — proposing another bump for a second hook in
+  the same project repeats a fix this repo's own history already falsified.
+- **Prefer bounding worker concurrency over widening the deadline.** When
+  the mechanism is "N workers cold-initializing at once fight for the
+  runner's cores," the fix that addresses the mechanism is capping
+  concurrent workers (Vitest `poolOptions.forks.maxForks` /
+  `poolOptions.threads.maxThreads`, sized off `availableParallelism()`
+  with headroom for sibling CI services like a DB/search container) for
+  that project — not a bigger number on the hook that happened to lose
+  the race this time.
+- **Never scope the change wider than the evidence.** `hookTimeout` (and
+  `testTimeout`) are configurable per-project in `vitest.workspace.mts`
+  *and* per-hook as a call's last argument. A fix aimed at one shared
+  setup hook must not raise the timeout for the whole project — that
+  silently triples (or more) the failure-detection window for every other
+  `beforeAll`/`afterAll` in every spec file the project covers, including
+  a future genuine hang unrelated to this flake.
+
+Both drivers reduce to the same discipline: **find what the time is
+actually being spent on, and address that** — a scaling parameter to
+redesign around, or contention to bound — rather than reaching for the
+timeout value because it's the line the stack trace happened to point at.
+
 Only accept a bare timeout bump when:
-- a redesign genuinely isn't possible without changing what the test
-  verifies (rare — most "N round-trips to reach a boundary" tests can be
-  reshaped as above), or
-- as a **modest safety margin layered on top of a redesign** that already
-  removed the scaling behavior — not as the fix itself. State explicitly
+- neither driver applies and no other driver can be identified after
+  actually reading the test/hook and its call path (rare — most cases
+  reduce to one of the two above), or
+- as a **modest safety margin layered on top of a fix that already
+  addressed the real driver** — not as the fix itself. State explicitly
   why the margin is still there (e.g. "no CI history yet for this
   reshaped test, and local/CI timing can differ") rather than leaving it
   unexplained.
 
-A proposed fix that is only a numeric timeout change, with no evidence the
-test's cost was checked for scaling with a parameter, is not HIGH
-confidence at Step 4 regardless of how clean the diff looks — see the
-confidence table there.
+A proposed fix that is only a numeric timeout change, with no evidence
+either driver was checked, is not HIGH confidence at Step 4 regardless of
+how clean the diff looks — see the confidence table there. Route it
+through the MEDIUM path and present the redesign or concurrency-capping
+alternative explicitly rather than defaulting to the bump.
 
 ---
 

--- a/apps/app/test/setup/crowi.ts
+++ b/apps/app/test/setup/crowi.ts
@@ -37,7 +37,12 @@ const initCrowi = async (crowi: Crowi): Promise<void> => {
 
 /**
  * Get a Crowi instance for integration testing.
- * By default, returns a singleton instance. Pass true to create a new instance.
+ * Memoizes `_instance` at module scope, but Vitest's `forks` pool resets the
+ * module registry per test file under the default `isolate: true` — so in
+ * practice this cold-inits on (almost) every file, not once per worker. See
+ * `apps/app/vitest.workspace.mts`'s `app-integration` project comment for
+ * why this project cannot set `isolate: false` to make it a real per-worker
+ * singleton.
  *
  * @returns Promise resolving to a Crowi instance
  */

--- a/apps/app/vitest.workspace.mts
+++ b/apps/app/vitest.workspace.mts
@@ -1,3 +1,4 @@
+import { availableParallelism } from 'node:os';
 import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import {
@@ -6,6 +7,19 @@ import {
   defineWorkspace,
   mergeConfig,
 } from 'vitest/config';
+
+// Each app-integration worker's first `beforeAll` pays two CPU-heavy, concurrent
+// per-worker setup costs: migrate-mongo.ts spawns a `dev:migrate:up` child process,
+// and crowi.ts's getInstance() does a cold Crowi init. Vitest's default fork pool
+// sizes itself to availableParallelism(), so on a CI runner (also running MongoDB
+// and Elasticsearch as sibling services) every worker's setup child process
+// competes for a core against another worker's setup — up to 2x the runner's CPU
+// count in flight at once. That contention, not any single hook being slow, is
+// what pushed both hookTimeout (#11752, migrate-mongo, already 2x the default) and
+// getInstance() (#11820/#11821/#11822) past their limits under load — measured
+// unloaded cold init is ~0.9s. Capping fork count leaves the runner headroom during
+// this contended window instead of widening the deadline around the contention.
+const integrationMaxForks = Math.max(1, availableParallelism() - 1);
 
 const configShared = defineConfig({
   plugins: [tsconfigPaths()],
@@ -64,6 +78,12 @@ export default defineWorkspace([
         './test/setup/mongo/index.ts',
         './test/setup/prisma.ts',
       ],
+      // See integrationMaxForks above: bounds concurrent cold-init contention
+      // rather than widening hookTimeout around it.
+      pool: 'forks',
+      poolOptions: {
+        forks: { maxForks: integrationMaxForks },
+      },
       deps: {
         // Transform inline modules (allows ESM in require context)
         interopDefault: true,
@@ -118,6 +138,11 @@ export default defineWorkspace([
         './test/setup/mongo/index.ts',
         './test/setup/prisma.ts',
       ],
+      // Same setupFiles as app-integration — same contention, same fix.
+      pool: 'forks',
+      poolOptions: {
+        forks: { maxForks: integrationMaxForks },
+      },
       deps: { interopDefault: true },
       server: {
         deps: {

--- a/apps/app/vitest.workspace.mts
+++ b/apps/app/vitest.workspace.mts
@@ -13,27 +13,38 @@ import {
 // child process, and crowi.ts's getInstance() does a cold Crowi init. Both
 // memoize a module-level singleton, but that memoization does NOT make
 // either one "once per worker" — Vitest's `forks` pool resets the module
-// registry per file under the default `isolate: true` (required here: this
-// project's per-file mongo teardown/reconnect in test/setup/mongo/index.ts
-// conflicts with isolate: false's shared module cache — confirmed by
-// reproducing the failure locally, same hazard the app-integration-vault
-// project's isolate: false comment below describes for its own case). So
-// this cost recurs on nearly every file, all run long, not just at worker
-// startup. Vitest's default fork pool sizes itself to availableParallelism(),
-// so on a CI runner (also running MongoDB and Elasticsearch as sibling
-// services) multiple files' setup child processes can end up competing for
-// the same cores at once — confirmed CI log for #11820/#11821/#11822 shows
-// three files' getInstance() hooks timing out in the same ~1s window near
-// the end of a 530s run, alongside a fourth file that succeeded but took
-// 8.4s for work that normally takes ~1s. That contention, not either setup
-// step being inherently slow (measured unloaded cold init is ~0.9s), is
-// what pushed both hookTimeout (#11752, migrate-mongo, already 2x the
-// default) and getInstance() past their limits under load. Capping fork
-// count reduces how many files' worth of this recurring cost can land on
-// the runner at the same moment; it does not make the cost itself go away
-// (that would require making the singleton a real per-worker singleton,
-// which isolate: false would give us if it didn't conflict with the mongo
-// setup above — left as a follow-up, not attempted here).
+// registry per file under the default `isolate: true`, so this cost
+// recurs on nearly every file, all run long, not just at worker startup.
+//
+// Making it a real once-per-worker singleton (isolate: false) was
+// investigated and rejected, for a reason more fundamental than a fixable
+// conflict: confirmed by logging VITEST_WORKER_ID per file, this project's
+// `growi_test_${workerId}` database naming (test/setup/mongo/test-db-config.ts)
+// is assigned per FILE, not per physical worker process — the same reused
+// OS process was handed VITEST_WORKER_ID 2 then 4 across two files in one
+// observed run. A persisted Crowi singleton would keep model bindings from
+// the first file's database while mongo/index.ts's beforeAll/afterAll
+// reconnects the shared mongoose connection to the second file's different
+// database underneath it — reproduced locally as cross-file assertion
+// failures (data written under one dbName, read as missing under another),
+// intermittently rather than every run. Realizing "once per worker" for
+// real would require reworking how database identity is assigned so it
+// tracks the physical process rather than the logical file/task — a larger,
+// separate change, not attempted here.
+//
+// So instead: Vitest's default fork pool sizes itself to
+// availableParallelism(), so on a CI runner (also running MongoDB and
+// Elasticsearch as sibling services) multiple files' setup child processes
+// can end up competing for the same cores at once — confirmed CI log for
+// #11820/#11821/#11822 shows three files' getInstance() hooks timing out in
+// the same ~1s window near the end of a 530s run, alongside a fourth file
+// that succeeded but took 8.4s for work that normally takes ~1s. That
+// contention, not either setup step being inherently slow (measured
+// unloaded cold init is ~0.9s), is what pushed both hookTimeout (#11752,
+// migrate-mongo, already 2x the default) and getInstance() past their
+// limits under load. Capping fork count reduces how many files' worth of
+// this recurring cost can land on the runner at the same moment — a
+// mitigation, not a fix for the underlying per-file recurrence.
 const integrationMaxForks = Math.max(1, availableParallelism() - 1);
 
 const configShared = defineConfig({

--- a/apps/app/vitest.workspace.mts
+++ b/apps/app/vitest.workspace.mts
@@ -8,17 +8,32 @@ import {
   mergeConfig,
 } from 'vitest/config';
 
-// Each app-integration worker's first `beforeAll` pays two CPU-heavy, concurrent
-// per-worker setup costs: migrate-mongo.ts spawns a `dev:migrate:up` child process,
-// and crowi.ts's getInstance() does a cold Crowi init. Vitest's default fork pool
-// sizes itself to availableParallelism(), so on a CI runner (also running MongoDB
-// and Elasticsearch as sibling services) every worker's setup child process
-// competes for a core against another worker's setup — up to 2x the runner's CPU
-// count in flight at once. That contention, not any single hook being slow, is
-// what pushed both hookTimeout (#11752, migrate-mongo, already 2x the default) and
-// getInstance() (#11820/#11821/#11822) past their limits under load — measured
-// unloaded cold init is ~0.9s. Capping fork count leaves the runner headroom during
-// this contended window instead of widening the deadline around the contention.
+// Every app-integration `beforeAll` pays two CPU-heavy setup costs on
+// (almost) every test file: migrate-mongo.ts spawns a `dev:migrate:up`
+// child process, and crowi.ts's getInstance() does a cold Crowi init. Both
+// memoize a module-level singleton, but that memoization does NOT make
+// either one "once per worker" — Vitest's `forks` pool resets the module
+// registry per file under the default `isolate: true` (required here: this
+// project's per-file mongo teardown/reconnect in test/setup/mongo/index.ts
+// conflicts with isolate: false's shared module cache — confirmed by
+// reproducing the failure locally, same hazard the app-integration-vault
+// project's isolate: false comment below describes for its own case). So
+// this cost recurs on nearly every file, all run long, not just at worker
+// startup. Vitest's default fork pool sizes itself to availableParallelism(),
+// so on a CI runner (also running MongoDB and Elasticsearch as sibling
+// services) multiple files' setup child processes can end up competing for
+// the same cores at once — confirmed CI log for #11820/#11821/#11822 shows
+// three files' getInstance() hooks timing out in the same ~1s window near
+// the end of a 530s run, alongside a fourth file that succeeded but took
+// 8.4s for work that normally takes ~1s. That contention, not either setup
+// step being inherently slow (measured unloaded cold init is ~0.9s), is
+// what pushed both hookTimeout (#11752, migrate-mongo, already 2x the
+// default) and getInstance() past their limits under load. Capping fork
+// count reduces how many files' worth of this recurring cost can land on
+// the runner at the same moment; it does not make the cost itself go away
+// (that would require making the singleton a real per-worker singleton,
+// which isolate: false would give us if it didn't conflict with the mongo
+// setup above — left as a follow-up, not attempted here).
 const integrationMaxForks = Math.max(1, availableParallelism() - 1);
 
 const configShared = defineConfig({


### PR DESCRIPTION
## Summary

Replaces the timeout-widening approach from #11824 (closed) with a fix aimed at the actual mechanism: bounding concurrent worker cold-init, not widening the deadline around it.

## Two corrections made while preparing this PR (kept visible, not squashed away)

**Correction 1**: The first draft claimed `getInstance()`/`migrate-mongo.ts` are "paid once by each Vitest worker's first file." Wrong — confirmed by instrumenting `getInstance()` with a throwaway `console.log`: Vitest's `forks` pool resets the module registry per test file under the default `isolate: true`, so the cold-init cost recurs on **nearly every file**, not once per worker.

**Correction 2 (deeper)**: The natural follow-up question was "then why not set `isolate: false` and make it a real per-worker singleton, instead of just capping concurrency?" Investigated and rejected — for a more fundamental reason than an easily-fixed conflict. Logging `VITEST_WORKER_ID` per file (against a real external MongoDB, not just the embedded path) showed this project's `growi_test_${workerId}` database naming is assigned **per file, not per physical worker process** — the same reused OS process was handed `VITEST_WORKER_ID` 2 then 4 across two files in one observed run. A persisted Crowi singleton under `isolate: false` would keep model bindings from an earlier file's database while the shared mongoose connection moves on to a different one underneath it — reproduced locally as intermittent cross-file assertion failures (data written under one `dbName`, read as missing under another). Making cold-init genuinely once-per-worker would require reworking how database identity is assigned so it tracks the physical process instead of the logical file/task — a separate, larger change, not attempted here. `maxForks` capping is therefore a deliberate mitigation, not a stand-in for a fix that was simply skipped.

## Evidence this is contention, not a slow hook

- Unloaded `getInstance()` cold init measured locally: **~0.9s**, well under the 10s default.
- `migrate-mongo.ts`'s hook already had its timeout doubled (10s → 20s) for this exact "environment timing" reason, with a documented measured baseline — and it **still flaked under load afterward** (#11752).
- Pulled the actual failing CI job log (run 33073692980, job 98522243250): the three `getInstance()` timeouts all landed in the same ~1 second window near the very end of a 530s run, alongside a fourth, unrelated file that succeeded but took 8.4s for work that normally takes ~1s — direct evidence of contention at that moment, not a slow hook in isolation.

## Fix

Caps `poolOptions.forks.maxForks` for both `app-integration` and `app-integration-exclusive` (they share the same `setupFiles`, so the same contention) to `availableParallelism() - 1`, leaving the runner headroom instead of widening the deadline around the contention.

No `hookTimeout` change — with contention bounded, the default 10s has ~10x headroom over the measured unloaded baseline.

## Verification

- Typecheck: `pnpm run lint:typecheck` — clean.
- The three originally-flaky specs (`v5.page.integ.ts`, `v5.non-public-page.integ.ts`, `v5.public-page.integ.ts`) pass together under the new pool config.
- `isolate: false` was probed twice (embedded MongoDB, then real external MongoDB) and confirmed non-viable both times, for two different reasons — see Correction 2.
- A full local `app-integration` + `app-integration-exclusive` run surfaced some pre-existing, unrelated flakes under this devcontainer's own resource contention (Elasticsearch client timeouts, an audit-log-bulk-export cron test) — reproduced identically with the change reverted, so unrelated to this fix. CI's actual runner shape (4 vCPU, not this devcontainer's 16) is what the `maxForks` sizing targets; this has not yet been confirmed against a real CI run.

## Also in this PR

Adds a guardrail to the `investigate-flaky-test` skill (`.claude/skills/investigate-flaky-test/SKILL.md`) generalizing the underlying principle — a bare timeout bump is a stopgap that tends to skip root-cause work — with two concrete drivers to check before accepting one: a test-local scaling parameter (existing guardrail), and concurrent setup-hook contention (new). The new driver's own worked example was itself corrected mid-PR after repeating the same kind of unverified assumption the guardrail exists to catch (Correction 1) — the guardrail now explicitly requires confirming what a memoization comment claims rather than trusting it.

## Follow-up (not in this PR)

Filed as a separate concern, not attempted here: this project's per-file `VITEST_WORKER_ID`/database-identity assignment doesn't track the physical worker process, which is what actually blocks a genuine once-per-worker singleton for `getInstance()`/migrate-mongo. Fixing that would eliminate the redundant cold-init entirely rather than rationing it, but needs its own careful design — reworking shared setup used by ~132 `*.integ.ts` files carries real cross-file-pollution risk, which is exactly the failure category this investigation kept running into.

Fixes #11820
Fixes #11821
Fixes #11822

---
_Generated by [Claude Code](https://claude.ai/code)_