### PR TITLE
refactor(backlinks): move the page-link model to prisma

### DIFF
--- a/apps/app/prisma/schema.prisma
+++ b/apps/app/prisma/schema.prisma
@@ -333,6 +333,23 @@ model pagebulkexportpagesnapshots {
   id String @id @default(auto()) @map("_id") @db.ObjectId
 }
 
+model pagelinks {
+  // No `v`/`__v`: this collection is prisma-only and has never been written by
+  // mongoose, so it carries no optimistic-concurrency version key — same as the other
+  // prisma-only collections (auditlog_es_sync_status, changestream_resume_tokens).
+  id         String  @id @default(auto()) @map("_id") @db.ObjectId
+  fromPageId String? @map("fromPage") @db.ObjectId
+  toPath     String
+  toPageId   String? @map("toPage") @db.ObjectId
+
+  fromPage pages? @relation("PageLinkFromPage", fields: [fromPageId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  toPage   pages? @relation("PageLinkToPage", fields: [toPageId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+  @@unique([fromPageId, toPath], map: "fromPage_1_toPath_1")
+  @@index([toPath], map: "toPath_1")
+  @@index([toPageId], map: "toPage_1")
+}
+
 model pageoperations {
   id          String                @id @default(auto()) @map("_id") @db.ObjectId
   /// Field referred in an index, but found no data to define the type.
@@ -401,6 +418,8 @@ model pages {
   attachments      attachments[]
   bookmarks        bookmarks[]
   pagetagrelations pagetagrelations[]
+  pagelinksFrom    pagelinks[]        @relation("PageLinkFromPage")
+  pagelinksTo      pagelinks[]        @relation("PageLinkToPage")
 
   @@index([parentId], map: "parent_1")
   @@index([path], map: "path_1")

--- a/apps/app/src/features/backlinks/interfaces/page-link.ts
+++ b/apps/app/src/features/backlinks/interfaces/page-link.ts
@@ -1,20 +1,7 @@
-import type { Document, Model, Types } from 'mongoose';
+import type { Types } from 'mongoose';
 
 export interface IPageLink {
   fromPage: Types.ObjectId;
   toPath: string;
   toPage: Types.ObjectId | null;
-}
-
-export interface PageLinkDocument extends IPageLink, Document {}
-export interface PageLinkModel extends Model<PageLinkDocument> {
-  replaceOutboundLinks(
-    fromPageId: Types.ObjectId,
-    resolvedRows: IPageLink[],
-  ): Promise<void>;
-  findBacklinkSources(toPageId: Types.ObjectId): Promise<Types.ObjectId[]>;
-  repointInboundLinks(
-    toPath: string,
-    toPage: Types.ObjectId | null,
-  ): Promise<void>;
 }

--- a/apps/app/src/features/backlinks/server/models/page-link-indexes.ts
+++ b/apps/app/src/features/backlinks/server/models/page-link-indexes.ts
@@ -1,0 +1,41 @@
+import type { CreateIndexesOptions, Db, IndexSpecification } from 'mongodb';
+
+export const PAGE_LINKS_COLLECTION = 'pagelinks';
+
+/**
+ * The indexes `pagelinks` requires.
+ *
+ * `fromPage_1_toPath_1` is a correctness constraint, not a tuning choice:
+ * `replaceOutboundLinks` upserts against that filter, so without the unique index
+ * concurrent replaces of one source page can insert duplicate rows.
+ *
+ * **Production provisions these from
+ * `migrations/20260901064500-add-indexes-to-pagelinks.js`, not from here** — a migration
+ * is an immutable snapshot, so it deliberately repeats the list rather than importing
+ * it. This declaration exists because the integration harness skips migrations on the
+ * default in-memory MongoDB (`test/setup/migrate-mongo.ts` runs them only against an
+ * external `MONGO_URI`), which would otherwise leave every integ test running against an
+ * index-less collection and quietly vacate the idempotency guarantees they assert.
+ *
+ * The two lists are kept honest by the index inventory assertion in
+ * `page-link-read-perf.integ.ts`, which runs against external MongoDB — where the
+ * migration really has run — and fails on any mismatch.
+ */
+export const PAGE_LINK_INDEXES: readonly {
+  key: IndexSpecification;
+  options: CreateIndexesOptions;
+}[] = [
+  { key: { fromPage: 1, toPath: 1 }, options: { unique: true } },
+  { key: { toPage: 1 }, options: {} },
+  { key: { toPath: 1 }, options: {} },
+];
+
+/** Idempotent: `createIndex` is a no-op when the identical index already exists. */
+export const ensurePageLinkIndexes = async (db: Db): Promise<void> => {
+  const collection = db.collection(PAGE_LINKS_COLLECTION);
+  await Promise.all(
+    PAGE_LINK_INDEXES.map(({ key, options }) =>
+      collection.createIndex(key, options),
+    ),
+  );
+};

--- a/apps/app/src/features/backlinks/server/models/page-link.ts
+++ b/apps/app/src/features/backlinks/server/models/page-link.ts
@@ -3,6 +3,7 @@ import { Types } from 'mongoose';
 import { Prisma } from '~/generated/prisma/client';
 
 import type { IPageLink } from '../../interfaces/page-link';
+import { throwOnWriteErrors } from './throw-on-write-errors';
 
 // Prisma-only collection: no mongoose schema, so its indexes are provisioned by
 // migrations/20260901064500-add-indexes-to-pagelinks.js rather than on connect.
@@ -36,7 +37,7 @@ export const extension = Prisma.defineExtension((client) => {
           // could interleave and drop rows — safe only because PageLinkUpsertQueue never
           // drains a page concurrently with itself.
           if (resolvedRows.length > 0) {
-            await client.$runCommandRaw({
+            const upsertResult = await client.$runCommandRaw({
               update: 'pagelinks',
               ordered: true,
               updates: resolvedRows.map((r) => ({
@@ -50,9 +51,10 @@ export const extension = Prisma.defineExtension((client) => {
                 upsert: true,
               })),
             });
+            throwOnWriteErrors(upsertResult, 'replaceOutboundLinks upsert');
           }
 
-          await client.$runCommandRaw({
+          const deleteResult = await client.$runCommandRaw({
             delete: 'pagelinks',
             deletes: [
               {
@@ -64,6 +66,7 @@ export const extension = Prisma.defineExtension((client) => {
               },
             ],
           });
+          throwOnWriteErrors(deleteResult, 'replaceOutboundLinks prune');
         },
 
         /**
@@ -130,7 +133,7 @@ export const extension = Prisma.defineExtension((client) => {
           // never its own backlink. Clearing it — rather than leaving it alone — is what
           // stops the path's previous occupant from staying cached there forever. The row
           // itself survives; `replaceOutboundLinks` owns row existence.
-          await client.$runCommandRaw({
+          const result = await client.$runCommandRaw({
             update: 'pagelinks',
             updates: [
               {
@@ -152,6 +155,7 @@ export const extension = Prisma.defineExtension((client) => {
               },
             ],
           });
+          throwOnWriteErrors(result, 'repointInboundLinks');
         },
       },
     },

--- a/apps/app/src/features/backlinks/server/models/page-link.ts
+++ b/apps/app/src/features/backlinks/server/models/page-link.ts
@@ -1,136 +1,159 @@
-import { Schema, Types } from 'mongoose';
+import { Types } from 'mongoose';
 
-import { getOrCreateModel } from '~/server/util/mongoose-utils';
+import { Prisma } from '~/generated/prisma/client';
 
-import type {
-  IPageLink,
-  PageLinkDocument,
-  PageLinkModel,
-} from '../../interfaces/page-link';
+import type { IPageLink } from '../../interfaces/page-link';
 
-const pageLinkSchema = new Schema<PageLinkDocument, PageLinkModel>({
-  fromPage: {
-    type: Schema.Types.ObjectId,
-    ref: 'Page',
-    required: true,
-  },
-  toPath: {
-    type: String,
-    required: true,
-  },
-  toPage: {
-    type: Schema.Types.ObjectId,
-    ref: 'Page',
-    default: null,
-    index: true,
-  },
-});
+// Prisma-only collection: no mongoose schema, so its indexes are provisioned by
+// migrations/20260901064500-add-indexes-to-pagelinks.js rather than on connect.
+// `Types.ObjectId` here is the id type the rest of the server passes around, not a
+// mongoose data-access dependency.
+export const extension = Prisma.defineExtension((client) => {
+  return client.$extends({
+    // No `result` block: the _id/__v aliases the migrated models declare exist for
+    // mongoose callers, and this collection has none.
+    model: {
+      pagelinks: {
+        /**
+         * Replace a page's outbound links with the freshly extracted set:
+         * insert new links, refresh existing ones, and delete links no longer present.
+         *
+         * Low-level primitive: writes exactly the rows it is given, with no filtering.
+         * Callers must go through the `syncOutboundLinks` service instead, which drops
+         * self-links before delegating here — do NOT call this static directly from
+         * event handlers.
+         */
+        async replaceOutboundLinks(
+          fromPageId: Types.ObjectId,
+          resolvedRows: IPageLink[],
+        ): Promise<void> {
+          const fromPageIdStr = fromPageId.toString();
+          const toPaths = resolvedRows.map((r) => r.toPath);
 
-// Only the indexes an actual query uses:
-//  - { fromPage, toPath } unique — serves replaceOutboundLinks' per-row upsert
-//    filter, its `toPath: { $nin }` delete, and every fromPage-only lookup
-//    (fromPage is the prefix), so a standalone fromPage index would be dead weight
-//  - toPage — serves findBacklinkSources
-// toPath alone has no query yet; B4's re-resolve-by-path adds one and should add
-// the index with it (the compound cannot serve toPath alone — wrong prefix).
-pageLinkSchema.index({ fromPage: 1, toPath: 1 }, { unique: true });
-// { fromPage, toPath } above can't serve a toPath-only query (wrong prefix) —
-// repointInboundLinks filters on toPath alone, so it needs its own index.
-pageLinkSchema.index({ toPath: 1 });
+          // Two raw commands, not one bulkWrite: Prisma has no bulk-upsert API, and no
+          // portable single command mixes upserts with a delete pre-MongoDB-8.0. That puts
+          // a round trip between them, so two concurrent replaces of the same fromPage
+          // could interleave and drop rows — safe only because PageLinkUpsertQueue never
+          // drains a page concurrently with itself.
+          if (resolvedRows.length > 0) {
+            await client.$runCommandRaw({
+              update: 'pagelinks',
+              ordered: true,
+              updates: resolvedRows.map((r) => ({
+                q: { fromPage: { $oid: fromPageIdStr }, toPath: r.toPath },
+                u: {
+                  $set: {
+                    toPage:
+                      r.toPage != null ? { $oid: r.toPage.toString() } : null,
+                  },
+                },
+                upsert: true,
+              })),
+            });
+          }
 
-/**
- * Replace a page's outbound links with the freshly extracted set:
- * insert new links, refresh existing ones, and delete links no longer present.
- *
- * Low-level primitive: writes exactly the rows it is given, with no filtering.
- * Callers must go through the `syncOutboundLinks` service instead, which drops
- * self-links before delegating here — do NOT call this static directly from
- * event handlers.
- */
-pageLinkSchema.statics.replaceOutboundLinks = async function (
-  fromPageId: Types.ObjectId,
-  resolvedRows: IPageLink[],
-): Promise<void> {
-  const toPaths = resolvedRows.map((r) => r.toPath);
-
-  // One ordered bulkWrite (not two awaited calls, not a transaction): keeps the
-  // replace in a single command and stays standalone-MongoDB compatible. The index
-  // is a derived cache and concurrent same-page upserts are idempotent, so strict
-  // atomicity isn't required.
-  await this.bulkWrite(
-    [
-      ...resolvedRows.map((r) => ({
-        updateOne: {
-          filter: { fromPage: fromPageId, toPath: r.toPath },
-          update: { $set: { toPage: r.toPage } },
-          upsert: true,
+          await client.$runCommandRaw({
+            delete: 'pagelinks',
+            deletes: [
+              {
+                q: {
+                  fromPage: { $oid: fromPageIdStr },
+                  toPath: { $nin: toPaths },
+                },
+                limit: 0,
+              },
+            ],
+          });
         },
-      })),
-      {
-        deleteMany: {
-          filter: { fromPage: fromPageId, toPath: { $nin: toPaths } },
+
+        /**
+         * Find IDs to all pages linking to this page.
+         */
+        async findBacklinkSources(
+          toPageId: Types.ObjectId,
+        ): Promise<Types.ObjectId[]> {
+          // Native `distinct`, not Prisma's `findMany({ distinct })`: both ride toPage_1,
+          // but Prisma dedupes in the query engine, so it streams a whole document per
+          // inbound link to the client first — measured 2.4x slower at a 20,000-inbound hub.
+          const result = await client.$runCommandRaw({
+            distinct: 'pagelinks',
+            key: 'fromPage',
+            query: { toPage: { $oid: toPageId.toString() } },
+          });
+
+          const values = Array.isArray(result.values) ? result.values : [];
+          return values.flatMap((value) =>
+            // Extended JSON: the driver hands ObjectIds back as { $oid }.
+            typeof value === 'object' &&
+            value != null &&
+            '$oid' in value &&
+            typeof value.$oid === 'string'
+              ? [new Types.ObjectId(value.$oid)]
+              : [],
+          );
         },
-      },
-    ],
-    { ordered: true },
-  );
-};
 
-/**
- * Find IDs to all pages linking to this page.
- */
-pageLinkSchema.statics.findBacklinkSources = async function (
-  toPageId: Types.ObjectId,
-): Promise<Types.ObjectId[]> {
-  return await this.distinct('fromPage', { toPage: toPageId });
-};
+        /**
+         * Point every row whose `toPath` field equals `toPath` at `toPage` (null =
+         * broken). One bulk update, matched by text — not per-source-page.
+         *
+         * Low-level primitive: writes the target it's given, resolving nothing itself.
+         * `reResolveByToPath` calls this once per already-resolved candidate path — do
+         * NOT call this static directly from event handlers.
+         */
+        async repointInboundLinks(
+          toPath: string,
+          toPage: Types.ObjectId | null,
+        ): Promise<void> {
+          // Both arguments are validated here because neither is protected downstream:
+          // `toPath` lands in a query filter, where an operator object from an unvalidated
+          // caller would match every row; `toPage` lands in an aggregation pipeline, which
+          // is not type-checked, so an expression object there is evaluated and its
+          // result written into the column.
+          if (typeof toPath !== 'string' || toPath.length === 0) {
+            throw new Error(
+              `repointInboundLinks requires a non-empty path string, received ${typeof toPath}`,
+            );
+          }
+          if (toPage != null && !(toPage instanceof Types.ObjectId)) {
+            throw new Error(
+              'repointInboundLinks requires an ObjectId or null as toPage',
+            );
+          }
 
-/**
- * Point every row whose `toPath` field equals `toPath` at `toPage` (null =
- * broken). One bulk update, matched by text — not per-source-page.
- *
- * Low-level primitive: writes the target it's given, resolving nothing itself.
- * `reResolveByToPath` calls this once per already-resolved candidate path — do
- * NOT call this static directly from event handlers.
- */
-pageLinkSchema.statics.repointInboundLinks = async function (
-  toPath: string,
-  toPage: Types.ObjectId | null,
-): Promise<void> {
-  // Both arguments are validated here because neither is protected downstream:
-  // `toPath` lands in a query filter, where an operator object from an unvalidated
-  // caller would match every row; `toPage` lands in an aggregation pipeline, which
-  // mongoose does not cast, so an expression object there is evaluated and its
-  // result written into the column.
-  if (typeof toPath !== 'string' || toPath.length === 0) {
-    throw new Error(
-      `repointInboundLinks requires a non-empty path string, received ${typeof toPath}`,
-    );
-  }
-  if (toPage != null && !(toPage instanceof Types.ObjectId)) {
-    throw new Error(
-      'repointInboundLinks requires an ObjectId or null as toPage',
-    );
-  }
+          const toPageOid = toPage != null ? { $oid: toPage.toString() } : null;
 
-  // The row whose own source is the target caches null, not the target: a page is
-  // never its own backlink. Clearing it — rather than leaving it alone — is what
-  // stops the path's previous occupant from staying cached there forever. The row
-  // itself survives; `replaceOutboundLinks` owns row existence, and
-  // `dropSelfLinks` drops it on the source's next save.
-  //
-  // One pipeline update rather than two plain ones, so no row is ever momentarily
-  // its own backlink and a failure cannot leave it that way.
-  await this.updateMany({ toPath }, [
-    {
-      $set: {
-        toPage: { $cond: [{ $eq: ['$fromPage', toPage] }, null, toPage] },
+          // A raw command because the $cond against the document's own `fromPage` is a
+          // pipeline update, which the Prisma query API cannot express.
+          //
+          // The row whose own source is the target caches null, not the target: a page is
+          // never its own backlink. Clearing it — rather than leaving it alone — is what
+          // stops the path's previous occupant from staying cached there forever. The row
+          // itself survives; `replaceOutboundLinks` owns row existence.
+          await client.$runCommandRaw({
+            update: 'pagelinks',
+            updates: [
+              {
+                q: { toPath },
+                u: [
+                  {
+                    $set: {
+                      toPage: {
+                        $cond: [
+                          { $eq: ['$fromPage', toPageOid] },
+                          null,
+                          toPageOid,
+                        ],
+                      },
+                    },
+                  },
+                ],
+                multi: true,
+              },
+            ],
+          });
+        },
       },
     },
-  ]);
-};
-
-export default getOrCreateModel<PageLinkDocument, PageLinkModel>(
-  'PageLink',
-  pageLinkSchema,
-);
+  });
+});

--- a/apps/app/src/features/backlinks/server/models/throw-on-write-errors.spec.ts
+++ b/apps/app/src/features/backlinks/server/models/throw-on-write-errors.spec.ts
@@ -1,0 +1,211 @@
+import { throwOnWriteErrors } from './throw-on-write-errors';
+
+// Every reply fixture below is a verbatim capture of what MongoDB returned for a
+// `$runCommandRaw` write against the pagelinks collection — an invented shape would let
+// the helper agree with the test while both disagree with the database. The sole
+// exception is the last test, which deliberately constructs a shape MongoDB does not
+// return, because that is the case it exists to cover.
+//
+// Assertions check what the message *tells the operator* (which call site, what MongoDB
+// said, the code), not how it is punctuated: reformatting the message is a refactor, and
+// a test that fails on it reports a regression that did not happen.
+
+/** Fails loudly rather than returning a message when the call does not throw. */
+const messageFrom = (call: () => void): string => {
+  try {
+    call();
+  } catch (err) {
+    return (err as Error).message;
+  }
+  throw new Error('expected throwOnWriteErrors to throw, but it returned');
+};
+
+describe('throwOnWriteErrors', () => {
+  describe('replies that reported no failure', () => {
+    // Not throwing is the contract here, not an absent assertion: a false positive on a
+    // clean reply would fail every backlink sync.
+    it('accepts an update that upserted a row', () => {
+      const reply = {
+        n: 1,
+        upserted: [{ index: 0, _id: { $oid: '6a990395c82a8dac0f6f31d1' } }],
+        nModified: 0,
+        ok: 1,
+      };
+
+      expect(() => throwOnWriteErrors(reply, 'ctx')).not.toThrow();
+    });
+
+    it('accepts a delete that removed a row', () => {
+      expect(() => throwOnWriteErrors({ n: 1, ok: 1 }, 'ctx')).not.toThrow();
+    });
+
+    it('accepts a write that matched nothing', () => {
+      expect(() =>
+        throwOnWriteErrors({ n: 0, nModified: 0, ok: 1 }, 'ctx'),
+      ).not.toThrow();
+    });
+  });
+
+  describe('replies that reported a failure while still resolving with ok: 1', () => {
+    it('throws for a duplicate key, naming the call site the reply cannot identify', () => {
+      const reply = {
+        n: 0,
+        writeErrors: [
+          {
+            index: 0,
+            code: 11000,
+            errmsg:
+              'E11000 duplicate key error collection: growi.pagelinks index: fromPage_1_toPath_1 dup key: { fromPage: ObjectId(\'6a99095574c3d607230d5b95\'), toPath: "/x" }',
+            keyPattern: { fromPage: 1, toPath: 1 },
+            keyValue: {
+              fromPage: { $oid: '6a99095574c3d607230d5b95' },
+              toPath: '/x',
+            },
+          },
+        ],
+        ok: 1,
+      };
+
+      const message = messageFrom(() =>
+        throwOnWriteErrors(reply, 'replaceOutboundLinks upsert'),
+      );
+
+      // Four raw writes share this helper and the reply names none of them.
+      expect(message).toContain('replaceOutboundLinks upsert');
+      expect(message).toContain('E11000 duplicate key error');
+      expect(message).toContain('fromPage_1_toPath_1');
+    });
+
+    it('throws for a rejected update operator', () => {
+      const reply = {
+        n: 0,
+        writeErrors: [
+          {
+            index: 0,
+            code: 9,
+            errmsg:
+              'Unknown modifier: $bogusOperator. Expected a valid update modifier or pipeline-style update specified as an array',
+          },
+        ],
+        nModified: 0,
+        ok: 1,
+      };
+
+      const message = messageFrom(() =>
+        throwOnWriteErrors(reply, 'repointInboundLinks'),
+      );
+
+      expect(message).toContain('repointInboundLinks');
+      expect(message).toContain('Unknown modifier: $bogusOperator');
+    });
+
+    it('reports every failed statement, not just the first', () => {
+      // An unordered batch attempts every statement, so one reply can carry several.
+      const reply = {
+        n: 0,
+        writeErrors: [
+          {
+            index: 0,
+            code: 11000,
+            errmsg:
+              'E11000 duplicate key error collection: growi.pagelinks index: fromPage_1_toPath_1 dup key: { fromPage: ObjectId(\'6a99095574c3d607230d5b95\'), toPath: "/x" }',
+            keyPattern: { fromPage: 1, toPath: 1 },
+            keyValue: {
+              fromPage: { $oid: '6a99095574c3d607230d5b95' },
+              toPath: '/x',
+            },
+          },
+          {
+            index: 1,
+            code: 11000,
+            errmsg:
+              'E11000 duplicate key error collection: growi.pagelinks index: fromPage_1_toPath_1 dup key: { fromPage: ObjectId(\'6a99095574c3d607230d5b95\'), toPath: "/y" }',
+            keyPattern: { fromPage: 1, toPath: 1 },
+            keyValue: {
+              fromPage: { $oid: '6a99095574c3d607230d5b95' },
+              toPath: '/y',
+            },
+          },
+        ],
+        ok: 1,
+      };
+
+      const message = messageFrom(() => throwOnWriteErrors(reply, 'ctx'));
+
+      // Both rows, not just one: the two entries differ only by the path they name.
+      expect(message).toContain('toPath: "/x"');
+      expect(message).toContain('toPath: "/y"');
+    });
+
+    it('throws when the write applied but the replica set did not acknowledge it', () => {
+      // n:1 and no writeErrors — the row IS written; only its durability is unconfirmed.
+      const reply = {
+        n: 1,
+        upserted: [{ index: 0, _id: { $oid: '6a9906b31f14d8271b5fac04' } }],
+        nModified: 0,
+        writeConcernError: {
+          code: 100,
+          codeName: 'UnsatisfiableWriteConcern',
+          errmsg: 'Not enough data-bearing nodes',
+          errInfo: {
+            writeConcern: { w: 5, wtimeout: 200, provenance: 'clientSupplied' },
+          },
+        },
+        ok: 1,
+      };
+
+      const message = messageFrom(() => throwOnWriteErrors(reply, 'ctx'));
+
+      // This errmsg does not repeat its own code, so it is the one fixture that can
+      // prove the code reaches the operator rather than merely appearing inside a quote.
+      expect(message).toContain('100');
+      expect(message).toContain('Not enough data-bearing nodes');
+    });
+
+    it('reports a rejected statement and an unacknowledged write from the same reply', () => {
+      // MongoDB really does return both at once: statements are assessed one by one, the
+      // write concern once at the end. Diagnosing either alone hides half the failure.
+      const reply = {
+        n: 0,
+        writeErrors: [
+          {
+            index: 0,
+            code: 11000,
+            errmsg:
+              'E11000 duplicate key error collection: growi.pagelinks index: fromPage_1_toPath_1 dup key: { fromPage: ObjectId(\'6a99095574c3d607230d5b95\'), toPath: "/x" }',
+            keyPattern: { fromPage: 1, toPath: 1 },
+            keyValue: {
+              fromPage: { $oid: '6a99095574c3d607230d5b95' },
+              toPath: '/x',
+            },
+          },
+        ],
+        writeConcernError: {
+          code: 100,
+          codeName: 'UnsatisfiableWriteConcern',
+          errmsg: 'Not enough data-bearing nodes',
+          errInfo: {
+            writeConcern: { w: 5, wtimeout: 200, provenance: 'clientSupplied' },
+          },
+        },
+        ok: 1,
+      };
+
+      const message = messageFrom(() => throwOnWriteErrors(reply, 'ctx'));
+
+      expect(message).toContain('E11000 duplicate key error');
+      expect(message).toContain('Not enough data-bearing nodes');
+    });
+  });
+
+  it('still reports a failure whose shape it does not recognise', () => {
+    // Deliberately not a real reply: MongoDB always sends errmsg. Guards the fallback
+    // against a future shape — an unreadable entry must surface, never be dropped as
+    // "no failure".
+    const reply = { n: 0, writeErrors: [{ index: 0, code: 11000 }], ok: 1 };
+
+    const message = messageFrom(() => throwOnWriteErrors(reply, 'ctx'));
+
+    expect(message).toContain('11000');
+  });
+});

--- a/apps/app/src/features/backlinks/server/models/throw-on-write-errors.ts
+++ b/apps/app/src/features/backlinks/server/models/throw-on-write-errors.ts
@@ -1,0 +1,49 @@
+import type { Prisma } from '~/generated/prisma/client';
+
+/**
+ * MongoDB reports per-statement write failures *inside a successful reply*: the command
+ * resolves with `ok: 1` and a `writeErrors` array (duplicate keys, bad update operators),
+ * and a write-concern failure resolves with `writeConcernError`. Only a command-level
+ * failure — an unknown command, a lost connection — rejects, as Prisma's P2010.
+ *
+ * So a `$runCommandRaw` write whose reply is discarded loses those failures silently.
+ * Every raw write in this feature passes its reply through here instead.
+ */
+export const throwOnWriteErrors = (
+  result: Prisma.JsonObject,
+  context: string,
+): void => {
+  const messages = [
+    ...describeAll(result.writeErrors),
+    ...describeAll(result.writeConcernError),
+  ];
+
+  if (messages.length === 0) {
+    return;
+  }
+
+  throw new Error(`${context} failed: ${messages.join('; ')}`);
+};
+
+// `writeErrors` is an array, `writeConcernError` a single object; both are absent when
+// the command wrote cleanly.
+const describeAll = (value: Prisma.JsonValue | undefined): string[] => {
+  if (value == null) {
+    return [];
+  }
+  return (Array.isArray(value) ? value : [value]).map(describeError);
+};
+
+const describeError = (entry: Prisma.JsonValue): string => {
+  if (typeof entry !== 'object' || entry == null || Array.isArray(entry)) {
+    return String(entry);
+  }
+
+  const errmsg = 'errmsg' in entry ? entry.errmsg : undefined;
+  if (typeof errmsg !== 'string') {
+    return JSON.stringify(entry);
+  }
+
+  const code = 'code' in entry ? entry.code : undefined;
+  return code != null ? `[${String(code)}] ${errmsg}` : errmsg;
+};

--- a/apps/app/src/features/backlinks/server/services/find-backlinks.ts
+++ b/apps/app/src/features/backlinks/server/services/find-backlinks.ts
@@ -4,14 +4,15 @@ import mongoose from 'mongoose';
 
 import type { PageDocument, PageModel } from '~/server/models/page';
 import { PageQueryBuilder } from '~/server/models/page';
+import { prisma } from '~/utils/prisma';
 
 import type { IBacklink } from '../../interfaces/backlink';
-import PageLink from '../models/page-link';
 
-// Intentionally unbounded: B2.1 measured this path against 100k pages with a
-// 5,000-inbound hub at a median 128 ms (192 ms at 20,000 inbound; 164 ms with a cache
-// 19x too small to hold the data), both plans index-backed, so no result cap or extra
-// index is warranted yet. Re-measure with page-link-read-perf.integ.ts before adding either.
+// Intentionally unbounded: B2.1 measures this path against 100k pages with a
+// 5,000-inbound hub at a median 29 ms (120 ms at 20,000 inbound), both plans
+// index-backed, so no result cap or extra index is warranted yet. Re-measure with
+// page-link-read-perf.integ.ts before adding either. Figures are devcontainer numbers
+// re-taken after the Prisma migration — don't read a trend across environments.
 type BacklinkSource = {
   _id: Types.ObjectId;
   path: string;
@@ -54,7 +55,7 @@ export const findBacklinks = async (
   toPageId: Types.ObjectId,
   user: IUser | null,
 ): Promise<IBacklink[]> => {
-  const backlinkIds = await PageLink.findBacklinkSources(toPageId);
+  const backlinkIds = await prisma.pagelinks.findBacklinkSources(toPageId);
 
   const { query } = await buildVisibleSourcesQuery(backlinkIds, user);
   const pages: BacklinkSource[] = await query.lean().exec();

--- a/apps/app/src/features/backlinks/server/services/page-link-lifecycle.integ.ts
+++ b/apps/app/src/features/backlinks/server/services/page-link-lifecycle.integ.ts
@@ -8,7 +8,14 @@ import type { PageDocument, PageModel } from '~/server/models/page';
 import PageRedirect from '~/server/models/page-redirect';
 import { prisma } from '~/utils/prisma';
 
-import PageLink from '../models/page-link';
+import { ensurePageLinkIndexes } from '../models/page-link-indexes';
+
+// pagelinks is prisma-only, and the harness skips migrations on the in-memory MongoDB.
+beforeAll(async () => {
+  const db = mongoose.connection.db;
+  if (db == null) throw new Error('no mongoose connection');
+  await ensurePageLinkIndexes(db);
+});
 
 /*
  * B1.15 — Integration tests for the B1 slice.
@@ -90,10 +97,11 @@ describe('Backlinks B1 slice (lifecycle integration)', () => {
   };
 
   const outboundRows = (fromPage: Types.ObjectId) =>
-    PageLink.find({ fromPage })
-      .select('toPath toPage -_id')
-      .sort({ toPath: 1 })
-      .lean();
+    prisma.pagelinks.findMany({
+      where: { fromPageId: fromPage.toString() },
+      select: { toPath: true, toPageId: true },
+      orderBy: { toPath: 'asc' },
+    });
 
   // The service handles create/update asynchronously (fire-and-forget from the
   // emitter's view). Poll the outbound-row count — the observable write-path
@@ -104,7 +112,11 @@ describe('Backlinks B1 slice (lifecycle integration)', () => {
   ): Promise<void> =>
     vi.waitFor(
       async () => {
-        expect(await PageLink.countDocuments({ fromPage })).toBe(count);
+        expect(
+          await prisma.pagelinks.count({
+            where: { fromPageId: fromPage.toString() },
+          }),
+        ).toBe(count);
       },
       { timeout: 15000, interval: 100 },
     );
@@ -143,7 +155,9 @@ describe('Backlinks B1 slice (lifecycle integration)', () => {
     const seededPaths = new RegExp(`^(/trash)?${PREFIX}/`);
     const pages = await Page.find({ path: seededPaths }).select('_id');
     const ids = pages.map((p) => p._id);
-    await PageLink.deleteMany({ fromPage: { $in: ids } });
+    await prisma.pagelinks.deleteMany({
+      where: { fromPageId: { in: ids.map((id) => id.toString()) } },
+    });
     await prisma.revisions.deleteMany({
       where: { pageId: { in: ids.map((id) => id.toString()) } },
     });
@@ -253,7 +267,7 @@ describe('Backlinks B1 slice (lifecycle integration)', () => {
     // The repeated link collapses to a single outbound row.
     await waitForOutboundCount(source._id, 1);
     expect(await outboundRows(source._id)).toEqual([
-      { toPath: target.path, toPage: target._id },
+      { toPath: target.path, toPageId: target._id.toString() },
     ]);
 
     // And the read lists the source exactly once.
@@ -310,7 +324,7 @@ describe('Backlinks B1 slice (lifecycle integration)', () => {
 
     // Only the non-self link remains as an outbound row.
     expect(await outboundRows(selfLinker._id)).toEqual([
-      { toPath: other.path, toPage: other._id },
+      { toPath: other.path, toPageId: other._id.toString() },
     ]);
 
     // The page is not a backlink of itself.
@@ -353,8 +367,8 @@ describe('Backlinks B1 slice (lifecycle integration)', () => {
 
     // toPath still mirrors the body; toPage followed the rename.
     expect(await outboundRows(source._id)).toEqual([
-      { toPath: oldPath, toPage: target._id },
-      { toPath: witness.path, toPage: witness._id },
+      { toPath: oldPath, toPageId: target._id.toString() },
+      { toPath: witness.path, toPageId: witness._id.toString() },
     ]);
 
     // What the user sees: the renamed target still lists the source.

--- a/apps/app/src/features/backlinks/server/services/page-link-read-perf.integ.ts
+++ b/apps/app/src/features/backlinks/server/services/page-link-read-perf.integ.ts
@@ -1,5 +1,6 @@
 import type { IUserHasId } from '@growi/core';
 import { escapeStringForMongoRegex } from '@growi/core/dist/utils';
+import type { Document } from 'mongodb';
 import mongoose, { type Types } from 'mongoose';
 
 import { getInstance } from '^/test/setup/crowi';
@@ -7,10 +8,63 @@ import { getInstance } from '^/test/setup/crowi';
 import type { PageDocument, PageModel } from '~/server/models/page';
 import UserGroup from '~/server/models/user-group';
 import UserGroupRelation from '~/server/models/user-group-relation';
+import { prisma } from '~/utils/prisma';
 
-import PageLink from '../models/page-link';
 import { buildVisibleSourcesQuery, findBacklinks } from './find-backlinks';
 import { syncOutboundLinks } from './page-link-sync';
+
+const PAGELINKS_COLLECTION = 'pagelinks';
+
+/**
+ * Raw driver handle — for the perf-critical bulk inserts and the collection-level
+ * inspection (indexes, explain) that need to bypass both ORMs.
+ */
+const rawPagelinksCollection = () => {
+  const db = mongoose.connection.db;
+  if (db == null) throw new Error('no mongoose connection');
+  return db.collection(PAGELINKS_COLLECTION);
+};
+
+/**
+ * The commands `fn` actually sent to the `pagelinks` collection, read off the database
+ * profiler.
+ *
+ * The plan and scoping assertions below are only worth anything if they describe the
+ * command *production* issues. A transcribed copy silently stops tracking the real one
+ * (it did exactly that when findBacklinkSources moved to Prisma), and a spy cannot reach
+ * the extension's closure-captured client. Observing the wire cannot drift.
+ */
+const capturePagelinkCommands = async (
+  fn: () => Promise<unknown>,
+): Promise<Document[]> => {
+  const db = mongoose.connection.db;
+  if (db == null) throw new Error('no mongoose connection');
+
+  const since = new Date();
+  await db.command({ profile: 2 });
+  try {
+    await fn();
+  } finally {
+    await db.command({ profile: 0 });
+  }
+
+  return db
+    .collection('system.profile')
+    .find({
+      ts: { $gte: since },
+      ns: `${db.databaseName}.${PAGELINKS_COLLECTION}`,
+    })
+    .sort({ ts: 1 })
+    .toArray();
+};
+
+/** Strip the session/routing envelope so a captured command can be fed back to `explain`. */
+const explainable = (command: Document): Document =>
+  Object.fromEntries(
+    Object.entries(command).filter(
+      ([key]) => !key.startsWith('$') && key !== 'lsid',
+    ),
+  );
 
 /*
  * B2.1 — read-path benchmark for backlinks retrieval at scale (requirement 3.4).
@@ -150,7 +204,7 @@ const describeCacheRegime = async (): Promise<{
   if (db == null) throw new Error('no mongoose connection');
   const [pages, links] = await Promise.all([
     db.command({ collStats: 'pages' }),
-    db.command({ collStats: PageLink.collection.collectionName }),
+    db.command({ collStats: PAGELINKS_COLLECTION }),
   ]);
   const bytes =
     pages.storageSize +
@@ -228,7 +282,9 @@ describe.skipIf(!isEnabled)('B2.1 backlinks read-path benchmark', () => {
       Page.deleteMany({ path: trashPathRe }),
       // A killed run's link rows: their fromPage ids died with the process, but every
       // seeded row's toPath carries the fixture prefix.
-      PageLink.deleteMany({ toPath: pathRe }),
+      prisma.pagelinks.deleteMany({
+        where: { toPath: { startsWith: PREFIX } },
+      }),
     ]);
   };
 
@@ -271,10 +327,11 @@ describe.skipIf(!isEnabled)('B2.1 backlinks read-path benchmark', () => {
       // Self-heal before seeding: see purgeFixtures.
       await purgeFixtures();
 
-      // syncIndexes(), not init(): init() only ever creates, and `growi_test_<workerId>`
-      // is reused across runs — so indexes B2.2 removed from the schema would survive and
-      // the inventory check below would flag a stale local database as a real gap.
-      await PageLink.syncIndexes();
+      // No index setup here: pagelinks is prisma-only, so its indexes come from
+      // migrations/20260901064500-add-indexes-to-pagelinks.js, which the harness has
+      // already applied (test/setup/migrate-mongo.ts). That is deliberately not
+      // re-created here — the inventory check below has to see what the migration
+      // really produced, or it would just be asserting its own setup back at itself.
 
       await User.insertMany(
         FIXTURE_USERNAMES.map((username) => ({
@@ -454,7 +511,7 @@ describe.skipIf(!isEnabled)('B2.1 backlinks read-path benchmark', () => {
         }
       }
 
-      await insertInBatches(PageLink.collection, linkDocs);
+      await insertInBatches(rawPagelinksCollection(), linkDocs);
 
       report(
         `[B2.1] seeded ${pageDocs.length} pages / ${linkDocs.length} link rows in ${Math.round(performance.now() - seedStarted)} ms`,
@@ -485,23 +542,27 @@ describe.skipIf(!isEnabled)('B2.1 backlinks read-path benchmark', () => {
         // biome-ignore lint/performance/noAwaitInLoops: batched to bound the delete size
         await Promise.all([
           Page.deleteMany({ _id: { $in: batch } }),
-          PageLink.deleteMany({ fromPage: { $in: batch } }),
+          prisma.pagelinks.deleteMany({
+            where: { fromPageId: { in: batch.map((id) => id.toString()) } },
+          }),
         ]);
       }
       // Guarded: a beforeAll that throws before hubPageId is assigned still runs this
-      // hook, and mongoose passes `{toPage: undefined}` through to the driver, which
-      // serializes it to `{toPage: null}` — matching every *unresolved* link row in the
-      // database, including rows this file never created (toPage defaults to null).
+      // hook. Unlike the Mongoose driver, Prisma's `toPageId: hubPageId.toString()`
+      // filter only ever matches that literal string — it cannot accidentally widen to
+      // "every unresolved row" the way `{toPage: undefined}` did over the raw driver.
       if (hubPageId != null) {
-        await PageLink.deleteMany({ toPage: hubPageId });
+        await prisma.pagelinks.deleteMany({
+          where: { toPageId: hubPageId.toString() },
+        });
       }
       await purgeFixtures();
     },
     10 * 60 * 1000,
   );
 
-  it('has exactly the two shipped indexes on pagelinks', async () => {
-    const indexes = await PageLink.collection.indexes();
+  it('has exactly the three shipped indexes on pagelinks', async () => {
+    const indexes = await rawPagelinksCollection().indexes();
     const byKey = new Map(indexes.map((idx) => [JSON.stringify(idx.key), idx]));
 
     // Closed set, not a presence check: every latency figure this file reports is only
@@ -510,16 +571,18 @@ describe.skipIf(!isEnabled)('B2.1 backlinks read-path benchmark', () => {
     // would otherwise leave every test in this file green (the distinct merely upgrades
     // to PROJECTION_COVERED <- DISTINCT_SCAN, still index-backed and still under target)
     // while the recorded numbers silently described a configuration that no longer
-    // exists. beforeAll's syncIndexes() drops indexes the schema no longer declares, so
-    // this asserts the schema itself rather than whatever a reused local database holds.
-    // `_id_` is included: it is in the inventory, though not one of the two "shipped".
+    // exists. What it reads is the migration's real output, so it doubles as that
+    // migration's drift test — and, since nothing reconciles indexes at connect any
+    // more, a `growi_test_<workerId>` left over from the mongoose era can fail here
+    // with a stale extra index. That is the intended signal, not a flake: drop the
+    // test database.
+    // `_id_` is included: it is in the inventory, though not one of the three "shipped".
     expect(indexes.map((idx) => idx.name).sort()).toEqual([
       '_id_', // implicit
       'fromPage_1_toPath_1', // replaceOutboundLinks' upsert filter and $nin delete
       'toPage_1', // what findBacklinkSources' distinct rides
+      'toPath_1', // repointInboundLinks' toPath-only filter (added by B4)
     ]);
-    // Subsumed by the set above, kept for the WHY: B2.2 dropped a standalone
-    // { fromPage } and { toPath } as unused — their absence is expected, not a gap.
 
     // Uniqueness is the one property the name set cannot express.
     const compound = byKey.get(JSON.stringify({ fromPage: 1, toPath: 1 }));
@@ -540,9 +603,9 @@ describe.skipIf(!isEnabled)('B2.1 backlinks read-path benchmark', () => {
 
     // Sub-steps, to locate the bottleneck rather than just observe the total.
     const distinctOnly = await measure(TIMED_RUNS, () =>
-      PageLink.findBacklinkSources(hubPageId),
+      prisma.pagelinks.findBacklinkSources(hubPageId),
     );
-    const sourceIds = await PageLink.findBacklinkSources(hubPageId);
+    const sourceIds = await prisma.pagelinks.findBacklinkSources(hubPageId);
     const filterOnly = await measure(TIMED_RUNS, async () => {
       // Production's own query builder, so this sub-step timing cannot drift away from
       // the query findBacklinks issues.
@@ -626,20 +689,24 @@ describe.skipIf(!isEnabled)('B2.1 backlinks read-path benchmark', () => {
     const db = mongoose.connection.db;
     if (db == null) throw new Error('no mongoose connection');
 
-    // distinct on { toPage } — explained via the command, since Model.distinct()
-    // has no .explain().
+    // Explain the command findBacklinkSources really sent, not a transcription of it.
+    const readCommands = await capturePagelinkCommands(() =>
+      prisma.pagelinks.findBacklinkSources(hubPageId),
+    );
+    expect(readCommands).toHaveLength(1);
+
     const distinctExplain = await db.command({
-      explain: {
-        distinct: PageLink.collection.collectionName,
-        key: 'fromPage',
-        query: { toPage: hubPageId },
-      },
+      explain: explainable(readCommands[0].command),
       verbosity: 'queryPlanner',
     });
     const distinctStages = collectStages(
       distinctExplain.queryPlanner?.winningPlan,
     );
 
+    report(
+      '[B2.1] read command:',
+      JSON.stringify(explainable(readCommands[0].command)),
+    );
     report('[B2.1] distinct winning plan stages:', distinctStages.join(' <- '));
     expect(distinctStages).not.toContain('COLLSCAN');
     // A covered distinct collapses to DISTINCT_SCAN; a plain index hit is IXSCAN.
@@ -649,7 +716,7 @@ describe.skipIf(!isEnabled)('B2.1 backlinks read-path benchmark', () => {
 
     // The viewer-filtered Page query, built by production — so this no-COLLSCAN
     // guarantee covers the query findBacklinks issues, not a copy of it.
-    const sourceIds = await PageLink.findBacklinkSources(hubPageId);
+    const sourceIds = await prisma.pagelinks.findBacklinkSources(hubPageId);
     const { query } = await buildVisibleSourcesQuery(sourceIds, viewer);
     // mongoose types explain() as resolving to the query's own result type; the real
     // shape is an untyped driver explain document, matching collectStages' parameter.
@@ -675,51 +742,57 @@ describe.skipIf(!isEnabled)('B2.1 backlinks read-path benchmark', () => {
     const untouchedPage = seededPageIds[2];
 
     const before = {
-      total: await PageLink.countDocuments(),
-      untouched: await PageLink.find({ fromPage: untouchedPage })
-        .select('toPath toPage -_id')
-        .sort({ toPath: 1 })
-        .lean(),
+      total: await prisma.pagelinks.count(),
+      untouched: await prisma.pagelinks.findMany({
+        where: { fromPageId: untouchedPage.toString() },
+        select: { toPath: true, toPageId: true },
+        orderBy: { toPath: 'asc' },
+      }),
     };
 
-    const bulkWriteSpy = vi.spyOn(PageLink, 'bulkWrite');
+    // Every write the save issued must be scoped to the edited page.
+    const writeCommands = await capturePagelinkCommands(() =>
+      syncOutboundLinks(editedPage, [
+        { fromPage: editedPage, toPath: `${PREFIX}/hub`, toPage: hubPageId },
+      ]),
+    );
+    expect(writeCommands.length).toBeGreaterThan(0);
 
-    await syncOutboundLinks(editedPage, [
-      { fromPage: editedPage, toPath: `${PREFIX}/hub`, toPage: hubPageId },
-    ]);
-
-    // Every operation the save issued must be scoped to the edited page.
-    expect(bulkWriteSpy).toHaveBeenCalledTimes(1);
-    const ops = bulkWriteSpy.mock.calls[0][0];
-    for (const op of ops) {
-      // replaceOutboundLinks issues only these two op kinds; anything else would be a
-      // new, unreviewed write shape and should fail this check rather than be skipped.
-      const filter =
-        'updateOne' in op
-          ? op.updateOne.filter
-          : 'deleteMany' in op
-            ? op.deleteMany.filter
-            : undefined;
-      expect(filter?.fromPage).toStrictEqual(editedPage);
+    for (const entry of writeCommands) {
+      const { command } = entry;
+      // The profiler logs each write statement on its own, or a batch envelope when the
+      // server groups them — accept either, reject anything else (a new, unreviewed write
+      // shape should fail here rather than be skipped).
+      const statements =
+        command.updates ??
+        command.deletes ??
+        (command.q != null ? [command] : undefined);
+      expect(
+        statements,
+        `unexpected command: ${JSON.stringify(command)}`,
+      ).toBeDefined();
+      for (const statement of statements) {
+        expect(statement.q?.fromPage?.toString()).toBe(editedPage.toString());
+      }
     }
-    bulkWriteSpy.mockRestore();
 
-    // And no other page's rows moved.
-    const afterUntouched = await PageLink.find({ fromPage: untouchedPage })
-      .select('toPath toPage -_id')
-      .sort({ toPath: 1 })
-      .lean();
+    // No other page's rows moved.
+    const afterUntouched = await prisma.pagelinks.findMany({
+      where: { fromPageId: untouchedPage.toString() },
+      select: { toPath: true, toPageId: true },
+      orderBy: { toPath: 'asc' },
+    });
     expect(afterUntouched).toStrictEqual(before.untouched);
     // The edited page dropped its EXTRA_LINKS_PER_PAGE rows and kept the hub row.
-    expect(await PageLink.countDocuments()).toBe(
+    expect(await prisma.pagelinks.count()).toBe(
       before.total - EXTRA_LINKS_PER_PAGE,
     );
 
     // The delete half filters { fromPage, toPath: { $nin } } — confirm that shape is
     // index-served too, so a save cannot degrade into a collection walk. Explained via
-    // the raw collection: it plans the literal filter (no mongoose casting in between)
-    // and its explain() is typed, unlike Query.explain().
-    const deleteExplain = await PageLink.collection
+    // the raw collection: it plans the literal filter (no ORM casting in between) and
+    // its explain() is typed, unlike Query.explain().
+    const deleteExplain = await rawPagelinksCollection()
       .find({
         fromPage: editedPage,
         toPath: { $nin: [`${PREFIX}/hub`] },

--- a/apps/app/src/features/backlinks/server/services/page-link-service-handlers.integ.ts
+++ b/apps/app/src/features/backlinks/server/services/page-link-service-handlers.integ.ts
@@ -1,11 +1,18 @@
-import { Types } from 'mongoose';
+import mongoose, { Types } from 'mongoose';
 
 import type { PageModel } from '~/server/models/page';
 import PageModelFactory from '~/server/models/page';
 import { prisma } from '~/utils/prisma';
 
-import PageLink from '../models/page-link';
+import { ensurePageLinkIndexes } from '../models/page-link-indexes';
 import { handlePageUpsertById } from './page-link-service-handlers';
+
+// pagelinks is prisma-only, and the harness skips migrations on the in-memory MongoDB.
+beforeAll(async () => {
+  const db = mongoose.connection.db;
+  if (db == null) throw new Error('no mongoose connection');
+  await ensurePageLinkIndexes(db);
+});
 
 // resolveToPageIds has its own coverage (target-page-resolution.spec.ts); mock it so this test
 // isolates the handler's contract against the real PageLink collection.
@@ -24,7 +31,7 @@ describe('handlePageUpsertById (integration)', () => {
   const siteUrl = 'https://wiki.example';
   const idByPath = new Map<string, Types.ObjectId>();
   const createdPageIds: Types.ObjectId[] = [];
-  const createdLinkIds: Types.ObjectId[] = [];
+  const createdLinkIds: string[] = [];
 
   let Page: PageModel;
 
@@ -35,11 +42,13 @@ describe('handlePageUpsertById (integration)', () => {
   });
 
   afterEach(async () => {
-    await PageLink.deleteMany({
-      $or: [
-        { fromPage: { $in: createdPageIds } },
-        { _id: { $in: createdLinkIds } },
-      ],
+    await prisma.pagelinks.deleteMany({
+      where: {
+        OR: [
+          { fromPageId: { in: createdPageIds.map((id) => id.toString()) } },
+          { id: { in: createdLinkIds } },
+        ],
+      },
     });
     await Page.deleteMany({ _id: { $in: createdPageIds } });
     await prisma.revisions.deleteMany({
@@ -89,10 +98,11 @@ describe('handlePageUpsertById (integration)', () => {
   };
 
   const outboundRowsOf = (pageId: Types.ObjectId) =>
-    PageLink.find({ fromPage: pageId })
-      .select('toPath toPage -_id')
-      .sort({ toPath: 1 })
-      .lean();
+    prisma.pagelinks.findMany({
+      where: { fromPageId: pageId.toString() },
+      select: { toPath: true, toPageId: true },
+      orderBy: { toPath: 'asc' },
+    });
 
   // Stands in for a row some other, unrelated page already owns because it linked to this
   // path before (or instead of) the page under test existing there.
@@ -101,15 +111,22 @@ describe('handlePageUpsertById (integration)', () => {
     toPath: string,
     toPage: Types.ObjectId | null,
   ): Promise<void> => {
-    const link = await PageLink.create({ fromPage, toPath, toPage });
-    createdLinkIds.push(link._id);
+    const link = await prisma.pagelinks.create({
+      data: {
+        fromPageId: fromPage.toString(),
+        toPath,
+        toPageId: toPage?.toString() ?? null,
+      },
+    });
+    createdLinkIds.push(link.id);
   };
 
   const inboundRowsAt = (toPath: string) =>
-    PageLink.find({ toPath })
-      .select('fromPage toPage -_id')
-      .sort({ fromPage: 1 })
-      .lean();
+    prisma.pagelinks.findMany({
+      where: { toPath },
+      select: { fromPageId: true, toPageId: true },
+      orderBy: { fromPageId: 'asc' },
+    });
 
   it('records internal links from path links and same-wiki absolute URLs', async () => {
     const docsId = new Types.ObjectId();
@@ -125,8 +142,8 @@ describe('handlePageUpsertById (integration)', () => {
     await handlePageUpsertById(pageId.toString(), siteUrl);
 
     expect(await outboundRowsOf(pageId)).toEqual([
-      { toPath: '/company/deals', toPage: dealsId },
-      { toPath: '/docs/target', toPage: docsId },
+      { toPath: '/company/deals', toPageId: dealsId.toString() },
+      { toPath: '/docs/target', toPageId: docsId.toString() },
     ]);
   });
 
@@ -144,7 +161,7 @@ describe('handlePageUpsertById (integration)', () => {
     // The different-host URL is dropped: the full-set assertion fails if it is
     // recorded at all, with either an id or a null target.
     expect(await outboundRowsOf(pageId)).toEqual([
-      { toPath: '/company/deals', toPage: dealsId },
+      { toPath: '/company/deals', toPageId: dealsId.toString() },
     ]);
   });
 
@@ -160,7 +177,7 @@ describe('handlePageUpsertById (integration)', () => {
     await handlePageUpsertById(pageId.toString(), siteUrl);
 
     expect(await outboundRowsOf(pageId)).toEqual([
-      { toPath: '/other', toPage: otherId },
+      { toPath: '/other', toPageId: otherId.toString() },
     ]);
   });
 
@@ -176,7 +193,7 @@ describe('handlePageUpsertById (integration)', () => {
     await handlePageUpsertById(pageId.toString(), siteUrl);
 
     expect(await outboundRowsOf(pageId)).toEqual([
-      { toPath: '/b', toPage: bId },
+      { toPath: '/b', toPageId: bId.toString() },
     ]);
   });
 
@@ -194,8 +211,8 @@ describe('handlePageUpsertById (integration)', () => {
     await handlePageUpsertById(pageId.toString(), siteUrl);
 
     expect(await outboundRowsOf(pageId)).toEqual([
-      { toPath: '/a', toPage: aId },
-      { toPath: '/c', toPage: cId },
+      { toPath: '/a', toPageId: aId.toString() },
+      { toPath: '/c', toPageId: cId.toString() },
     ]);
   });
 
@@ -238,7 +255,11 @@ describe('handlePageUpsertById (integration)', () => {
     const extractionMs = await handlePageUpsertById(goneId.toString(), siteUrl);
 
     // A stale queue entry for a deleted source must not leave orphan rows behind.
-    expect(await PageLink.find({ fromPage: goneId }).lean()).toEqual([]);
+    expect(
+      await prisma.pagelinks.findMany({
+        where: { fromPageId: goneId.toString() },
+      }),
+    ).toEqual([]);
     // Nothing extracted, so no rest is owed.
     expect(extractionMs).toBe(0);
   });
@@ -272,7 +293,7 @@ describe('handlePageUpsertById (integration)', () => {
     await handlePageUpsertById(pageId.toString(), siteUrl);
 
     expect(await outboundRowsOf(pageId)).toEqual([
-      { toPath: '/a', toPage: targetId },
+      { toPath: '/a', toPageId: targetId.toString() },
     ]);
   });
 
@@ -290,7 +311,7 @@ describe('handlePageUpsertById (integration)', () => {
     await handlePageUpsertById(pageId.toString(), siteUrl);
 
     expect(await inboundRowsAt(targetPath)).toEqual([
-      { fromPage: inboundSource, toPage: pageId },
+      { fromPageId: inboundSource.toString(), toPageId: pageId.toString() },
     ]);
   });
 
@@ -306,7 +327,7 @@ describe('handlePageUpsertById (integration)', () => {
     await handlePageUpsertById(pageId.toString(), siteUrl);
 
     expect(await inboundRowsAt(targetPath)).toEqual([
-      { fromPage: inboundSource, toPage: pageId },
+      { fromPageId: inboundSource.toString(), toPageId: pageId.toString() },
     ]);
   });
 
@@ -320,7 +341,10 @@ describe('handlePageUpsertById (integration)', () => {
     await handlePageUpsertById(pageId.toString(), siteUrl);
 
     expect(await inboundRowsAt(unrelatedPath)).toEqual([
-      { fromPage: inboundSource, toPage: unrelatedTarget },
+      {
+        fromPageId: inboundSource.toString(),
+        toPageId: unrelatedTarget.toString(),
+      },
     ]);
   });
 });

--- a/apps/app/src/features/backlinks/server/services/page-link-service.integ.ts
+++ b/apps/app/src/features/backlinks/server/services/page-link-service.integ.ts
@@ -8,9 +8,17 @@ import type Crowi from '~/server/crowi';
 import type { PageDocument, PageModel } from '~/server/models/page';
 import UserGroup from '~/server/models/user-group';
 import UserGroupRelation from '~/server/models/user-group-relation';
+import { prisma } from '~/utils/prisma';
 
-import PageLink from '../models/page-link';
+import { ensurePageLinkIndexes } from '../models/page-link-indexes';
 import { PageLinkService } from './page-link-service';
+
+// pagelinks is prisma-only, and the harness skips migrations on the in-memory MongoDB.
+beforeAll(async () => {
+  const db = mongoose.connection.db;
+  if (db == null) throw new Error('no mongoose connection');
+  await ensurePageLinkIndexes(db);
+});
 
 /*
  * B1.7 — findBacklinks: permission-filtered backlinks read.
@@ -73,13 +81,15 @@ describe('PageLinkService.findBacklinks (integration)', () => {
     });
 
   const linkTo = (
-    source: PageDocument,
-    target: PageDocument,
+    source: HydratedDocument<PageDocument>,
+    target: HydratedDocument<PageDocument>,
   ): Promise<unknown> =>
-    PageLink.create({
-      fromPage: source._id,
-      toPath: target.path,
-      toPage: target._id,
+    prisma.pagelinks.create({
+      data: {
+        fromPageId: source._id.toString(),
+        toPath: target.path,
+        toPageId: target._id.toString(),
+      },
     });
 
   // --- lifecycle ---------------------------------------------------------
@@ -133,7 +143,9 @@ describe('PageLinkService.findBacklinks (integration)', () => {
       path: new RegExp(`^${PREFIX}/`),
     }).select('_id');
     const ids = pages.map((p) => p._id);
-    await PageLink.deleteMany({ fromPage: { $in: ids } });
+    await prisma.pagelinks.deleteMany({
+      where: { fromPageId: { in: ids.map((id) => id.toString()) } },
+    });
     await Page.deleteMany({ path: new RegExp(`^${PREFIX}/`) });
   });
 

--- a/apps/app/src/features/backlinks/server/services/page-link-sync.integ.ts
+++ b/apps/app/src/features/backlinks/server/services/page-link-sync.integ.ts
@@ -4,33 +4,46 @@ import mongoose, { Types } from 'mongoose';
 import type { PageDocument, PageModel } from '~/server/models/page';
 import PageModelFactory from '~/server/models/page';
 import PageRedirect from '~/server/models/page-redirect';
+import { prisma } from '~/utils/prisma';
 
 import type { IPageLink } from '../../interfaces/page-link';
-import PageLink from '../models/page-link';
+import { ensurePageLinkIndexes } from '../models/page-link-indexes';
 import { reResolveByToPath, syncOutboundLinks } from './page-link-sync';
+
+// pagelinks is prisma-only, and the harness skips migrations on the in-memory MongoDB,
+// so the unique index the idempotency assertions rely on has to be applied here.
+beforeAll(async () => {
+  const db = mongoose.connection.db;
+  if (db == null) throw new Error('no mongoose connection');
+  await ensurePageLinkIndexes(db);
+});
 
 describe('syncOutboundLinks (integration)', () => {
   const fromPage = new Types.ObjectId();
 
   beforeEach(async () => {
-    await PageLink.deleteMany({ fromPage });
+    await prisma.pagelinks.deleteMany({
+      where: { fromPageId: fromPage.toString() },
+    });
   });
 
   // Fetch this page's outbound rows in a stable, comparable shape.
   const outboundRows = () =>
-    PageLink.find({ fromPage })
-      .select('toPath toPage -_id')
-      .sort({ toPath: 1 })
-      .lean();
+    prisma.pagelinks.findMany({
+      where: { fromPageId: fromPage.toString() },
+      select: { toPath: true, toPageId: true },
+      orderBy: { toPath: 'asc' },
+    });
 
-  // Capture the persisted _id per toPath so churn (delete + re-insert) can be
-  // detected: an in-place update keeps the same _id, a re-insert changes it.
+  // Capture the persisted id per toPath so churn (delete + re-insert) can be
+  // detected: an in-place update keeps the same id, a re-insert changes it.
   const outboundIds = async () => {
-    const rows = await PageLink.find({ fromPage })
-      .select('toPath')
-      .sort({ toPath: 1 })
-      .lean();
-    return rows.map((row) => ({ toPath: row.toPath, id: row._id.toString() }));
+    const rows = await prisma.pagelinks.findMany({
+      where: { fromPageId: fromPage.toString() },
+      select: { toPath: true, id: true },
+      orderBy: { toPath: 'asc' },
+    });
+    return rows.map((row) => ({ toPath: row.toPath, id: row.id }));
   };
 
   it('is idempotent — running twice with the same set yields identical rows', async () => {
@@ -43,8 +56,8 @@ describe('syncOutboundLinks (integration)', () => {
     // Absolute expectation: the resolved target id is cached in toPage, and the
     // broken row is stored with a null target.
     const expected = [
-      { toPath: '/a', toPage: targetA },
-      { toPath: '/missing', toPage: null },
+      { toPath: '/a', toPageId: targetA.toString() },
+      { toPath: '/missing', toPageId: null },
     ];
 
     await syncOutboundLinks(fromPage, rows);
@@ -60,7 +73,7 @@ describe('syncOutboundLinks (integration)', () => {
     // ...and the second run changes nothing: no duplicate insert on the
     // { fromPage, toPath } upsert filter.
     expect(afterSecond).toEqual(expected);
-    // Every row keeps its original _id across runs, proving the rows are
+    // Every row keeps its original id across runs, proving the rows are
     // updated in place — no deletion+reinsert churn.
     expect(idsAfterSecond).toEqual(idsAfterFirst);
   });
@@ -84,8 +97,8 @@ describe('syncOutboundLinks (integration)', () => {
     const rows = await outboundRows();
     // Assert full rows: /a keeps its original target, /c is added, /b is gone.
     expect(rows).toEqual([
-      { toPath: '/a', toPage: targetA },
-      { toPath: '/c', toPage: targetC },
+      { toPath: '/a', toPageId: targetA.toString() },
+      { toPath: '/c', toPageId: targetC.toString() },
     ]);
   });
 
@@ -100,7 +113,7 @@ describe('syncOutboundLinks (integration)', () => {
 
     const rows = await outboundRows();
     // Only the non-self link survives, with its target cached.
-    expect(rows).toEqual([{ toPath: '/other', toPage: other }]);
+    expect(rows).toEqual([{ toPath: '/other', toPageId: other.toString() }]);
   });
 
   it('clears all outbound rows when the page has no links left', async () => {
@@ -119,7 +132,7 @@ describe('syncOutboundLinks (integration)', () => {
 describe('reResolveByToPath (integration)', () => {
   let Page: PageModel;
   let createdPages: Types.ObjectId[] = [];
-  let createdLinks: Types.ObjectId[] = [];
+  let createdLinks: string[] = [];
   let createdRedirects: Types.ObjectId[] = [];
 
   beforeAll(async () => {
@@ -129,7 +142,7 @@ describe('reResolveByToPath (integration)', () => {
 
   afterEach(async () => {
     await Page.deleteMany({ _id: { $in: createdPages } });
-    await PageLink.deleteMany({ _id: { $in: createdLinks } });
+    await prisma.pagelinks.deleteMany({ where: { id: { in: createdLinks } } });
     await PageRedirect.deleteMany({ _id: { $in: createdRedirects } });
     createdPages = [];
     createdLinks = [];
@@ -145,8 +158,14 @@ describe('reResolveByToPath (integration)', () => {
   };
 
   const createLink = async (row: IPageLink): Promise<void> => {
-    const link = await PageLink.create(row);
-    createdLinks.push(link._id);
+    const link = await prisma.pagelinks.create({
+      data: {
+        fromPageId: row.fromPage.toString(),
+        toPath: row.toPath,
+        toPageId: row.toPage?.toString() ?? null,
+      },
+    });
+    createdLinks.push(link.id);
   };
 
   /** Stands in for what a rename with "create redirect page" leaves behind. */
@@ -160,10 +179,11 @@ describe('reResolveByToPath (integration)', () => {
 
   // Whole row set, so a dropped or extra row fails too — not just a wrong target.
   const inboundRows = (toPath: string) =>
-    PageLink.find({ toPath })
-      .select('fromPage toPage -_id')
-      .sort({ fromPage: 1 })
-      .lean();
+    prisma.pagelinks.findMany({
+      where: { toPath },
+      select: { fromPageId: true, toPageId: true },
+      orderBy: { fromPageId: 'asc' },
+    });
 
   it('repoints a stale cache at the page that now occupies the path', async () => {
     const source = new Types.ObjectId();
@@ -178,7 +198,7 @@ describe('reResolveByToPath (integration)', () => {
     await reResolveByToPath('/re-resolve-integ/reused');
 
     expect(await inboundRows('/re-resolve-integ/reused')).toEqual([
-      { fromPage: source, toPage: occupant._id },
+      { fromPageId: source.toString(), toPageId: occupant._id.toString() },
     ]);
   });
 
@@ -194,7 +214,7 @@ describe('reResolveByToPath (integration)', () => {
     await reResolveByToPath('/re-resolve-integ/created-later');
 
     expect(await inboundRows('/re-resolve-integ/created-later')).toEqual([
-      { fromPage: source, toPage: page._id },
+      { fromPageId: source.toString(), toPageId: page._id.toString() },
     ]);
   });
 
@@ -209,7 +229,7 @@ describe('reResolveByToPath (integration)', () => {
     await reResolveByToPath('/re-resolve-integ/vanished');
 
     expect(await inboundRows('/re-resolve-integ/vanished')).toEqual([
-      { fromPage: source, toPage: null },
+      { fromPageId: source.toString(), toPageId: null },
     ]);
   });
 
@@ -240,12 +260,12 @@ describe('reResolveByToPath (integration)', () => {
     expect(rows).toHaveLength(2);
     expect(rows).toEqual(
       expect.arrayContaining([
-        { fromPage: sourceA, toPage: page._id },
-        { fromPage: sourceB, toPage: page._id },
+        { fromPageId: sourceA.toString(), toPageId: page._id.toString() },
+        { fromPageId: sourceB.toString(), toPageId: page._id.toString() },
       ]),
     );
     expect(await inboundRows('/re-resolve-integ/unrelated')).toEqual([
-      { fromPage: sourceA, toPage: untouchedTarget },
+      { fromPageId: sourceA.toString(), toPageId: untouchedTarget.toString() },
     ]);
   });
 
@@ -265,7 +285,7 @@ describe('reResolveByToPath (integration)', () => {
     await reResolveByToPath('/re-resolve-integ/old-name');
 
     expect(await inboundRows('/re-resolve-integ/old-name')).toEqual([
-      { fromPage: source, toPage: page._id },
+      { fromPageId: source.toString(), toPageId: page._id.toString() },
     ]);
   });
 
@@ -290,7 +310,7 @@ describe('reResolveByToPath (integration)', () => {
     await reResolveByToPath('/re-resolve-integ/redir-mid');
 
     expect(await inboundRows('/re-resolve-integ/redir-a')).toEqual([
-      { fromPage: source, toPage: newOccupant._id },
+      { fromPageId: source.toString(), toPageId: newOccupant._id.toString() },
     ]);
   });
 
@@ -331,35 +351,45 @@ describe('reResolveByToPath (integration)', () => {
     expect(rows).toEqual(
       expect.arrayContaining([
         // no self-backlink, and no stale target left behind
-        { fromPage: source._id, toPage: null },
+        { fromPageId: source._id.toString(), toPageId: null },
         // ...without holding back the rest of the path
-        { fromPage: otherSource, toPage: source._id },
+        { fromPageId: otherSource.toString(), toPageId: source._id.toString() },
       ]),
     );
     expect(await inboundRows('/re-resolve-integ/self-elsewhere')).toEqual([
-      { fromPage: source._id, toPage: unrelatedTarget },
+      {
+        fromPageId: source._id.toString(),
+        toPageId: unrelatedTarget.toString(),
+      },
     ]);
   });
 });
 
-describe('PageLink.repointInboundLinks (integration)', () => {
-  let createdLinks: Types.ObjectId[] = [];
+describe('prisma.pagelinks.repointInboundLinks (integration)', () => {
+  let createdLinks: string[] = [];
 
   afterEach(async () => {
-    await PageLink.deleteMany({ _id: { $in: createdLinks } });
+    await prisma.pagelinks.deleteMany({ where: { id: { in: createdLinks } } });
     createdLinks = [];
   });
 
   const createLink = async (row: IPageLink): Promise<void> => {
-    const link = await PageLink.create(row);
-    createdLinks.push(link._id);
+    const link = await prisma.pagelinks.create({
+      data: {
+        fromPageId: row.fromPage.toString(),
+        toPath: row.toPath,
+        toPageId: row.toPage?.toString() ?? null,
+      },
+    });
+    createdLinks.push(link.id);
   };
 
   const inboundRows = (toPath: string) =>
-    PageLink.find({ toPath })
-      .select('fromPage toPage -_id')
-      .sort({ fromPage: 1 })
-      .lean();
+    prisma.pagelinks.findMany({
+      where: { toPath },
+      select: { fromPageId: true, toPageId: true },
+      orderBy: { fromPageId: 'asc' },
+    });
 
   // A row at an unrelated path: its survival is what proves nothing was written.
   const seedBystander = async (): Promise<{
@@ -389,12 +419,12 @@ describe('PageLink.repointInboundLinks (integration)', () => {
 
     // Matched on the message: for the two inputs mongoose would ignore anyway,
     // this is the only assertion that tells the guard from an unrelated failure.
-    await expect(PageLink.repointInboundLinks(badToPath, null)).rejects.toThrow(
-      /non-empty path string/,
-    );
+    await expect(
+      prisma.pagelinks.repointInboundLinks(badToPath, null),
+    ).rejects.toThrow(/non-empty path string/);
 
     expect(await inboundRows('/repoint-guard/bystander')).toEqual([
-      { fromPage: source, toPage: target },
+      { fromPageId: source.toString(), toPageId: target.toString() },
     ]);
   });
 
@@ -404,13 +434,13 @@ describe('PageLink.repointInboundLinks (integration)', () => {
     // Unguarded this is written, not rejected: the update is a pipeline, which
     // mongoose does not cast, so the expression is evaluated into the column.
     await expect(
-      PageLink.repointInboundLinks('/repoint-guard/bystander', {
+      prisma.pagelinks.repointInboundLinks('/repoint-guard/bystander', {
         $literal: 'pwned',
       } as unknown as Types.ObjectId),
     ).rejects.toThrow(/ObjectId or null/);
 
     expect(await inboundRows('/repoint-guard/bystander')).toEqual([
-      { fromPage: source, toPage: target },
+      { fromPageId: source.toString(), toPageId: target.toString() },
     ]);
   });
 });

--- a/apps/app/src/features/backlinks/server/services/page-link-sync.spec.ts
+++ b/apps/app/src/features/backlinks/server/services/page-link-sync.spec.ts
@@ -1,10 +1,10 @@
 import { Types } from 'mongoose';
+import { mockDeep } from 'vitest-mock-extended';
 
 import PageRedirect from '~/server/models/page-redirect';
+import type { PrismaClient } from '~/utils/prisma';
 
 import type { IPageLink } from '../../interfaces/page-link';
-// vi.mock is hoisted above these imports, so PageLink is the mocked default export.
-import PageLink from '../models/page-link';
 import {
   dropSelfLinks,
   reResolveByToPath,
@@ -12,10 +12,11 @@ import {
 } from './page-link-sync';
 import { resolveToPageIds } from './target-page-resolution';
 
-vi.mock('../models/page-link', () => ({
-  default: {
-    replaceOutboundLinks: vi.fn(),
-    repointInboundLinks: vi.fn(),
+const mockPrisma = mockDeep<PrismaClient>();
+
+vi.mock('~/utils/prisma', () => ({
+  get prisma() {
+    return mockPrisma;
   },
 }));
 
@@ -113,11 +114,11 @@ describe('syncOutboundLinks', () => {
 
     await syncOutboundLinks(fromPageId, [other, self, broken]);
 
-    expect(PageLink.replaceOutboundLinks).toHaveBeenCalledTimes(1);
-    expect(PageLink.replaceOutboundLinks).toHaveBeenCalledWith(fromPageId, [
-      other,
-      broken,
-    ]);
+    expect(mockPrisma.pagelinks.replaceOutboundLinks).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.pagelinks.replaceOutboundLinks).toHaveBeenCalledWith(
+      fromPageId,
+      [other, broken],
+    );
   });
 
   it('still calls replaceOutboundLinks with [] when every row is a self-link (clears stale rows)', async () => {
@@ -126,7 +127,10 @@ describe('syncOutboundLinks', () => {
 
     await syncOutboundLinks(fromPageId, [self]);
 
-    expect(PageLink.replaceOutboundLinks).toHaveBeenCalledWith(fromPageId, []);
+    expect(mockPrisma.pagelinks.replaceOutboundLinks).toHaveBeenCalledWith(
+      fromPageId,
+      [],
+    );
   });
 });
 
@@ -153,8 +157,8 @@ describe('reResolveByToPath', () => {
     // Pin the path handed to the resolver: without this, resolving the wrong
     // path still reads '/target' out of the stubbed map and passes.
     expect(resolveToPageIds).toHaveBeenCalledWith(['/target']);
-    expect(PageLink.repointInboundLinks).toHaveBeenCalledTimes(1);
-    expect(PageLink.repointInboundLinks).toHaveBeenCalledWith(
+    expect(mockPrisma.pagelinks.repointInboundLinks).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.pagelinks.repointInboundLinks).toHaveBeenCalledWith(
       '/target',
       occupant,
     );
@@ -168,7 +172,10 @@ describe('reResolveByToPath', () => {
     await reResolveByToPath('/target');
 
     expect(resolveToPageIds).toHaveBeenCalledWith(['/target']);
-    expect(PageLink.repointInboundLinks).toHaveBeenCalledWith('/target', null);
+    expect(mockPrisma.pagelinks.repointInboundLinks).toHaveBeenCalledWith(
+      '/target',
+      null,
+    );
   });
 
   it('resolves and writes the paths that redirect here, not just the path itself', async () => {
@@ -195,13 +202,16 @@ describe('reResolveByToPath', () => {
       '/old',
       '/older',
     ]);
-    expect(PageLink.repointInboundLinks).toHaveBeenCalledTimes(3);
-    expect(PageLink.repointInboundLinks).toHaveBeenCalledWith(
+    expect(mockPrisma.pagelinks.repointInboundLinks).toHaveBeenCalledTimes(3);
+    expect(mockPrisma.pagelinks.repointInboundLinks).toHaveBeenCalledWith(
       '/target',
       occupant,
     );
-    expect(PageLink.repointInboundLinks).toHaveBeenCalledWith('/old', occupant);
-    expect(PageLink.repointInboundLinks).toHaveBeenCalledWith(
+    expect(mockPrisma.pagelinks.repointInboundLinks).toHaveBeenCalledWith(
+      '/old',
+      occupant,
+    );
+    expect(mockPrisma.pagelinks.repointInboundLinks).toHaveBeenCalledWith(
       '/older',
       elsewhere,
     );

--- a/apps/app/src/features/backlinks/server/services/page-link-sync.ts
+++ b/apps/app/src/features/backlinks/server/services/page-link-sync.ts
@@ -1,9 +1,9 @@
 import type { Types } from 'mongoose';
 
 import PageRedirect from '~/server/models/page-redirect';
+import { prisma } from '~/utils/prisma';
 
 import type { IPageLink } from '../../interfaces/page-link';
-import PageLink from '../models/page-link';
 import {
   REDIRECT_CHAIN_MAX_DEPTH,
   resolveToPageIds,
@@ -30,7 +30,7 @@ export const syncOutboundLinks = async (
 ): Promise<void> => {
   const linksExceptSelf = dropSelfLinks(fromPageId, resolvedRows);
 
-  await PageLink.replaceOutboundLinks(fromPageId, linksExceptSelf);
+  await prisma.pagelinks.replaceOutboundLinks(fromPageId, linksExceptSelf);
 };
 
 /**
@@ -61,7 +61,7 @@ export const reResolveByToPath = async (toPath: string): Promise<void> => {
 
   await Promise.all(
     paths.map((path) =>
-      PageLink.repointInboundLinks(path, resolved.get(path) ?? null),
+      prisma.pagelinks.repointInboundLinks(path, resolved.get(path) ?? null),
     ),
   );
 };

--- a/apps/app/src/migrations/20260901064500-add-indexes-to-pagelinks.js
+++ b/apps/app/src/migrations/20260901064500-add-indexes-to-pagelinks.js
@@ -1,0 +1,77 @@
+import mongoose from 'mongoose';
+
+import { getMongoUri, mongoOptions } from '~/server/util/mongoose-utils';
+import loggerFactory from '~/utils/logger';
+
+const logger = loggerFactory('growi:migrate:add-indexes-to-pagelinks');
+
+const COLLECTION_NAME = 'pagelinks';
+
+/**
+ * `pagelinks` is a prisma-only collection (no mongoose model, no `prisma db push` in
+ * deploy), so its indexes must be provisioned here — schema.prisma's @@index/@@unique
+ * declarations describe them but create nothing.
+ *
+ * - fromPage_1_toPath_1 is the correctness-critical one: replaceOutboundLinks upserts
+ *   against that filter, and without the unique constraint concurrent replaces of the
+ *   same source page can insert duplicate rows, surfacing as duplicated backlinks.
+ *   It also serves every fromPage-only lookup (fromPage is the prefix), so a standalone
+ *   fromPage index would be dead weight.
+ * - toPage_1 is what findBacklinkSources' distinct rides.
+ * - toPath_1 serves repointInboundLinks, which filters on toPath alone (the compound
+ *   above cannot serve it — wrong prefix).
+ *
+ * Names match MongoDB's own `<field>_<direction>` convention so they line up with the
+ * `map:` values in schema.prisma, and with whatever `prisma db push` would create once
+ * the migration off mongoose completes repo-wide.
+ */
+const INDEXES = [
+  { key: { fromPage: 1, toPath: 1 }, options: { unique: true } },
+  { key: { toPage: 1 }, options: {} },
+  { key: { toPath: 1 }, options: {} },
+];
+
+const indexNameOf = (key) =>
+  Object.entries(key)
+    .map(([field, direction]) => `${field}_${direction}`)
+    .join('_');
+
+export async function up() {
+  logger.info('Apply migration');
+
+  await mongoose.connect(getMongoUri(), mongoOptions);
+  const collection = mongoose.connection.collection(COLLECTION_NAME);
+
+  // No dedupe pass before the unique build (unlike the auditlog migration, which
+  // retrofitted a constraint onto pre-existing data): this collection has been under the
+  // same unique index since it was introduced, and the feature that writes it has not
+  // shipped, so no database can hold a duplicate for it to trip over.
+  // createIndex creates the collection if absent and is a no-op when the identical index
+  // already exists, so this is safe whether or not it was provisioned elsewhere.
+  await Promise.all(
+    INDEXES.map(({ key, options }) => collection.createIndex(key, options)),
+  );
+}
+
+export async function down(db) {
+  logger.info('Rollback migration');
+
+  await mongoose.connect(getMongoUri(), mongoOptions);
+
+  const items = await db
+    .listCollections({ name: COLLECTION_NAME }, { nameOnly: true })
+    .toArray();
+  if (items.length === 0) {
+    return;
+  }
+
+  const collection = db.collection(COLLECTION_NAME);
+  await Promise.all(
+    INDEXES.map(async ({ key }) => {
+      const name = indexNameOf(key);
+      if (await collection.indexExists(name)) {
+        await collection.dropIndex(name);
+      }
+    }),
+  );
+}

--- a/apps/app/src/server/service/import/non-transferable-collections.ts
+++ b/apps/app/src/server/service/import/non-transferable-collections.ts
@@ -23,6 +23,13 @@
  *   documents alone are enough for the destination to restore the operator's plugins.
  * - `attachments` — attachment metadata is content and is transferred; only the payload
  *   collections below are excluded.
+ * - `pagelinks` — the backlink index. It is a cache derived from page bodies, so it looks
+ *   like a rebuildable artifact, but it is derived from content the transfer itself
+ *   carries and holds nothing but page references, which the transfer preserves — so the
+ *   rows stay valid at the destination, exactly as `pagetagrelations` does. Unlike
+ *   `yjs-writings` it does not regenerate on its own: rows are only rewritten when a page
+ *   is next saved, so skipping it would leave backlinks silently empty until every page
+ *   had been edited.
  */
 export const NON_TRANSFERABLE_COLLECTIONS: ReadonlySet<string> = new Set([
   // The key this very transfer authenticates with, plus the record of which migration
@@ -104,6 +111,7 @@ export const TRANSFERABLE_COLLECTIONS: ReadonlySet<string> = new Set([
   'namedqueries',
   'newsitems',
   'newsreadstatuses',
+  'pagelinks',
   'pageredirects',
   'pages',
   'pagetagrelations',

--- a/apps/app/src/utils/prisma.ts
+++ b/apps/app/src/utils/prisma.ts
@@ -1,3 +1,4 @@
+import { extension as PageLinkExtension } from '~/features/backlinks/server/models/page-link';
 import { extension as CommentExtension } from '~/features/comment/server';
 import { extension as MastraRefreshedModelCatalogExtension } from '~/features/mastra/server/models/refreshed-model-catalog';
 import {
@@ -218,6 +219,7 @@ export const createPrisma = (datasourceUrl?: string) =>
     .$extends(CommentExtension)
     .$extends(ExternalAccountExtension)
     .$extends(MastraRefreshedModelCatalogExtension)
+    .$extends(PageLinkExtension)
     .$extends(RevisionExtension)
     .$extends(UserExtension)
     // TagExtension must precede PageTagRelationExtension: the latter calls


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/185823
┗ https://redmine.weseek.co.jp/issues/188157

Moves `PageLink` off Mongoose: the three statics become a `Prisma.defineExtension`, and the mongoose schema is removed rather than kept for index creation.

## Changes

| | |
|---|---|
| `schema.prisma` | new `pagelinks` model + named back-relations on `pages` |
| `page-link.ts` | mongoose schema/statics/default-export gone; Prisma extension only |
| `interfaces/page-link.ts` | `PageLinkDocument` / `PageLinkModel` dropped; `IPageLink` stays |
| `migrations/20260901064500-…` | **new** — provisions the three indexes |
| `page-link-indexes.ts` | **new** — index declaration + test-side `ensurePageLinkIndexes` |
| `find-backlinks.ts`, `page-link-sync.ts` | call `prisma.pagelinks.*` |
| `utils/prisma.ts` | wires `PageLinkExtension` |
| 6 test files | migrated to Prisma-backed fixtures/assertions |

No API or behaviour change — `findBacklinkSources` still returns `Types.ObjectId[]`, and no route response shape moved.

## Notable, beyond the mechanical port

**`findBacklinkSources` uses MongoDB's native `distinct`, not Prisma's `findMany({ distinct })`.** Prisma dedupes in the query engine, so it streams a whole document per inbound link to the client first. Measured on 220k rows with a 20,000-inbound hub: **112.4 ms → 46.0 ms (2.4x)**, identical results. Both ride `toPage_1`.

**Indexes come from a migration, not `prisma db push`.** Nothing in this repo runs `db push`, so `schema.prisma`'s `@@index` / `@@unique` declarations describe indexes but create none — same situation as `auditlog_es_sync_status` / `changestream_resume_tokens`. `fromPage_1_toPath_1` is a correctness constraint rather than tuning: `replaceOutboundLinks` upserts against that filter, so without it concurrent replaces of one source page can insert duplicates.

**The perf test now explains the command production really issues**, captured off the database profiler, instead of a hand-written copy. The old copy had silently stopped tracking the real query the moment `findBacklinkSources` changed — exactly the drift its own comment claimed to prevent. Same technique restores the write-scoping assertion that the removed `bulkWrite` spy used to provide. Its recorded baselines are re-measured (100k pages / 5,000-inbound hub: **median 29 ms**; 20,000 inbound: **120 ms**), both plans `FETCH <- IXSCAN`.

## Verification

`pnpm run lint` (2459 files) · `build:server` incl. declaration emit (2479 specifiers, 0 unresolved) · 54/54 tests · gated perf suite 4/4 against a **dropped** database, so the migration provisioned from scratch:

```
MIGRATED UP: 20260901064500-add-indexes-to-pagelinks.js
[B2.1] pagelinks indexes: _id_, fromPage_1_toPath_1, toPage_1, toPath_1
```

Unique constraint verified as *enforced*, not merely present (duplicate `{fromPage, toPath}` insert rejected).

See the comment below on the schema-shape decision — that's the part most worth a second opinion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)