### PR TITLE
fix(page-bulk-export): Embed attachment images in exported PDFs (RELAY mode)

### DIFF
--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/embed-images.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/embed-images.ts
@@ -1,0 +1,127 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type Crowi from '~/server/crowi';
+import { ResponseMode } from '~/server/interfaces/attachment';
+import { Attachment } from '~/server/models/attachment';
+import loggerFactory from '~/utils/logger';
+
+const logger = loggerFactory('growi:features:page-bulk-export:embed-images');
+
+/**
+ * Matches `<img ... src="/attachment/<24-char hex id>" ...>` — the app-root
+ * relative path GROWI's web renderer emits for attachment images (see
+ * apps/app/src/server/routes/attachment/get.ts's `/:id([0-9a-z]{24})` route).
+ *
+ * pdf-converter opens the exported HTML via `file://` (see
+ * apps/pdf-converter/src/service/pdf-convert.ts), which has no origin to
+ * resolve an app-root-relative path against, so these must be rewritten
+ * before the HTML is written to disk (Requirement: images must render in
+ * the exported PDF, not just links/text).
+ */
+const ATTACHMENT_IMG_SRC = /src="\/attachment\/([0-9a-z]{24})"/g;
+
+/**
+ * Directory (relative to a job's html output dir) that downloaded/relayed
+ * attachment images are written into. Mirrors `_bulk-export.css`'s
+ * leading-underscore convention so pdf-converter's `*.html`-only scan never
+ * mistakes these for pages.
+ */
+const ASSETS_DIRNAME = '_bulk-export-assets';
+
+/**
+ * Rewrite `/attachment/<id>` image sources in `htmlString` to something
+ * `pdf-converter`'s `file://` navigation can actually load. Only handles
+ * RELAY-mode storage (the local filesystem and GridFS `fileUploadService`
+ * implementations): the attachment's bytes are fetched server-side (this
+ * runs inside the `app` process, which already has full access to
+ * fileUploadService — no HTTP round-trip or session cookie needed) and
+ * saved once per job into `ASSETS_DIRNAME` on the shared
+ * `page_bulk_export_tmp` volume; the `src` becomes a relative path to that
+ * local copy, same pattern as the shared CSS file.
+ *
+ * REDIRECT-mode (S3/GCS) and DELEGATE-mode storage are not handled here and
+ * are left as-is (best effort — the image will be missing from the PDF,
+ * but the page still converts). See growilabs/growi#<ISSUE_NUMBER> for
+ * background and follow-up on those modes.
+ *
+ * @param htmlString rendered page HTML, before it is written to fileOutputPath
+ * @param fileOutputPath absolute path the HTML will be written to (used to
+ *   compute the relative href to `ASSETS_DIRNAME`)
+ * @param outputDir the job's html output dir (ASSETS_DIRNAME lives directly
+ *   under this, once per job — shared across pages, like the CSS file)
+ * @param crowi crowi instance (for fileUploadService + Attachment lookups)
+ */
+export async function embedAttachmentImages(
+  htmlString: string,
+  fileOutputPath: string,
+  outputDir: string,
+  crowi: Crowi,
+): Promise<string> {
+  const matches = [...htmlString.matchAll(ATTACHMENT_IMG_SRC)];
+  if (matches.length === 0) {
+    return htmlString;
+  }
+
+  const { fileUploadService } = crowi;
+  if (fileUploadService.determineResponseMode() !== ResponseMode.RELAY) {
+    // REDIRECT (S3/GCS) and DELEGATE modes aren't handled yet; leave the
+    // HTML untouched rather than guess.
+    return htmlString;
+  }
+
+  const assetsDir = path.join(outputDir, ASSETS_DIRNAME);
+
+  // De-dupe: the same attachment can appear more than once on a page.
+  const uniqueIds = [...new Set(matches.map((m) => m[1]))];
+
+  const replacements = new Map<string, string>();
+
+  await Promise.all(
+    uniqueIds.map(async (id) => {
+      try {
+        const attachment = await Attachment.findById(id);
+        if (attachment == null) return;
+
+        const readable = await fileUploadService.findDeliveryFile(attachment);
+        const assetFileName = `${id}${path.extname(attachment.fileName ?? '')}`;
+        const assetFilePath = path.join(assetsDir, assetFileName);
+
+        // Written once per job; subsequent pages reusing the same
+        // attachment just reference the already-written file.
+        if (!fs.existsSync(assetFilePath)) {
+          await fs.promises.mkdir(assetsDir, { recursive: true });
+          const writeStream = fs.createWriteStream(assetFilePath);
+          await new Promise<void>((resolve, reject) => {
+            readable.pipe(writeStream);
+            writeStream.on('finish', resolve);
+            writeStream.on('error', reject);
+            readable.on('error', reject);
+          });
+        }
+
+        const relativeHref = path
+          .relative(path.dirname(fileOutputPath), assetFilePath)
+          .split(path.sep)
+          .map(encodeURIComponent)
+          .join('/');
+        replacements.set(id, relativeHref);
+      } catch (err) {
+        logger.warn(
+          'Failed to embed attachment image %s for bulk export: %o',
+          id,
+          err,
+        );
+      }
+    }),
+  );
+
+  if (replacements.size === 0) {
+    return htmlString;
+  }
+
+  return htmlString.replace(ATTACHMENT_IMG_SRC, (fullMatch, id) => {
+    const replacement = replacements.get(id);
+    return replacement != null ? `src="${replacement}"` : fullMatch;
+  });
+}

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/embed-images.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/embed-images.ts
@@ -1,12 +1,29 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { getIdStringForRef, type IPage, type IUser } from '@growi/core';
+import type { HydratedDocument } from 'mongoose';
+import mongoose from 'mongoose';
 
 import type Crowi from '~/server/crowi';
 import { ResponseMode } from '~/server/interfaces/attachment';
-import { Attachment } from '~/server/models/attachment';
+import {
+  Attachment,
+  type IAttachmentDocument,
+} from '~/server/models/attachment';
 import loggerFactory from '~/utils/logger';
 
 const logger = loggerFactory('growi:features:page-bulk-export:embed-images');
+
+// TODO: remove this local interface when models/page has typescriptized
+// (see the identical TODO in apps/app/src/server/routes/attachment/get.ts,
+// whose permission check this mirrors).
+interface PageModel {
+  isAccessiblePageByViewer: (
+    pageId: string,
+    user: HydratedDocument<IUser> | undefined,
+  ) => Promise<boolean>;
+}
 
 /**
  * Matches `<img ... src="/attachment/<24-char hex id>" ...>` — the app-root
@@ -45,18 +62,35 @@ const ASSETS_DIRNAME = '_bulk-export-assets';
  * but the page still converts). See growilabs/growi#<ISSUE_NUMBER> for
  * background and follow-up on those modes.
  *
- * @param htmlString rendered page HTML, before it is written to fileOutputPath
- * @param fileOutputPath absolute path the HTML will be written to (used to
- *   compute the relative href to `ASSETS_DIRNAME`)
- * @param outputDir the job's html output dir (ASSETS_DIRNAME lives directly
- *   under this, once per job — shared across pages, like the CSS file)
- * @param crowi crowi instance (for fileUploadService + Attachment lookups)
+ * Mirrors the same page-viewer permission check the `/attachment/:id` route
+ * enforces (see retrieveAttachmentFromIdParam in
+ * apps/app/src/server/routes/attachment/get.ts): an attachment ID parsed out
+ * of the rendered HTML could belong to a different, private page the
+ * exporting user isn't allowed to read, so each attachment's `page` is
+ * checked via `Page.isAccessiblePageByViewer` before it is fetched/embedded.
+ * Attachments with no `page` (e.g. profile images) skip this check, same as
+ * the attachment route does.
  */
 export async function embedAttachmentImages(
   htmlString: string,
-  fileOutputPath: string,
-  outputDir: string,
-  crowi: Crowi,
+  {
+    fileOutputPath,
+    outputDir,
+    crowi,
+    exportingUser,
+  }: {
+    /** absolute path the HTML will be written to (used to compute the
+     * relative href to ASSETS_DIRNAME) */
+    fileOutputPath: string;
+    /** the job's html output dir (ASSETS_DIRNAME lives directly under this,
+     * once per job — shared across pages, like the CSS file) */
+    outputDir: string;
+    /** crowi instance (for fileUploadService + Attachment lookups) */
+    crowi: Crowi;
+    /** the user who requested the export (pageBulkExportJob.user, resolved
+     * once per job by the caller) — permission checks run as this user */
+    exportingUser: HydratedDocument<IUser> | undefined;
+  },
 ): Promise<string> {
   const matches = [...htmlString.matchAll(ATTACHMENT_IMG_SRC)];
   if (matches.length === 0) {
@@ -75,15 +109,37 @@ export async function embedAttachmentImages(
   // De-dupe: the same attachment can appear more than once on a page.
   const uniqueIds = [...new Set(matches.map((m) => m[1]))];
 
+  // Batch-fetch instead of one findById per id.
+  const attachments = await Attachment.find({ _id: { $in: uniqueIds } });
+  const attachmentById = new Map<string, IAttachmentDocument>(
+    attachments.map((a) => [a._id.toString(), a]),
+  );
+
+  const Page = mongoose.model<IPage, PageModel>('Page');
+
   const replacements = new Map<string, string>();
 
   await Promise.all(
     uniqueIds.map(async (id) => {
       try {
-        const attachment = await Attachment.findById(id);
+        const attachment = attachmentById.get(id);
         if (attachment == null) return;
 
-        const readable = await fileUploadService.findDeliveryFile(attachment);
+        if (attachment.page != null) {
+          const isAccessible = await Page.isAccessiblePageByViewer(
+            getIdStringForRef(attachment.page),
+            exportingUser,
+          );
+          if (!isAccessible) {
+            logger.warn(
+              "Skipping attachment %s for bulk export: exporting user can't " +
+                'access the page it belongs to.',
+              id,
+            );
+            return;
+          }
+        }
+
         const assetFileName = `${id}${path.extname(attachment.fileName ?? '')}`;
         const assetFilePath = path.join(assetsDir, assetFileName);
 
@@ -91,13 +147,18 @@ export async function embedAttachmentImages(
         // attachment just reference the already-written file.
         if (!fs.existsSync(assetFilePath)) {
           await fs.promises.mkdir(assetsDir, { recursive: true });
+          const readable = await fileUploadService.findDeliveryFile(attachment);
           const writeStream = fs.createWriteStream(assetFilePath);
-          await new Promise<void>((resolve, reject) => {
-            readable.pipe(writeStream);
-            writeStream.on('finish', resolve);
-            writeStream.on('error', reject);
-            readable.on('error', reject);
-          });
+          try {
+            await pipeline(readable, writeStream);
+          } catch (streamErr) {
+            // Don't leave a truncated file behind — a later reference to the
+            // same attachment in this job would otherwise treat it as
+            // "already downloaded" via the fs.existsSync check above, and
+            // silently embed a corrupted image.
+            await fs.promises.rm(assetFilePath, { force: true });
+            throw streamErr;
+          }
         }
 
         const relativeHref = path

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/export-pages-to-fs-async.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/export-pages-to-fs-async.ts
@@ -19,6 +19,7 @@ import PageBulkExportPageSnapshot from '../../../models/page-bulk-export-page-sn
 import type { IPageBulkExportJobCronService } from '..';
 import { BulkExportJobStreamDestroyedByCleanupError } from '../errors';
 import { createBulkExportMarkdownRenderer } from '../markdown';
+import { embedAttachmentImages } from './embed-images';
 
 const logger = loggerFactory(
   'growi:features:page-bulk-export:export-pages-to-fs-async',
@@ -106,6 +107,12 @@ export async function getPageWritable(
             let htmlString: string;
             try {
               htmlString = await renderer.renderToHtml(markdownBody, cssHref);
+              htmlString = await embedAttachmentImages(
+                htmlString,
+                fileOutputPath,
+                outputDir,
+                this.crowi,
+              );
             } catch (renderErr) {
               logger.warn(
                 'BulkExportMarkdownRenderer failed for page %s: %o',

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/export-pages-to-fs-async.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/export-pages-to-fs-async.ts
@@ -6,6 +6,7 @@ import {
   getParentPath,
   normalizePath,
 } from '@growi/core/dist/utils/path-utils';
+import mongoose from 'mongoose';
 
 import {
   PageBulkExportFormat,
@@ -71,6 +72,11 @@ export async function getPageWritable(
   // BulkExportMarkdownRenderer caches the unified pipeline at module level.
   const renderer = createBulkExportMarkdownRenderer();
 
+  // Resolved once per job (not per page): the user embedAttachmentImages
+  // runs its per-attachment permission check as.
+  const User = mongoose.model('User');
+  const exportingUser = await User.findById(pageBulkExportJob.user);
+
   // For pdf format, write the shared stylesheet once per job. Every page links
   // to it relatively, so the (~MB) CSS is not duplicated into each page's HTML.
   const cssFilePath = path.join(outputDir, SHARED_CSS_FILENAME);
@@ -107,12 +113,12 @@ export async function getPageWritable(
             let htmlString: string;
             try {
               htmlString = await renderer.renderToHtml(markdownBody, cssHref);
-              htmlString = await embedAttachmentImages(
-                htmlString,
+              htmlString = await embedAttachmentImages(htmlString, {
                 fileOutputPath,
                 outputDir,
-                this.crowi,
-              );
+                crowi: this.crowi,
+                exportingUser,
+              });
             } catch (renderErr) {
               logger.warn(
                 'BulkExportMarkdownRenderer failed for page %s: %o',


### PR DESCRIPTION
## Summary

Fixes page bulk export (PDF conversion) dropping all images. `pdf-converter` opens each exported page's HTML via `file://` (see `apps/pdf-converter/src/service/pdf-convert.ts`), so the app-root-relative `<img src="/attachment/<id>">` GROWI's renderer emits can never resolve — there's no origin for a `file://` document to resolve it against.

Closes #11830

## Change

After `renderToHtml` in `export-pages-to-fs-async.ts`, `embedAttachmentImages` (new file: `page-bulk-export-job-cron/steps/embed-images.ts`) rewrites `<img src="/attachment/<id>">` tags in the rendered HTML:

- For each referenced attachment, fetch its bytes server-side via `fileUploadService.findDeliveryFile` (this runs inside the already-authenticated `app` process — no HTTP round-trip or session cookie needed).
- Write each file once per export job into a shared `_bulk-export-assets/` directory alongside the job's HTML output (same convention as the already-shared `_bulk-export.css`).
- Rewrite the `src` to a relative path pointing at that local copy, so `pdf-converter`'s `file://` navigation can load it directly.

## Scope

This PR only handles **RELAY**-mode storage (`fileUploadService.determineResponseMode() === ResponseMode.RELAY`), i.e. the local filesystem and GridFS uploaders. If the mode isn't RELAY, `embedAttachmentImages` returns the HTML untouched — same as today's behavior — so REDIRECT (S3/GCS) and DELEGATE-mode deployments are unaffected by this change, neither improved nor regressed.

REDIRECT/DELEGATE support is intentionally left out of this PR; I don't have an S3/GCS environment to verify against and didn't want to land unverified behavior for those modes. Happy to follow up with that in a separate PR if there's interest.

## Testing

- Verified manually against `FILE_UPLOAD=local`: pages with attached images now retain those images in the exported PDF.
- `tsc --noEmit` and `biome check` pass on the changed/added files.
- No existing tests cover this path; let me know if a test double for `fileUploadService` in this suite is expected for a PR like this and I'll add one.
