### PR TITLE
ci: Skip changeset check for master-headed PRs

### DIFF
--- a/.github/workflows/check-changesets.yml
+++ b/.github/workflows/check-changesets.yml
@@ -36,6 +36,17 @@ jobs:
         pnpm install --frozen-lockfile
 
     - name: Reject changesets that can never be consumed
+      # Skip when the PR's source branch is master itself (e.g. a release-promotion PR
+      # such as master -> release/current or master -> release/8.0.x). `changeset status`
+      # only sees changesets that are still present as files, and every changeset for
+      # content already on master has necessarily been consumed (deleted) by the "Version
+      # Packages" run that shipped it. So diffing a master-headed PR against its (often
+      # long-stale) release-branch base always finds changed packages with zero surviving
+      # changeset files, which is an unconditional false positive, not a real omission.
+      # This does assume every commit that reaches master went through this same check on
+      # its own feature PR; an admin merge that bypasses branch protection could still slip
+      # an un-changeset'd package change onto master undetected by this rule.
+      if: github.head_ref != 'master'
       run: |
         # A CI checkout is a detached HEAD with remote-tracking refs only, so the bare
         # branch name changesets uses by default (`git merge-base master HEAD`) does not


### PR DESCRIPTION
## Problem

`check-changesets` (`Reject changesets that can never be consumed` step) runs `pnpm changeset status --since="origin/${{ github.base_ref }}"`, which errors when non-ignored packages have content changes since that ref but zero `.changeset/*.md` files currently exist.

For a release-promotion PR whose head is `master` (e.g. `master -> release/current`, `master -> release/8.0.x`), the base branch is often behind master by one or more already-shipped release cycles. Every changeset covering those cycles was already consumed (deleted) by its own "Version Packages" run, so `.changeset/` is empty at promotion time while the diff still touches non-ignored packages. `changeset status` has no memory of already-consumed changesets — it only checks whether changeset *files* currently exist — so this fails unconditionally, with no correlation to whether a real changeset was actually skipped.

Reproduced on PR #11778 (`master -> release/current`): `check-changesets` fails with `Some packages have been changed but no changesets were found`, even though the flagged `@growi/core` change (`IPage.ttlTimestamp` -> `wipExpiredAt`, from #11513) already had a changeset that was already consumed (package.json bumped 2.5.0 -> 3.0.0 in a prior Version Packages commit). Confirmed locally: checked out `origin/master` in a worktree and re-ran the exact CI command, reproducing the same failure with `.changeset/` empty.

## Fix

Skip the "Reject changesets that can never be consumed" step when the PR's source branch is `master` itself:

```yaml
if: github.head_ref != 'master'
```

Rationale: content on `master` already passed this same check on its own feature PR before merging, so re-checking it against a stale downstream release/integration branch is redundant and structurally guaranteed to false-positive. This does **not** gate on `base_ref`, because GROWI's PR history includes ordinary `fix/*`/`imprv/*` PRs landing directly on `dev/*.x` integration branches (not just `master`) -- gating on base would silently skip the check for that whole class of PRs it exists to police. Gating on `head_ref == 'master'` instead correctly targets "the source branch is the vetted trunk," independent of which branch receives it.

## Known caveat

This assumes every commit that reaches `master` went through this check on its own feature PR. `master`'s branch protection does not currently enforce required status checks or restrict admin merges, so a commit that bypasses normal PR review could in theory land an un-changeset'd package change on `master` undetected by this rule, and it would then ride through any subsequent `master`-headed PR unexercised. This is not a regression from this change: today the check is unconditionally red (100% false positive) on every `master`-headed promotion PR, so it currently carries zero usable signal for this case either. Noted in a workflow comment rather than engineered around here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)