### PR TITLE
feat: add slash command to the editor shortcuts list

### DIFF
--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -519,7 +519,7 @@
     "editor": {
       "title": "Editor shortcuts",
       "Slash Command": "Slash Command",
-      "Slash Command Desc": "(Insert Markdown elements from the menu)",
+      "Slash Command Desc": "(Show the command menu)",
       "Indent": "Indent",
       "Outdent": "Outdent",
       "Save Page": "Save Page",

--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -518,6 +518,8 @@
     },
     "editor": {
       "title": "Editor shortcuts",
+      "Slash Command": "Slash Command",
+      "Slash Command Desc": "(Insert Markdown elements from the menu)",
       "Indent": "Indent",
       "Outdent": "Outdent",
       "Save Page": "Save Page",

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -515,7 +515,7 @@
     "editor": {
       "title": "Raccourcis d'édition",
       "Slash Command": "Commande slash",
-      "Slash Command Desc": "(Insérer des éléments Markdown depuis le menu)",
+      "Slash Command Desc": "(Afficher le menu des commandes)",
       "Indent": "Indentation",
       "Outdent": "Retrait",
       "Save Page": "Sauvegarder la page",

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -514,6 +514,8 @@
     },
     "editor": {
       "title": "Raccourcis d'édition",
+      "Slash Command": "Commande slash",
+      "Slash Command Desc": "(Insérer des éléments Markdown depuis le menu)",
       "Indent": "Indentation",
       "Outdent": "Retrait",
       "Save Page": "Sauvegarder la page",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -552,6 +552,8 @@
     },
     "editor": {
       "title": "エディターショートカット",
+      "Slash Command": "スラッシュコマンド",
+      "Slash Command Desc": "(メニューから Markdown 要素を挿入)",
       "Indent": "インデント",
       "Outdent": "左インデント",
       "Save Page": "保存",

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -553,7 +553,7 @@
     "editor": {
       "title": "エディターショートカット",
       "Slash Command": "スラッシュコマンド",
-      "Slash Command Desc": "(メニューから Markdown 要素を挿入)",
+      "Slash Command Desc": "(コマンドメニューを表示)",
       "Indent": "インデント",
       "Outdent": "左インデント",
       "Save Page": "保存",

--- a/apps/app/public/static/locales/ko_KR/translation.json
+++ b/apps/app/public/static/locales/ko_KR/translation.json
@@ -489,6 +489,8 @@
     },
     "editor": {
       "title": "편집기 단축키",
+      "Slash Command": "슬래시 명령어",
+      "Slash Command Desc": "(메뉴에서 Markdown 요소 삽입)",
       "Indent": "들여쓰기",
       "Outdent": "내어쓰기",
       "Save Page": "페이지 저장",

--- a/apps/app/public/static/locales/ko_KR/translation.json
+++ b/apps/app/public/static/locales/ko_KR/translation.json
@@ -490,7 +490,7 @@
     "editor": {
       "title": "편집기 단축키",
       "Slash Command": "슬래시 명령어",
-      "Slash Command Desc": "(메뉴에서 Markdown 요소 삽입)",
+      "Slash Command Desc": "(명령 메뉴 표시)",
       "Indent": "들여쓰기",
       "Outdent": "내어쓰기",
       "Save Page": "페이지 저장",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -511,7 +511,7 @@
     "editor": {
       "title": "编辑器快捷方式",
       "Slash Command": "斜杠命令",
-      "Slash Command Desc": "(从菜单插入 Markdown 元素)",
+      "Slash Command Desc": "(显示命令菜单)",
       "Indent": "缩进",
       "Outdent": "回退缩进",
       "Save Page": "保存页面",

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -510,6 +510,8 @@
     },
     "editor": {
       "title": "编辑器快捷方式",
+      "Slash Command": "斜杠命令",
+      "Slash Command Desc": "(从菜单插入 Markdown 元素)",
       "Indent": "缩进",
       "Outdent": "回退缩进",
       "Save Page": "保存页面",

--- a/apps/app/src/client/components/ShortcutsModal/ShortcutsModal.tsx
+++ b/apps/app/src/client/components/ShortcutsModal/ShortcutsModal.tsx
@@ -189,6 +189,19 @@ const ShortcutsModalSubstance = (): React.JSX.Element => {
               <strong>{t('modal_shortcuts.editor.title')}</strong>
             </h6>
             <ul className="list-unstyled m-0">
+              {/* Slash Command */}
+              <li className="d-flex align-items-center p-3 border-bottom">
+                <div className="flex-grow-1">
+                  {t('modal_shortcuts.editor.Slash Command')}
+                  <br />
+                  <span className="small text-secondary">
+                    {t('modal_shortcuts.editor.Slash Command Desc')}
+                  </span>
+                </div>
+                <div>
+                  <span className="key">/</span>
+                </div>
+              </li>
               {/* Search in Editor */}
               <li className="d-flex align-items-center p-3 border-bottom">
                 <div className="flex-grow-1">


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/188174

ショートカット一覧モーダルの「エディターショートカット」に slash command の項目を追加しました。

<img width="710" height="913" alt="スクリーンショット 2026-08-31 192839" src="https://github.com/user-attachments/assets/af3a789e-89e7-486c-b612-9af00373ea07" />