### PR TITLE
docs(flaky-test-skills): bake in lessons from PR #11826's misdiagnosis chain

### DIFF
--- a/.claude/skills/detect-flaky-ci/SKILL.md
+++ b/.claude/skills/detect-flaky-ci/SKILL.md
@@ -69,9 +69,10 @@ first:
    signal (see "Cheap Suspicion Mining" below). Passive: waits for a future
    run to repeat it (`--vitest-threshold`).
 2. **`flaky/suspected`** — a vitest observation that also matches one or more
-   of the four cheap, mechanical signals in "Cheap Suspicion Mining" (diff/PR
-   mismatch, sandwich pattern, matrix divergence, or a targeted historical
-   backfill hit). No LLM judgment is spent getting here — these are
+   of the five cheap, mechanical signals in "Cheap Suspicion Mining" (diff/PR
+   mismatch, sandwich pattern, matrix divergence, a shared setup-hook timeout
+   with cross-file slowdown, or a targeted historical backfill hit). No LLM
+   judgment is spent getting here — these are
    grep/diff-level checks against data this skill already fetched (or, for
    ④, a small bounded amount of extra targeted fetching). Handed to
    `investigate-flaky-test`, which spends exactly one rerun to turn this
@@ -89,36 +90,44 @@ actual rerun, which is an investigation action, not a detection action.
 ## Cheap Suspicion Mining (vitest only)
 
 Before falling back to passive `--vitest-threshold` accumulation, check each
-vitest failure identity against four mechanical signals. All four are
-grep/diff/API-field comparisons — no log-content reasoning beyond a literal
-string search, no code reading. ①-③ run against a **fresh** observation
-made during this scan; ④ runs once per scan against **existing**
-`flaky/observing` issues regardless of whether anything new was observed
-for them today (see its own subsection below for why it's structured
-differently).
+vitest failure identity against five mechanical signals. ①-③ and ⑤ are
+grep/diff/API-field comparisons — no code reading and no qualitative log
+judgment; ⑤ additionally needs one extra log fetch (a nearby passing run
+of the same job) to compare numbers against, but the comparison itself is
+still mechanical (duration deltas), not reasoning about *why*. ①-③ and ⑤
+run against a **fresh** observation made during this scan; ④ runs once per
+scan against **existing** `flaky/observing` issues regardless of whether
+anything new was observed for them today (see its own subsection below for
+why it's structured differently) — ④'s number is legacy (it was added
+before ⑤) and does not reflect run order; the fresh/existing split is what
+matters, not the numbering.
 
-**Evaluate all of ①-③ for every fresh observation — do not stop at the
-first hit.** All three reuse data already fetched in Steps 1-2 (no extra API
-calls), so short-circuiting saves nothing. It also actively loses
-information: ① (diff/PR mismatch) is the loosest of the three — it only
+**Evaluate all of ①-③ and ⑤ for every fresh observation — do not stop at
+the first hit.** All reuse data already fetched in Steps 1-2 (⑤ needs one
+extra log fetch, see below, but no extra run/job listing), so
+short-circuiting saves little. Stopping early also actively loses
+information: ① (diff/PR mismatch) is the loosest of the four — it only
 needs "the PR/commit diff doesn't touch this area" — so it tends to match
-almost any isolated failure before ② or ③ get evaluated. Stopping at ①
+almost any isolated failure before ②, ③, or ⑤ get evaluated. Stopping at ①
 means never learning whether the same failure also had a same-commit
-matrix-divergence proof (③, arguably the strongest of the three — it's a
-same-commit, same-code comparison, not an inference from an unrelated
-diff) or a sandwich pattern (②). Left unrecorded, this makes ②/③ look like
-they never fire in practice, when in fact they may be firing constantly
-underneath ①'s wider net — record every check that matches, not just the
-first:
+matrix-divergence proof (③, arguably the strongest of the three original
+signals — it's a same-commit, same-code comparison, not an inference from
+an unrelated diff), a sandwich pattern (②), or a measured cross-file
+slowdown (⑤, the strongest signal of all when it hits — it's a direct
+resource-contention measurement, not an inference). Left unrecorded, this
+makes ②/③/⑤ look like they never fire in practice, when in fact they may
+be firing constantly underneath ①'s wider net — record every check that
+matches, not just the first:
 
-- **Record every match.** Note in this run's evidence which of ①/②/③ hit,
+- **Record every match.** Note in this run's evidence which of ①/②/③/⑤ hit,
   even when more than one did.
 - **Report all matched checks in the issue**, not just one (see the issue
   body template below) — a reader deciding how much to trust "suspected"
   should see every corroborating signal, not whichever happened to be
   checked first.
 - **When space forces picking a single headline reason** (e.g. a short
-  status line), prefer the strongest evidence, not check order: ③ (same
+  status line), prefer the strongest evidence, not check order: ⑤ (measured
+  cross-file slowdown, a direct resource-contention measurement) > ③ (same
   commit, same code, divergent outcome) > ② (disappears-and-reappears
   within the window) > ① (diff/PR mismatch, an inference rather than a
   direct comparison).
@@ -166,8 +175,44 @@ all. Get sibling job results from the Step 2 jobs-list call you already made
 for this run (`gh api repos/growilabs/growi/actions/runs/{RUN_ID}/jobs`) —
 filter by job name prefix, compare conclusions.
 
-If none of ①-③ hit for a fresh observation, fall through to the existing
-passive `flaky/observing` / `--vitest-threshold` path unchanged.
+**⑤ Setup-hook timeout with cross-file slowdown.** A failure whose error is
+`Hook timed out in Nms` on a hook registered in a Vitest **project's
+`setupFiles`** (not a spec file's own `beforeAll`/`afterAll`) — e.g.
+`test/setup/migrate-mongo.ts`, `test/setup/crowi.ts`'s `getInstance()` — is
+shared across every spec file the pool assigns to whichever worker hit it,
+so the failing spec file is often incidental, not the cause. Do not
+classify this as a problem with the named hook (or, worse, propose a bare
+timeout bump on it) without checking whether the whole run was under
+unusual load, which this signal measures directly:
+
+1. Get the failing job's per-file duration lines (the reporter's own
+   `✓ |app-integration| path/to/file.integ.ts (N tests) NNNNms` lines —
+   strip ANSI codes first: `sed -E 's/\x1b\[[0-9;]*m//g'`).
+2. Find a **passing** run of the *same job* (same workflow, same matrix
+   cell) close in time — the sibling matrix cell from ③'s check often
+   already qualifies; otherwise the nearest earlier passing run of the same
+   job name.
+3. Compare 3-5 *unrelated* files' durations (files with no connection to
+   the failing hook or to each other) between the two runs. If they are
+   consistently and substantially slower (this investigation's worked
+   example: 2.6-3.4x) in the failing run, that is direct, measured evidence
+   the whole run — not the named hook — was under unusual load. If the
+   comparison files run at roughly the same speed in both runs, this signal
+   does not fire; do not force it.
+
+Do **not** use per-line `console.log` timestamps from the raw CI log to
+reason about *when within the run* something happened — Vitest/CI log
+capture can buffer a worker's stdout and flush it in one burst near the
+job's end, so dozens of unrelated timestamps landing in the same
+one-second window is an artifact of that buffering, not proof of
+tail-of-run clustering. (This investigation initially misread exactly that
+pattern as "failures cluster at the end of the run" before discovering the
+buffering.) The reporter's own summary `Duration`/per-file `NNNNms` figures
+are computed by Vitest's internal timer, not from log-line timestamps, and
+remain trustworthy for the comparison in step 3.
+
+If none of ①-③ or ⑤ hit for a fresh observation, fall through to the
+existing passive `flaky/observing` / `--vitest-threshold` path unchanged.
 
 **④ Targeted historical backfill (existing `flaky/observing` issues only).**
 ①-③ only look at data already in hand for *today's* observation. This one
@@ -237,7 +282,7 @@ promotion rule as ①-③ applies. If the deeper search finds nothing, leave
 the issue at `flaky/observing` and move on; this is not a required gate, it
 is a best-effort extra pass.
 
-Genuinely subtle flakiness that doesn't show up in any of ①-④ still needs
+Genuinely subtle flakiness that doesn't show up in any of ①-⑤ still needs
 the old accumulation path (or a human/LLM eyeballing it later) — none of
 these checks are exhaustive.
 
@@ -817,10 +862,10 @@ Step 1.5 skip-list (already-known, not re-fetched), how many jobs actually
 scanned, how many classified as infra noise (with which pattern), how many
 new issues created, how many existing issues updated, how many escalated to
 `flaky/suspected` vs `flaky/confirmed`, and **a separate hit count for each
-of the four mining checks** (①, ②, ③, ④'s backfill) — since all of ①-③ are
-now evaluated for every observation rather than stopping at the first hit,
-one suspected issue can match more than one check, so these four counts
-will not sum to the total number of suspected issues. Report them
+of the five mining checks** (①, ②, ③, ⑤, ④'s backfill) — since all of
+①-③ and ⑤ are now evaluated for every observation rather than stopping at
+the first hit, one suspected issue can match more than one check, so these
+five counts will not sum to the total number of suspected issues. Report them
 separately anyway; this is the data that answers "which of these checks is
 actually pulling weight" over time. This is the only user-facing output —
 do not create files.
@@ -851,7 +896,7 @@ do not create files.
   jobs could not be evidenced and continue with what you can read (run/job
   metadata, conclusions) rather than stopping the whole scan; do not
   silently skip affected runs without reporting them in Step 5.
-- Cheap suspicion mining (① / ② / ③ / ④) finds no clean signal either way
+- Cheap suspicion mining (① / ② / ③ / ④ / ⑤) finds no clean signal either way
   (e.g. a PR touches half the repo, or matrix siblings are also failing for
   unrelated reasons): do not force a tier — fall through to
   `flaky/observing` and let the passive threshold path handle it. These

--- a/.claude/skills/investigate-flaky-test/SKILL.md
+++ b/.claude/skills/investigate-flaky-test/SKILL.md
@@ -263,22 +263,29 @@ an error surfaced from a service/model file (not the spec file itself) in
 the log's stack trace usually points at a product-code race worth reading
 carefully before dismissing as test flakiness.
 
-### Guardrail — a bare timeout increase is a last resort, not the default "Environment timing" fix
+### Guardrail — a bare timeout increase is a stopgap; find what's actually driving the cost first
 
 A numeric timeout bump (`}, 15_000)` → `}, 20_000)` and so on) is the
-cheapest possible edit, which is exactly why it is easy to reach for
-without checking whether it actually addresses the cause. Before proposing
-one, check whether the test's own wall time **scales with a parameter of
-the test** (a loop count, a data size, an iteration count) rather than
-being a fixed cost that merely got unlucky under load. A bump over a
-scaling cost does not fix anything — it raises the load level at which the
-test starts failing again, and the next CI-busy period trips it once more.
-Concretely: read the test body, not just the failing assertion. If it
-issues `N` real round-trips (network, DB, filesystem) where `N` is
-`maxRequests`, a loop bound, or similar, and the assertions of interest
-only concern the *boundary* (a limit being reached/exceeded, a count
-saturating, a last-element condition), that is a redesign opportunity, not
-an environment-timing dead end:
+cheapest possible edit, and that is exactly the problem: it is easy to
+reach for as *the* fix without ever asking what made the operation slow.
+Left unexamined, it tends to become the default "Environment timing" fix —
+and because it never touches the actual driver of the cost, it is usually
+a way of avoiding the root-cause work rather than doing it. It doesn't
+remove the underlying slowness; it just moves the load level at which the
+test starts failing again a bit higher, and the next CI-busy period trips
+it once more. Treat a bare bump as a **last resort**, not a first move —
+before proposing one, identify what is actually driving the observed
+duration. Two drivers show up repeatedly in this codebase; neither is
+fixed by a bigger number:
+
+**Driver 1 — the test's own wall time scales with a parameter of the
+test** (a loop count, a data size, an iteration count) rather than being a
+fixed cost that merely got unlucky under load. Read the test body, not
+just the failing assertion. If it issues `N` real round-trips (network,
+DB, filesystem) where `N` is `maxRequests`, a loop bound, or similar, and
+the assertions of interest only concern the *boundary* (a limit being
+reached/exceeded, a count saturating, a last-element condition), that is a
+redesign opportunity, not an environment-timing dead end:
 
 - Seed the precondition directly instead of looping to it — many
   libraries expose a lower-level primitive that reaches the same state in
@@ -295,20 +302,91 @@ an environment-timing dead end:
 - This turns an O(N) cost into an O(1) cost, which removes the test's
   sensitivity to CI load rather than buying temporary headroom against it.
 
+**Driver 2 — the cost scales with how much concurrent setup work is in
+flight, not a test-local parameter.** A `beforeAll`/`afterAll` in a
+`setupFiles` entry (migration replay, a singleton service cold-init, etc.)
+looks like it should run once per Vitest worker — the code usually
+memoizes a module-level singleton to make it look that way — but **verify
+that before trusting it**: Vitest's `forks` pool resets the module
+registry per test file under the default `isolate: true`, so a
+"per-worker singleton" comment can be describing intent, not actual
+behavior, and the cost can really be recurring on nearly every file all
+run long (confirm with a throwaway `console.log` inside the memoized
+branch and count how many times it fires across a few files — do not
+assume from the comment). Either way — once per worker or once per file —
+"this hook's own cost doesn't loop over anything, so there's nothing to
+redesign" sounds like it forces driver 1's dead end, but it doesn't: the
+cost still scales with **how many files/workers pay it at the same
+moment**, since anything else running on the same CI runner competes for
+the same CPU while each pays its own heavy setup cost (spawning a
+migration subprocess, initializing a singleton, etc.). A same-commit
+failure across several unrelated spec files that all timed out on the
+identical `beforeAll` line, with no code change near that line, is the
+signature of this shape (see `test/setup/crowi.ts`'s `getInstance()` /
+`test/setup/migrate-mongo.ts` in GROWI's own `apps/app` for a worked
+example — PR #11824 misclassified this as "nothing to redesign, so a bump
+is fine," and the fix that replaced it, PR #11826, initially misclassified
+it too, asserting the *same* per-worker premise without checking it before
+publishing — a `console.log` count across a few files falsified it and
+changed the story that shipped). Where this applies:
+
+- **Measure the unloaded baseline, and don't stop at the number — check
+  the model it's measuring.** Run the failing spec(s) alone (no sibling
+  workers contending) and read the hook's own duration off the reporter.
+  If it already sits close to the current limit, a larger timeout may be
+  warranted — state the measured number. If it sits well under the limit
+  (e.g. under a fifth of it), the limit was never the problem; contention
+  pushed a normally-fast hook past it. But a low unloaded number only says
+  the hook is fast *once* — it does not tell you whether it pays that cost
+  once per worker or once per file. Confirm which, per the paragraph
+  above, before describing the mechanism in a fix or a doc: "once per
+  worker" and "once per file, many times over" call for the same lever
+  (bound concurrency) but very different claims about how much it helps,
+  and an unverified "once per worker" claim is exactly the kind of
+  plausible-but-unchecked assertion this whole guardrail exists to catch.
+- **Check for a same-project precedent that a bump already failed.** If a
+  *different* hook sharing the same `setupFiles`/project already had its
+  timeout raised for the same "environment timing" reason and still
+  flaked afterward (grep prior flaky-test issues/PRs for the project
+  name), that is direct evidence the bottleneck is concurrency, not any
+  single hook's deadline — proposing another bump for a second hook in
+  the same project repeats a fix this repo's own history already falsified.
+- **Prefer bounding worker concurrency over widening the deadline.** When
+  the mechanism is "N workers/files doing cold-init at once fight for the
+  runner's cores," the fix that addresses the mechanism is capping
+  concurrent workers (Vitest `poolOptions.forks.maxForks` /
+  `poolOptions.threads.maxThreads`, sized off `availableParallelism()`
+  with headroom for sibling CI services like a DB/search container) for
+  that project — not a bigger number on the hook that happened to lose
+  the race this time.
+- **Never scope the change wider than the evidence.** `hookTimeout` (and
+  `testTimeout`) are configurable per-project in `vitest.workspace.mts`
+  *and* per-hook as a call's last argument. A fix aimed at one shared
+  setup hook must not raise the timeout for the whole project — that
+  silently triples (or more) the failure-detection window for every other
+  `beforeAll`/`afterAll` in every spec file the project covers, including
+  a future genuine hang unrelated to this flake.
+
+Both drivers reduce to the same discipline: **find what the time is
+actually being spent on, and address that** — a scaling parameter to
+redesign around, or contention to bound — rather than reaching for the
+timeout value because it's the line the stack trace happened to point at.
+
 Only accept a bare timeout bump when:
-- a redesign genuinely isn't possible without changing what the test
-  verifies (rare — most "N round-trips to reach a boundary" tests can be
-  reshaped as above), or
-- as a **modest safety margin layered on top of a redesign** that already
-  removed the scaling behavior — not as the fix itself. State explicitly
+- neither driver applies and no other driver can be identified after
+  actually reading the test/hook and its call path (rare — most cases
+  reduce to one of the two above), or
+- as a **modest safety margin layered on top of a fix that already
+  addressed the real driver** — not as the fix itself. State explicitly
   why the margin is still there (e.g. "no CI history yet for this
   reshaped test, and local/CI timing can differ") rather than leaving it
   unexplained.
 
-A proposed fix that is only a numeric timeout change, with no evidence the
-test's cost was checked for scaling with a parameter, is not HIGH
-confidence at Step 4 regardless of how clean the diff looks — see the
-confidence table there.
+A proposed fix that is only a numeric timeout change, with no evidence
+either driver was checked, is not HIGH confidence at Step 4 regardless of
+how clean the diff looks — see the confidence table there. Route it
+through the MEDIUM path and present the redesign or concurrency-capping
+alternative explicitly rather than defaulting to the bump.
 
 ---
 


### PR DESCRIPTION
## Summary

PR #11826 (closed, superseded by #11828) went through several rounds of incorrect diagnosis while investigating #11820/#11821/#11822: a "once per worker" cold-init premise that wasn't true, an `isolate: false` fix that seemed promising but broke on a different axis, a "tail-end of the run" clustering pattern that turned out to be a `console.log` buffering artifact, and finally — the most costly one — a config change that never took effect at all (Vitest's deprecated `defineWorkspace()` per-project `poolOptions` is silently ignored; the CLI-flag/`package.json`-script form is what actually applies). 24 real CI reruns were spent "verifying" that no-op change before this was caught.

This PR bakes the reusable lessons from that chain into the two flaky-test skills, so a future investigation doesn't have to rediscover them.

## Changes

**`investigate-flaky-test` (Step 5-B, Implement)**: require confirming a configuration/settings fix actually takes effect (measured locally — e.g. `time` a run and compare CPU%, or check that changing a value in the reachable range changes behavior) before spending any CI verification budget on it. This is the single gap that let 24 real CI reruns pass judgment on a change that was never applied.

**`detect-flaky-ci` (Cheap Suspicion Mining)**: adds signal ⑤ — a failure whose error is `Hook timed out in Nms` on a **shared `setupFiles` hook** (not a spec file's own hook) should be checked for cross-file slowdown in the same run before being attributed to that hook specifically, since the hook is usually incidental to whichever spec file happened to share its worker at that moment. The check: compare 3-5 unrelated files' per-file durations between the failing run and a nearby passing run of the same job — a consistent, substantial slowdown across unrelated files (this investigation's worked example: 2.6-3.4x) is direct evidence of run-wide contention, stronger than any of the existing ①-③ signals. Also documents the `console.log` timestamp buffering trap (dozens of unrelated worker timestamps landing in the same one-second window is a log-flush artifact, not proof of real-time clustering) so a future investigation doesn't misread it the way this one initially did.

No code changes — skill/documentation only.

---
_Generated by [Claude Code](https://claude.ai/code)_