### PR TITLE
fix: cap integration test fork concurrency to stop migrate-mongo hook timeouts

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -59,7 +59,7 @@
     "prelint:openapi:apiv1": "pnpm run openapi:generate-spec:apiv1",
     "test": "vitest run",
     "test:unit": "vitest run --project=app-unit",
-    "test:integ": "vitest run --project=app-integration --project=app-integration-exclusive",
+    "test:integ": "vitest run --project=app-integration --project=app-integration-exclusive --poolOptions.forks.maxForks=4",
     "test:components": "vitest run --project=app-components",
     "test:coverage": "run-p test:coverage:* test:integ",
     "test:coverage:unit": "COLUMNS=200 vitest run --coverage --project=app-unit",

--- a/apps/app/test/setup/migrate-mongo.ts
+++ b/apps/app/test/setup/migrate-mongo.ts
@@ -40,13 +40,15 @@ function runMigrations(mongoUri: string): void {
 // GitHub-hosted `ubuntu-latest` runners' advertised 4 vCPUs) and cut local
 // reproduction of this failure from ~80% of files to roughly 1%.
 //
-// 30s (was 20s) is a modest margin layered on top of that fix, not a
-// substitute for it: even 4 truly-concurrent `dev:migrate:up` chains (each a
-// nested pnpm -> node -> migrate-mongo -> umzug spawn) can occasionally still
-// exceed 20s under host contention outside the pool's control (a busy CI
-// runner, a slow migration added later). If this still times out with the
-// pool capped, that is a real regression to investigate, not a signal to
-// raise the number further.
+// Deliberately kept at 20s (not bumped to 30s): the cap above is the fix,
+// and a wider budget's only job would be absorbing genuine future
+// regressions instead of catching them — a migration step that grows slow
+// enough to need 25s is a real problem worth seeing fail here, not
+// something to give more room to quietly pass. If this still times out
+// with the pool capped, that is a real regression to investigate (or fresh
+// evidence that the budget genuinely needs measured headroom — see
+// investigate-flaky-test's Step 3 guardrail), not a signal to raise the
+// number as insurance ahead of time.
 beforeAll(() => {
   // Skip if already run (setupFiles run per test file, but we only need to migrate once per worker)
   if (migrationsRun) {
@@ -65,4 +67,4 @@ beforeAll(() => {
 
   runMigrations(mongoUri);
   migrationsRun = true;
-}, 30_000);
+}, 20_000);

--- a/apps/app/test/setup/migrate-mongo.ts
+++ b/apps/app/test/setup/migrate-mongo.ts
@@ -25,14 +25,28 @@ function runMigrations(mongoUri: string): void {
   });
 }
 
-// 20s timeout (2x the 10s default): this hook spawns `dev:migrate:up`, which
-// runs every migration through the dev TS runner once per Vitest worker. The
-// dev runner is now Node-native (strip-only type stripping + a synchronous
-// resolve-only hook), ~2x faster to load the graph than the former tsx, so per-file
-// resolve/load is no longer the bottleneck — the residual time is mostly DB
-// I/O under the parallel integration run. 20s is a modest margin over that;
-// any further reduction should follow a measured baseline (Phase 3.8.e ±20%
-// gate on the devcontainer), not a guess.
+// This hook spawns `dev:migrate:up`, which runs every migration through the dev
+// TS runner once per test file (VITEST_WORKER_ID — used by getTestDbConfig() to
+// name each file's database — is a per-file dispatch counter, not a bounded
+// physical-worker id, so this genuinely runs once per file, not once per
+// worker despite the `migrationsRun` guard below).
+//
+// #11752: without a concurrency cap, Vitest sizes its fork pool off the
+// runner's reported CPU count, which can be far higher than what the runner
+// can actually sustain running this workload in parallel — CI logs showed
+// 100+ concurrent `dev:migrate:up` invocations, saturating the runner and
+// blowing this hook's budget almost every run. `test:integ`'s
+// `--poolOptions.forks.maxForks=4` flag is the actual fix (matches
+// GitHub-hosted `ubuntu-latest` runners' advertised 4 vCPUs) and cut local
+// reproduction of this failure from ~80% of files to roughly 1%.
+//
+// 30s (was 20s) is a modest margin layered on top of that fix, not a
+// substitute for it: even 4 truly-concurrent `dev:migrate:up` chains (each a
+// nested pnpm -> node -> migrate-mongo -> umzug spawn) can occasionally still
+// exceed 20s under host contention outside the pool's control (a busy CI
+// runner, a slow migration added later). If this still times out with the
+// pool capped, that is a real regression to investigate, not a signal to
+// raise the number further.
 beforeAll(() => {
   // Skip if already run (setupFiles run per test file, but we only need to migrate once per worker)
   if (migrationsRun) {
@@ -51,4 +65,4 @@ beforeAll(() => {
 
   runMigrations(mongoUri);
   migrationsRun = true;
-}, 20_000);
+}, 30_000);

--- a/apps/app/vitest.workspace.mts
+++ b/apps/app/vitest.workspace.mts
@@ -64,6 +64,10 @@ export default defineWorkspace([
         './test/setup/mongo/index.ts',
         './test/setup/prisma.ts',
       ],
+      // Fork concurrency is capped in CI via the `test:integ` script's
+      // `--poolOptions.forks.maxForks` flag, not here — see #11752. (Vitest's
+      // deprecated workspace-file resolution does not apply a project-level
+      // `poolOptions` from this file; the CLI flag does, so the cap lives there.)
       deps: {
         // Transform inline modules (allows ESM in require context)
         interopDefault: true,


### PR DESCRIPTION
## Summary

`test/setup/migrate-mongo.ts`'s `beforeAll` hook spawns a full `dev:migrate:up`
subprocess chain (pnpm -> node -> migrate-mongo -> umzug) once per test file
— confirmed by instrumenting `VITEST_WORKER_ID`/`VITEST_POOL_ID`: the id used
by `getTestDbConfig()` to name each file's database is a per-file dispatch
counter, not a bounded physical-worker id, so this hook genuinely runs once
per file (up to 134 times), not once per worker as its old comment assumed.

Without any concurrency cap, Vitest sizes its fork pool off the CI runner's
reported CPU count. The failing CI log
(https://github.com/growilabs/growi/actions/runs/32723940703/attempts/1)
shows over 100 distinct `growi_test_N` databases starting migrations within
under a second of each other, saturating the runner and blowing the hook's
20s budget for whichever 3 spec files happened to share a worker at that
moment.

## Root Cause

Category: test-infra concurrency (previously suspected as generic
"Environment timing", but pinned down to a concrete, reproducible mechanism).
`test:integ` runs two Vitest projects (`app-integration`,
`app-integration-exclusive`) in one invocation with no cap on fork pool size,
so the effective concurrency of `dev:migrate:up` invocations is bounded only
by the runner's `os.cpus()` reading — not by anything the workload can
actually sustain.

Local reproduction: running the `src/server/routes/apiv3` integration files
(31 files) with no cap reproduced the exact `Hook timed out in 20000ms`
failure on ~80% of files. With `--poolOptions.forks.maxForks=4`, the same
run and a larger 93-file run both passed with zero hook timeouts (one
timeout appeared during a subsequent, much larger stress run, but that run's
own MongoDB connection also dropped with `ECONNREFUSED` moments later —
consistent with the local devcontainer's shared Mongo container itself
becoming resource-constrained from repeated heavy local test runs, not a
gap in the fix).

## Fix

- `apps/app/package.json`: `test:integ` now passes
  `--poolOptions.forks.maxForks=4`, matching GitHub-hosted `ubuntu-latest`
  runners' advertised 4 vCPUs. (A project-level `poolOptions` in
  `vitest.workspace.mts` was tried first but Vitest's deprecated
  workspace-file resolution does not apply it — the CLI flag does, so the
  cap lives on the script instead; a comment in `vitest.workspace.mts`
  documents this.)
- `apps/app/test/setup/migrate-mongo.ts`: hook timeout raised 20s -> 30s as a
  modest safety margin layered on top of the concurrency cap (not a
  substitute for it) — even 4 truly-concurrent migration chains can
  occasionally exceed 20s under host contention outside the pool's control.

## Verification

In progress — re-running CI to confirm the fix holds across repeated
executions (see comments below). This PR stays draft until that completes.

Fixes #11752