### PR TITLE
feat(backlinks): B5.1 delete-side link primitive, target-state derivation, and the B5 spec corrections

### DIFF
--- a/.kiro/specs/backlinks/design.md
+++ b/.kiro/specs/backlinks/design.md
@@ -14,8 +14,9 @@ before changing/renaming/deleting a page; spot their own broken outgoing links),
 feature introduces a new server-side directed **link graph** (`PageLink`), kept current through
 the existing page-lifecycle event bus and queried under the existing page-grant model. It adds
 storage, one service, one read endpoint, one panel, and a background backfill job; it changes no
-existing lifecycle, permission, or Markdown/wiki-link behavior. The `PageLink` indexes are created
-by Mongoose `autoIndex` at model registration (new collection — no migration needed).
+existing lifecycle, permission, or Markdown/wiki-link behavior. `pagelinks` is a **Prisma-only**
+collection, so its indexes are provisioned by a migrate-mongo index migration (there is no mongoose
+schema to build them on connect, and deploy never runs `prisma db push`).
 
 ### Goals
 
@@ -40,8 +41,9 @@ by Mongoose `autoIndex` at model registration (new collection — no migration n
     it is consistent with this non-goal.
 - A **blocking boot-time** backfill (a migrate-mongo data migration). Ruled out: it would take
   the wiki offline for the full backfill duration, which scales with page count and is
-  unacceptable for large instances. Index creation is not boot-blocking either — `autoIndex`
-  builds the indexes on a new, empty collection at model registration.
+  unacceptable for large instances. Index creation is not boot-blocking in practice either — the
+  index migration runs at boot but builds three indexes on a new, empty collection, which is
+  effectively instant; it is the *data* backfill that had to move off the boot path.
 - Indexing attachments or `/share/*` targets (only creatable GROWI pages are indexed).
 
 ## Boundary Commitments
@@ -56,8 +58,8 @@ by Mongoose `autoIndex` at model registration (new collection — no migration n
   following and direct `_id` resolution when `toPath` is a permalink.
 - Synchronization of `PageLink` rows in response to page-lifecycle events.
 - The one-time backfill: a background `CronService` job that populates rows for pre-existing pages
-  without taking the wiki offline. (The `PageLink` indexes themselves are created by `autoIndex`
-  at model registration, not by a migration.)
+  without taking the wiki offline. (The `pagelinks` indexes themselves come from the index
+  migration — cheap on an empty collection — not from this job.)
 - The read API + SWR hook + UI panel that present backlinks and forward-link health.
 
 ### Out of Boundary
@@ -178,7 +180,7 @@ graph TB
 | Frontend | React + SWR (existing) | Backlinks panel + data hook | New tab in `PageAccessoriesModal`; reuse `PageListItemS`/`PagePathLabel` |
 | Backend / Services | Express apiv3 + a new `PageLinkService` | Read endpoint + event listeners | Listener wired in `crowi` setup like `search.ts` |
 | Rendering | Existing unified remark/rehype plugins | Server-side link extraction | Node-compatible; trimmed processor (link plugins only) |
-| Data / Storage | MongoDB + Mongoose (existing) | `PageLink` collection + indexes | New model via `getOrCreateModel`; indexes built by `autoIndex` at model registration (new collection — no migration) |
+| Data / Storage | MongoDB via **Prisma** (`~/utils/prisma`) | `pagelinks` collection + indexes | Prisma-only collection: no mongoose schema, methods on a `Prisma.defineExtension` block; indexes provisioned by `migrations/20260901064500-add-indexes-to-pagelinks.js` (nothing runs `prisma db push`, so schema.prisma declares indexes but creates none) |
 | Messaging / Events | `crowi.events.page` (Node EventEmitter) | Sync triggers | Subscribe only |
 | Background job | `CronService` / node-cron (existing) | One-time backfill of pre-existing pages | Chunked + resumable + throttled; mirrors page-bulk-export job; admin Socket.IO progress |
 
@@ -193,10 +195,12 @@ not yet implemented and land with that story.
 apps/app/src/features/backlinks/
 ├── interfaces/
 │   ├── page-link.ts              # IPageLink + PageLinkDocument/PageLinkModel (statics declared as implemented)
-│   └── backlink.ts               # read DTOs: IBacklink, IBacklinkResponse (+ LinkTargetState B5.1, ILinkTarget B5.4)
+│   └── backlink.ts               # read DTOs: IBacklink, IBacklinkResponse (+ LinkTargetState B5.1, ILinkTarget B5.4, response.linkTargets B5.9)
 ├── server/
 │   ├── models/
-│   │   ├── page-link.ts          # Mongoose model (getOrCreateModel) + statics
+│   │   ├── page-link.ts          # Prisma extension (Prisma.defineExtension) — the pagelinks model methods
+│   │   ├── page-link-indexes.ts  # index declaration + ensurePageLinkIndexes (integ harness; production uses the migration)
+│   │   ├── throw-on-write-errors.ts    # $runCommandRaw replies carry writeErrors/writeConcernError inside ok:1 — throw on both
 │   │   └── page-link-backfill-job.ts   # (B3) Mongoose model: backfill progress marker + atomic claim (multi-instance)
 │   ├── services/
 │   │   ├── extract-internal-link-paths.ts  # pure: (markdown, pagePath, siteUrl?) => Promise<string[]> (resolved, deduped)
@@ -206,6 +210,8 @@ apps/app/src/features/backlinks/
 │   │   ├── page-link-upsert-queue.ts   # coalescing queue (Set<pageId> + duty-cycle paced drain) — requirement 3.5
 │   │   ├── upsert-queue-pacing.ts      # validates the configured pacing budget, per-value fallback to CONFIG_DEFINITIONS
 │   │   ├── find-backlinks.ts           # read query: backlink sources filtered by viewer grant
+│   │   ├── link-target-state.ts        # (B5.1) pure: (toPage, target status) => LinkTargetState
+│   │   ├── find-forward-link-health.ts # (B5.4) read query: a page's trashed/broken outbound targets, viewer-filtered
 │   │   ├── page-link-service.ts        # thin Crowi adapter: subscribes to crowi.events.page, owns config access, delegates
 │   │   └── page-link-backfill-cron.ts  # (B3) CronService: chunked, resumable, throttled backfill (in-memory path->id map)
 │   └── routes/
@@ -217,13 +223,19 @@ apps/app/src/features/backlinks/
         ├── BacklinksPanel.tsx          # incoming list + empty state (+ forward-health section — B5.6)
         └── BacklinkListItem.tsx        # one row (title + path + target-state badge — badge B5.5)
 
-# No migration file: PageLink indexes are created by Mongoose autoIndex at model
-# registration (new collection); the backfill is the cron job above.
+# Migration: apps/app/src/migrations/20260901064500-add-indexes-to-pagelinks.js provisions
+# the three pagelinks indexes. Required because pagelinks is a prisma-only collection — no
+# mongoose schema builds them on connect, and deploy never runs `prisma db push`. The
+# migration deliberately repeats the list in page-link-indexes.ts rather than importing it
+# (a migration is an immutable snapshot); the two are kept in step by the index-inventory
+# assertion in page-link-read-perf.integ.ts. The backfill remains the online cron job
+# above, not a migration.
 ```
 
 > **Outgoing-health types are declared by B5, not up front.** `interfaces/backlink.ts` holds only
 > `IBacklink` / `IBacklinkResponse` today; the `LinkTargetState` union arrives with its derivation
-> helper in **B5.1** and the `ILinkTarget` DTO with the forward-health read in **B5.4**. The target
+> helper in **B5.1**, the `ILinkTarget` DTO with the forward-health read in **B5.4**, and
+> `IBacklinkResponse.linkTargets` with the endpoint/hook wiring in **B5.9**. The target
 > shapes below (§ Data Models) are unchanged — only *when* they are declared moved. (The original plan
 > declared both in B1.1; B1 shipped without them, and keeping a type in the same change as its only
 > producer is the better trade than a type with no consumer.)
@@ -332,7 +344,7 @@ needs no write — derived state reads the restored page's status.
 | 3.3 | Deleted page not an active source | reconcile (permanent: remove rows; trashed: filtered at read) | Delete flow |
 | 3.4 | <~1s at ≥100k pages | indexes `{toPage}`, unique `{fromPage, toPath}` | — |
 | 3.5 | Bound extraction impact under save bursts | PageLinkService coalescing queue (`Set<pageId>` + paced drain) | Save flow |
-| 4.1 | One-time backfill | PageLinkBackfillCron (indexes via `autoIndex` at model registration) | Backfill flow |
+| 4.1 | One-time backfill | PageLinkBackfillCron (indexes via the `pagelinks` index migration) | Backfill flow |
 | 4.2 | Backfilled == post-enablement | backfill reuses `extractInternalLinkPaths`; emits same rows as the live path | Backfill flow |
 | 4.3 | Re-run / restart produces no duplicates | unique `{fromPage,toPath}` + upsert; resumable progress marker | Backfill flow |
 | 5.1 | Links survive rename/move | resolveToPageIds redirect-following + `_id`-stable cache | Reconcile notes |
@@ -342,18 +354,18 @@ needs no write — derived state reads the restored page's status.
 | 6.1 | Soft-delete target → trashed | derived state from target status | Delete flow |
 | 6.2 | Permanent-delete target → broken | reconcile nulls inbound `toPage` | Delete flow |
 | 6.3 | Restore → normal | derived state (no write) | Delete flow |
-| 6.4 | Indicate trashed/deleted target on viewed page | forward-health read (fromPage=X) + badge | Read flow |
+| 6.4 | Indicate trashed/deleted target on viewed page | forward-health read (fromPage=X) → `linkTargets` on the backlinks endpoint → `useSWRxBacklinks` → panel section + badge | Read flow |
 
 ## Components and Interfaces
 
 | Component | Layer | Intent | Req | Key Dependencies (P0/P1) | Contracts |
 |-----------|-------|--------|-----|--------------------------|-----------|
-| PageLink model | Data | Persist directed link edges | 1.5,3.x,4.3 | Mongoose, getOrCreateModel (P0) | State |
+| pagelinks (PageLink) model | Data | Persist directed link edges | 1.5,3.x,4.3 | Prisma client extension (P0), pagelinks index migration (P0) | State |
 | extractInternalLinkPaths | Server logic | Body+path+siteUrl → resolved internal paths | 1.2–1.6, 1.10, 1.11 | render plugins, isCreatablePage, normalizePath, isPermalink, app:siteUrl (P0) | Service |
 | resolveToPageIds | Server logic | paths → toPage ids, batched (incl. permalink by id) | 1.9, 5.x | Page.find by _id/path, PageRedirect.retrievePageRedirectEndpointsBatch, isPermalink (P0) | Service |
 | PageLinkService | Server service | Subscribe to events, sync index, query backlinks | 1.1,2.x,3.x,5,6 | events.page (P0), PageQueryBuilder.addViewerCondition (P0) | Service, Event |
-| getBacklinksHandlerFactory (routes/backlinks.ts) | API | Read endpoint | 1.1,1.7,2.x,6.4 | apiv3 middleware (P0), PageLinkService (P0) | API |
-| useSWRxBacklinks | Client store | Fetch backlinks | 1.1 | apiv3Get (P0) | Service |
+| getBacklinksHandlerFactory (routes/backlinks.ts) | API | Read endpoint — incoming backlinks **+ forward-link health** (B5.9) | 1.1,1.7,2.x,6.4 | apiv3 middleware (P0), PageLinkService (P0) | API |
+| useSWRxBacklinks | Client store | Fetch backlinks **+ link targets** (B5.9) | 1.1,6.4 | apiv3Get (P0) | Service |
 | BacklinksPanel / BacklinkListItem | UI | Render list, empty state, target-state badge | 1.1,1.7,1.8,6.4 | useSWRxBacklinks, PageListItemS (P1) | — |
 | PageLinkBackfillCron | Batch | Populate pre-existing pages (chunked, resumable, throttled, online) | 4.1,4.2,4.3 | CronService (P0), extractInternalLinkPaths (P0), Revision, in-memory path→id map (P0) | Batch, State |
 
@@ -377,7 +389,14 @@ needs no write — derived state reads the restored page's status.
 **Contracts**: State [x]
 
 ##### State Management
-- Schema (mirrors `PageTagRelation` conventions, `getOrCreateModel`):
+- **Prisma-only collection.** `pagelinks` is declared in `apps/app/prisma/schema.prisma` and its
+  model methods live in a `Prisma.defineExtension` block (`server/models/page-link.ts`) — there is no
+  mongoose schema and no `getOrCreateModel`. It joins the repo's prisma-only pattern
+  (`auditlog_es_sync_status`, `changestream_resume_tokens`) rather than the mongoose-schema-plus-
+  extension shape the `mongoose-to-prisma` skill produces for models that predate Prisma, because it
+  is greenfield and unshipped. No `__v`: nothing has ever written it through mongoose.
+- Row shape (`interfaces/page-link.ts`; `Types.ObjectId` is the id type the rest of the server passes
+  around, not a mongoose data-access dependency):
 ```typescript
 interface IPageLink {
   fromPage: ObjectId;        // ref Page, required
@@ -385,14 +404,25 @@ interface IPageLink {
   toPage: ObjectId | null;   // ref Page cache, default null
 }
 ```
-- Indexes: `{ fromPage: 1 }`, `{ toPath: 1 }`, `{ toPage: 1 }`, and unique `{ fromPage: 1, toPath: 1 }`.
-- Statics: `replaceOutboundLinks(fromPageId, resolvedRows)`, `findBacklinkSources(toPageId)`,
-  `reconcileDeletedPages(pageIds)`, `repointInboundLinks(toPath, toPage)`.
+- Indexes — **three**, provisioned by `migrations/20260901064500-add-indexes-to-pagelinks.js`
+  (`prisma db push` is never run, so schema.prisma's `@@index`/`@@unique` describe them but create
+  nothing): unique `fromPage_1_toPath_1`, `toPage_1`, `toPath_1`. There is deliberately **no
+  standalone `fromPage_1`** — `fromPage` is the compound's prefix, so every `fromPage`-only lookup
+  already rides it and a separate index would be dead weight. `fromPage_1_toPath_1` is a correctness
+  constraint, not tuning: `replaceOutboundLinks` upserts against that filter.
+- Model methods: `replaceOutboundLinks(fromPageId, resolvedRows)`, `findBacklinkSources(toPageId)`,
+  `repointInboundLinks(toPath, toPage)`, `reconcileDeletedPages(pageIds)` (B5.1).
+- **Raw-command rule.** Several of these use `client.$runCommandRaw` because Prisma's query API
+  cannot express what they need (no bulk-upsert API; `repointInboundLinks` needs a pipeline update).
+  MongoDB reports per-statement failures *inside* an `ok: 1` reply, so **every raw write passes its
+  reply through `throwOnWriteErrors`**, which throws on both `writeErrors` and `writeConcernError` —
+  parity with the `bulkWrite(..., { ordered: true })` these replaced, which threw on both. Do not add
+  try/catch at call sites; `PageLinkUpsertQueue` is the error boundary.
 - `repointInboundLinks` is the write half of re-resolve-by-path: it points the rows matching
   `toPath` at an already-resolved `toPage` (`null` = broken) and resolves nothing itself. The
   resolution lives in the `reResolveByToPath` **service** (page-link-sync), mirroring the
   `syncOutboundLinks` / `replaceOutboundLinks` split — so the derived `toPage` is always what the
-  shared resolver reports, never a value the caller supplies. The static **clears** the row whose own
+  shared resolver reports, never a value the caller supplies. The method **clears** the row whose own
   source is the target (a page is never its own backlink) rather than skipping it — skipping would
   preserve whatever page occupied the path when that source was last saved, leaving it listed as a
   backlink of a page its body no longer points to. The row itself is cleared, not deleted: row
@@ -403,10 +433,21 @@ interface IPageLink {
     row on the source's next save — so `findForwardLinkHealth` must not report it as broken (B5.4).
   - Both arguments are validated: `toPath` unless it is a non-empty string, `toPage` unless it is an
     ObjectId or null. Neither is protected downstream — `toPath` becomes a query filter where an
-    operator object would match every row, and `toPage` goes into an aggregation pipeline, which
-    mongoose does not cast, so an expression object there would be evaluated into the column.
+    operator object would match every row, and `toPage` goes into an aggregation pipeline, which is
+    not type-checked, so an expression object there would be evaluated into the column. (The
+    validation matters *more* under Prisma than it did under mongoose: this is a `$runCommandRaw`
+    pipeline update, so nothing casts either argument on the way to the server.)
   - The two writes are one pipeline update, so a row is never momentarily its own backlink and a
     failure cannot leave it that way.
+- `reconcileDeletedPages` (B5.1) is **two writes, not one**: delete the gone pages' outbound rows
+  (`fromPage $in ids`) and null every inbound cache pointing at them (`toPage $in ids` →
+  `toPage: null`). Neither half needs a pipeline update, so unlike `repointInboundLinks` both are
+  expressible through the Prisma query API (`deleteMany` / `updateMany`) — prefer that, and reach for
+  `$runCommandRaw` + `throwOnWriteErrors` only if a raw command turns out to be needed. No new index:
+  both filters ride existing indexes (`fromPage_1_toPath_1` by prefix, `toPage_1`). Not a
+  transaction: the index is a derived cache, the two halves are independently idempotent, and staying
+  single-command-per-write keeps the collection standalone-MongoDB compatible (the same trade
+  `replaceOutboundLinks` documents).
 
 #### extractInternalLinkPaths
 
@@ -603,6 +644,28 @@ findForwardLinkHealth(fromPageId: ObjectId, user: IUser | null): Promise<ILinkTa
     private paths to anyone who can read the linking page. Resolution itself is grant-blind by
     design (it must match what a click does, and the live path lookup was always grant-blind), so
     the filter belongs on this read path, not in `resolveToPageIds`.
+  - **One query does both jobs.** Deriving `trashed` needs the target page's `status`, and the leak
+    fix needs the target pages run through the grant filter — that is the *same* set of documents, so
+    it is a single `Page` query, not a grant query plus a status round trip. Shape: the non-null
+    `toPage` ids → `PageQueryBuilder(Page.find({ _id: { $in: targetIds } }))` →
+    `addViewerCondition(user)` → `.select('_id path status')`, then derive each row's state from the
+    returned document. `broken` rows (`toPage == null`) are settled with no lookup at all.
+  - **It cannot reuse `buildVisibleSourcesQuery`.** That builder calls
+    `addConditionToExcludeTrashed()`, and trashed targets are exactly what this read reports — so
+    forward-health needs its own sibling builder that applies the grant condition **only**, and
+    selects `status` (which the backlinks read does not need). Deriving state in the same query is
+    what makes the difference load-bearing rather than incidental.
+  - **`path` is asymmetric by construction.** For a `trashed` (or `normal`) row it is the target
+    page's *current* `path` from that query; for a `broken` row there is no page, so it is the row's
+    own `toPath` — faithful to what the body actually links to. That is also why a broken row leaks
+    nothing: `toPath` is text the linking page's own author wrote.
+  - **A non-null `toPage` absent from the query result is omitted**, not reported as broken: "the
+    viewer may not read it" and "the document is gone" are indistinguishable from the result set, and
+    reporting the latter would leak the former's existence. A genuinely permanently-deleted target
+    becomes `broken` because the delete-family reconcile (B5.2) nulls the inbound cache.
+  - A **self row** (`fromPage == toPage`'s page, cleared to `null` by `repointInboundLinks`) also
+    reads as `broken` although its path resolves. It is transient and must **not** be reported — see
+    the `repointInboundLinks` note under § PageLink model.
 
 **Implementation Notes**
 - Integration: register in `crowi` page-service setup; never edit `PageService`.
@@ -626,20 +689,35 @@ findForwardLinkHealth(fromPageId: ObjectId, user: IUser | null): Promise<ILinkTa
 ##### API Contract
 | Method | Endpoint | Request | Response | Errors |
 |--------|----------|---------|----------|--------|
-| GET | `/_api/v3/page/backlinks` | query: `pageId` (MongoId) | `{ backlinks: IBacklink[] }` | 400, 403, 500 |
+| GET | `/_api/v3/page/backlinks` | query: `pageId` (MongoId) | `{ backlinks: IBacklink[], linkTargets: ILinkTarget[] }` | 400, 403, 500 |
 
 - Middleware: `accessTokenParser([SCOPE.READ.FEATURES.PAGE])`, `loginRequired` (guest per ACL),
-  `apiV3FormValidator`; `req.user` is the viewer. Delegates to `PageLinkService.findBacklinks`.
+  `apiV3FormValidator`; `req.user` is the viewer. Delegates to `PageLinkService.findBacklinks` and
+  (B5.9) `PageLinkService.findForwardLinkHealth`.
 - Response carries only filtered pages (no count derived from unfiltered set) → 2.2.
+- **Forward-link health rides this endpoint rather than a second one** (B5.9). It is keyed on the
+  same `pageId`, has the same viewer and the same 403 semantics, and `BacklinksPanel` renders both
+  sections at once — a separate route would mean a second round trip on every panel open, a second
+  hook, and a second registration in `apiv3/index.js`, for no independent cacheability. The two
+  reads are issued concurrently (`Promise.all`) so the added field costs no extra latency; each
+  applies its own filter (sources for `backlinks`, targets for `linkTargets`).
 
 ### Client
 
 #### useSWRxBacklinks (summary)
 ```typescript
-useSWRxBacklinks(pageId: string | null): SWRResponse<IBacklink[]>;
+// B5.9 widens the payload from IBacklink[] to the whole response, so the panel can read
+// both sections from one fetch. Today (B1) it resolves to r.data.backlinks.
+useSWRxBacklinks(pageId: string | null): SWRResponse<IBacklinkResponse, IErrorV3[]>;
 ```
-- Key `['/page/backlinks', pageId, isGuestUser]`; fetch via `apiv3Get(...).then(r => r.data.backlinks)`.
-  `useSWRImmutable`; key `null` when `pageId == null`.
+- Key `['/page/backlinks', pageId, isGuestUser]`; fetch via `apiv3Get<IBacklinkResponse>(...)`.
+  Key `null` when `pageId == null`. Errors are `IErrorV3[]`, not `Error` — `apiv3Request` rejects
+  with the apiv3 error array.
+- **Plain `useSWR`, not `useSWRImmutable`**: grants can change while `pageId` and the user stay the
+  same, so a reopened panel must revalidate rather than serve a stale cache for the session.
+- Widening the return type is a **breaking change for `BacklinksPanel`** (it currently receives the
+  array directly). That churn is deliberately placed in B5.9/B5.6, which are rewriting the panel
+  anyway — it is not an unplanned break of B1.11.
 
 #### BacklinksPanel / BacklinkListItem (summary)
 - New tab in `PageAccessoriesModal`. `BacklinksPanel` renders the incoming list (empty state per
@@ -654,9 +732,9 @@ useSWRxBacklinks(pageId: string | null): SWRResponse<IBacklink[]>;
 > A data migration that parses every page body would therefore make the wiki **offline for the
 > full backfill duration** — minutes on small wikis, but tens of minutes to hours on large-plan
 > instances. So the heavy data part runs **online** as a throttled background job after boot.
-> Nothing schema-related blocks boot either: `PageLink` is a new collection, so its indexes
-> (`{toPage}`, unique `{fromPage,toPath}`) are created by Mongoose
-> `autoIndex` at model registration — no migration is involved. Backlinks are simply incomplete
+> Nothing schema-related blocks boot either: the index migration that provisions the three
+> `pagelinks` indexes (unique `fromPage_1_toPath_1`, `toPage_1`, `toPath_1`) builds them on a new,
+> empty collection, which is effectively instant. Backlinks are simply incomplete
 > for pre-existing pages until the job finishes (acceptable per 4.2, which only requires
 > completeness *after* the process completes); newly edited pages index immediately via the event
 > listener.
@@ -695,7 +773,11 @@ useSWRxBacklinks(pageId: string | null): SWRResponse<IBacklink[]>;
 - Input per chunk: a cursor page-batch (`Page.find(...).cursor({ batch_size })` +
   `createBatchStream`); body via `Revision.findById(page.revision).body`.
 - Per page: `extractInternalLinkPaths(body, page.path, siteUrl)` → resolve each path via the in-memory
-  map (or, for a permalink path, via the id-existence set) → `bulkWrite` upserts (`ordered:false`).
+  map (or, for a permalink path, via the id-existence set) → batched upserts. **`pagelinks` is a
+  Prisma-only collection with no mongoose model, so there is no `Model.bulkWrite`**: the chunk write
+  is either repeated `replaceOutboundLinks` calls or a new batched model method on the extension —
+  and if it uses `$runCommandRaw`, its reply must go through `throwOnWriteErrors` like every other
+  raw write here. B3 decides which; `ordered: false` remains the intent for a chunk.
 - Idempotency: unique `{fromPage,toPath}` + upsert; safe to re-run and to resume mid-chunk (4.3).
 - Progress/observability: emit count/total over the existing admin Socket.IO channel (as the
   Elasticsearch reindex does).
@@ -718,7 +800,9 @@ useSWRxBacklinks(pageId: string | null): SWRResponse<IBacklink[]>;
   across rename/move/restore), so they satisfy 5.4 with no reconciliation.
 
 ### Derived target state (not stored)
-_Declared in B5.1, alongside the derivation helper (see § File Structure Plan)._
+_Declared in B5.1, alongside the derivation helper — a pure `link-target-state.ts` on the **read**
+path, not in `page-link-sync`: nothing on the write path derives this, and B5.4 folds the derivation
+into the grant-filtered target query it already has to issue (see § File Structure Plan)._
 ```typescript
 type LinkTargetState = 'normal' | 'trashed' | 'broken';
 // broken  := toPage == null
@@ -736,9 +820,18 @@ interface IBacklink {
 // Outgoing link health (findForwardLinkHealth): a page the subject links out to, plus its state.
 // Declared in B5.4, alongside the read query that produces it.
 interface ILinkTarget {
-  pageId: string;
+  // null exactly when targetState is 'broken': a broken row is `toPage == null`, so there
+  // is no page id to report. Non-null for 'trashed' (and 'normal', which this read never
+  // returns). Making it required-string would be unsatisfiable for the broken case.
+  pageId: string | null;
+  // The target page's CURRENT path when it exists; the row's own `toPath` when broken.
   path: string;
   targetState: LinkTargetState; // required — a health row is meaningless without it
+}
+
+interface IBacklinkResponse {
+  backlinks: IBacklink[];
+  linkTargets: ILinkTarget[]; // B5.9 — trashed/broken outbound targets of the same page
 }
 ```
 
@@ -882,24 +975,30 @@ interface ILinkTarget {
 
 ## Migration Strategy
 
-No migration: `PageLink` indexes are created by Mongoose `autoIndex` at model registration (new,
-empty collection). The only bulk step is the online throttled backfill job after boot.
+One index migration, no data migration: `migrations/20260901064500-add-indexes-to-pagelinks.js`
+provisions the three `pagelinks` indexes at boot (instant on an empty collection); the only bulk step
+is the online throttled backfill job after boot.
 
-> **`autoIndex` creates, it never drops.** Removing an index from the schema (as B2.2 did for the
-> redundant `{fromPage}` and `{toPath}`) leaves `fromPage_1` / `toPath_1` in place on any collection
-> that was already created with them — so a dev or staging instance that ran an earlier build keeps
-> paying their write cost until the collection is dropped. Harmless while the feature is unreleased,
-> which is why no migration ships here; **once `PageLink` has shipped, an index removal needs a
-> migrate-mongo migration with an explicit `dropIndex`**, not just a schema edit.
+> **Why the indexes need a migration at all.** `pagelinks` is Prisma-only — no mongoose schema means
+> no `autoIndex` on connect, and nothing in this repo runs `prisma db push`, so schema.prisma's
+> `@@index`/`@@unique` declarations describe the indexes but create none. The migration is the only
+> thing that creates them in production. `server/models/page-link-indexes.ts` repeats the same list
+> for the integration harness (which skips migrations on the default in-memory MongoDB); the
+> index-inventory assertion in `page-link-read-perf.integ.ts` fails on any drift between the two.
+>
+> **Leftover indexes from earlier builds.** A dev or staging instance created under the pre-Prisma
+> mongoose schema may still carry the redundant standalone `fromPage_1` that B2.2 dropped from the
+> schema — `createIndex` adds, it never removes. Harmless while the feature is unreleased; **once
+> `pagelinks` has shipped, an index removal needs its own migration with an explicit `dropIndex`.**
 
 ```mermaid
 graph TB
-    Boot[boot: model registration] --> Idx[autoIndex creates PageLink indexes]
+    Boot[boot: migrate-mongo] --> Idx[index migration creates pagelinks indexes]
     Idx --> Serve[app serves traffic]
     Serve --> Claim{atomic claim job doc}
     Claim -- not claimed/complete --> Tick[cron tick: process one chunk]
     Tick --> Map[resolve via in-memory path to id map]
-    Map --> Bulk[bulkWrite upsert PageLink ordered false]
+    Map --> Bulk[batched upsert pagelinks unordered]
     Bulk --> Save[persist progress marker]
     Save --> Done{all pages processed}
     Done -- no --> Idle[idle until next tick throttle]
@@ -907,7 +1006,7 @@ graph TB
     Done -- yes --> Mark[mark job complete]
 ```
 
-- **No boot downtime**: `autoIndex` on the empty `PageLink` collection is effectively instant. The
+- **No boot downtime**: the index migration on the empty `pagelinks` collection is effectively instant. The
   wiki is online throughout the backfill; pre-existing backlinks fill in progressively.
 - **Estimated backfill wall-clock** (≈5 ms/page CPU; in-memory resolution): ~10 min/100k pages at
   full speed, scaled up by the inverse duty cycle (e.g. ~40 min/100k at 25% duty) and by average

--- a/.kiro/specs/backlinks/design.md
+++ b/.kiro/specs/backlinks/design.md
@@ -411,7 +411,7 @@ interface IPageLink {
   already rides it and a separate index would be dead weight. `fromPage_1_toPath_1` is a correctness
   constraint, not tuning: `replaceOutboundLinks` upserts against that filter.
 - Model methods: `replaceOutboundLinks(fromPageId, resolvedRows)`, `findBacklinkSources(toPageId)`,
-  `repointInboundLinks(toPath, toPage)`, `reconcileDeletedPages(pageIds)` (B5.1).
+  `repointInboundLinks(toPath, toPage)`, `removeLinksForPages(pageIds)` (B5.1).
 - **Raw-command rule.** Several of these use `client.$runCommandRaw` because Prisma's query API
   cannot express what they need (no bulk-upsert API; `repointInboundLinks` needs a pipeline update).
   MongoDB reports per-statement failures *inside* an `ok: 1` reply, so **every raw write passes its
@@ -439,15 +439,32 @@ interface IPageLink {
     pipeline update, so nothing casts either argument on the way to the server.)
   - The two writes are one pipeline update, so a row is never momentarily its own backlink and a
     failure cannot leave it that way.
-- `reconcileDeletedPages` (B5.1) is **two writes, not one**: delete the gone pages' outbound rows
-  (`fromPage $in ids`) and null every inbound cache pointing at them (`toPage $in ids` →
-  `toPage: null`). Neither half needs a pipeline update, so unlike `repointInboundLinks` both are
-  expressible through the Prisma query API (`deleteMany` / `updateMany`) — prefer that, and reach for
-  `$runCommandRaw` + `throwOnWriteErrors` only if a raw command turns out to be needed. No new index:
-  both filters ride existing indexes (`fromPage_1_toPath_1` by prefix, `toPage_1`). Not a
-  transaction: the index is a derived cache, the two halves are independently idempotent, and staying
-  single-command-per-write keeps the collection standalone-MongoDB compatible (the same trade
-  `replaceOutboundLinks` documents).
+- `removeLinksForPages` (B5.1) is the delete-side primitive, and like the other two it is named for
+  its mechanism, not for the decision: it writes unconditionally, and the trashed-vs-gone decision
+  lives in the `reconcileDeletedPages` **service** (B5.2). Both names exist on purpose — same split
+  as `syncOutboundLinks` / `replaceOutboundLinks` and `reResolveByToPath` / `repointInboundLinks`.
+- It is **two writes, not one**: delete the gone pages' outbound rows (`fromPage $in ids`), then null
+  every inbound cache pointing at them (`toPage $in ids` → `toPage: null`), which is what makes those
+  rows read as `broken`. Outbound goes first because those are the rows that have lost their source
+  and could still be surfaced as a phantom backlink. No new index — both filters ride existing ones
+  (`fromPage_1_toPath_1` by prefix, `toPage_1`).
+  - **The two halves cannot use the same API, and this was measured, not assumed.** The delete is
+    plain `deleteMany` through the Prisma query API (verified working). The inbound null **must** be
+    `$runCommandRaw` + `throwOnWriteErrors`, for two independent reasons: `pagelinks.updateMany`'s
+    generated data input accepts **only `toPath`** — the relation scalars are not settable through it
+    (`Unknown argument 'toPageId'`), nor via the relation (`toPage: { disconnect: true }`) — **and**
+    the client-wide `$allModels.updateMany` extension in `utils/prisma.ts` injects
+    `v: { increment: 1 }` for mongoose optimistic-concurrency parity, a field this prisma-only
+    collection deliberately does not have. So *any* update on `pagelinks` through the query API is a
+    `PrismaClientValidationError`; the raw command is the only route, independent of whether a
+    pipeline update is needed. (No prisma-only, `v`-less model had ever been updated before this, so
+    the trap was unexercised.)
+  - No argument validation, unlike `repointInboundLinks`: every id is stringified and then wrapped as
+    `$oid` (or cast by Prisma), so an operator object from an untyped caller cannot reach a filter
+    position — it degrades to a malformed id the server rejects.
+  - Not a transaction: the index is a derived cache, the two halves are independently idempotent, and
+    staying single-command-per-write keeps the collection standalone-MongoDB compatible (the same
+    trade `replaceOutboundLinks` documents).
 
 #### extractInternalLinkPaths
 
@@ -800,7 +817,7 @@ useSWRxBacklinks(pageId: string | null): SWRResponse<IBacklinkResponse, IErrorV3
   across rename/move/restore), so they satisfy 5.4 with no reconciliation.
 
 ### Derived target state (not stored)
-_Declared in B5.1, alongside the derivation helper — a pure `link-target-state.ts` on the **read**
+_Declared in B5.1, alongside `deriveLinkTargetState` — a pure `link-target-state.ts` on the **read**
 path, not in `page-link-sync`: nothing on the write path derives this, and B5.4 folds the derivation
 into the grant-filtered target query it already has to issue (see § File Structure Plan)._
 ```typescript
@@ -876,8 +893,12 @@ interface IBacklinkResponse {
   while the default walks the chain to its real end; two documents sharing a `fromPath` resolve to
   the first and log a warning. The existing `retrievePageRedirectEndpoints` tests double as the
   regression net for the shared pipeline, and one of them pins that page view stays uncapped.
-- `reconcileDeletedPages`: trashed page → no-op; permanently-gone page → outbound removed and
-  inbound `toPage` nulled (3.3, 6.2).
+- `reconcileDeletedPages` (service): trashed page → no-op; permanently-gone page → delegates to
+  `removeLinksForPages` (3.3, 6.2).
+- `deriveLinkTargetState`: `broken` when the row has no cached target (outranking any status handed
+  in alongside), `trashed` when the target's status is `deleted`, `normal` otherwise — including a
+  `null`/`undefined` status, which is a v4-era page that `addConditionToExcludeTrashed` counts as
+  published (6.1–6.3).
 - `reResolveByToPath`: forwards the target the resolver reports for the path, and forwards `null`
   when the path is absent from the map (so a row can return to broken); resolves and writes the
   paths that redirect to it as well, each carrying the resolver's own verdict rather than the
@@ -895,6 +916,11 @@ interface IBacklinkResponse {
   (2.1–2.3); grant change flips visibility on the next read (2.4).
 - Rename/move: inbound links continue resolving to the page at its new path without index
   writes; descendant move behaves identically (5.1, 5.2).
+- `removeLinksForPages` write semantics against a real collection (the observable contract is the
+  resulting rows): the gone pages' outbound rows are deleted, inbound caches pointing at them are
+  nulled while the rows and their `toPath` survive, unrelated rows are untouched, a batch is handled
+  including a row that is both a gone source and a gone target (deleted, not merely nulled), and it
+  is idempotent. Mutation-checked: an over-broad `deleteMany`/update filter fails the suite.
 - `repointInboundLinks` write semantics, driven through `reResolveByToPath` against a real
   collection (there is no unit spec: the observable contract is the resulting rows, and asserting
   the `updateMany` filter instead would spy on the mechanism). Rows at the path are repointed

--- a/.kiro/specs/backlinks/design.md
+++ b/.kiro/specs/backlinks/design.md
@@ -465,6 +465,20 @@ interface IPageLink {
   - Not a transaction: the index is a derived cache, the two halves are independently idempotent, and
     staying single-command-per-write keeps the collection standalone-MongoDB compatible (the same
     trade `replaceOutboundLinks` documents).
+- **Batching is the caller's job, not the primitives'.** Every write primitive here sends its whole
+  work-set in a single command — `removeLinksForPages` puts all of `pageIds` in one `$in`,
+  `replaceOutboundLinks` emits one update statement per extracted row plus a `$nin` over every path.
+  A large enough work-set therefore approaches MongoDB's 16MB command cap (and, for
+  `replaceOutboundLinks`, the 100,000-statement batch cap), and the command is rejected whole: the
+  write throws and the rows stay stale until the next save or a backfill — loud, and self-healing,
+  but a real gap in the meantime. None of the primitives chunk internally, deliberately: every
+  recursive delete path in `PageService` already funnels through
+  `createBatchStream(BULK_REINDEX_SIZE)` (100), so the delete-family handlers (B5.3) can only ever
+  hand over a batch of that size, and a chunk loop would be an untestable branch guarding a caller
+  that does not exist. **The precondition, not the loop, is the contract** — it is stated on
+  `removeLinksForPages`' JSDoc for the next caller to find. If a future caller assembles page ids
+  outside a batch stream (a backfill, a migration, a group-deletion sweep), chunk **both** primitives
+  at that point, with a threshold that caller's measured size justifies. (Raised in review of B5.1.)
 
 #### extractInternalLinkPaths
 

--- a/.kiro/specs/backlinks/spec.json
+++ b/.kiro/specs/backlinks/spec.json
@@ -1,7 +1,7 @@
 {
   "feature_name": "backlinks",
   "created_at": "2026-06-23T06:56:53Z",
-  "updated_at": "2026-08-06T00:00:00Z",
+  "updated_at": "2026-09-03T00:00:00Z",
   "language": "en",
   "phase": "tasks-generated",
   "approvals": {

--- a/.kiro/specs/backlinks/spec.json
+++ b/.kiro/specs/backlinks/spec.json
@@ -1,7 +1,7 @@
 {
   "feature_name": "backlinks",
   "created_at": "2026-06-23T06:56:53Z",
-  "updated_at": "2026-09-03T00:00:00Z",
+  "updated_at": "2026-09-08T00:00:00Z",
   "language": "en",
   "phase": "tasks-generated",
   "approvals": {

--- a/.kiro/specs/backlinks/tasks.md
+++ b/.kiro/specs/backlinks/tasks.md
@@ -613,38 +613,49 @@ the restored page's status. Independent of B3/B4.
 > already-completed B1 tasks cross-reference them by number; renumbering would break those
 > references.
 
-- [ ] B5.1 Add the reconcile model method and target-state derivation
+- [x] B5.1 Add the delete-side model primitive and target-state derivation
   - **The model is Prisma, not Mongoose** (B1.2's text is superseded — see its note). So this is not
-    a mongoose static: `reconcileDeletedPages(pageIds)` becomes a method in the
-    `Prisma.defineExtension` block in `server/models/page-link.ts`, alongside
-    `replaceOutboundLinks` / `findBacklinkSources` / `repointInboundLinks`
-  - Two writes, one per direction: delete the gone pages' outbound rows (`fromPage $in ids`) and
-    null every inbound cache pointing at them (`toPage $in ids` → `toPage: null`). **No new index** —
+    a mongoose static: it is a method in the `Prisma.defineExtension` block in
+    `server/models/page-link.ts`, alongside `replaceOutboundLinks` / `findBacklinkSources` /
+    `repointInboundLinks`
+  - **Named `removeLinksForPages(pageIds)`, not `reconcileDeletedPages`.** Like its two siblings the
+    primitive is named for its mechanism and writes unconditionally; the trashed-vs-gone *decision*
+    is B5.2's service op, which keeps the name `reconcileDeletedPages`. Same split as
+    `syncOutboundLinks` / `replaceOutboundLinks` and `reResolveByToPath` / `repointInboundLinks`
+  - Two writes, one per direction: delete the gone pages' outbound rows (`fromPage $in ids`) first —
+    they have lost their source and are what a reader could surface as a phantom backlink — then null
+    every inbound cache pointing at them (`toPage $in ids` → `toPage: null`). **No new index** —
     both filters ride indexes that already exist via
     `migrations/20260901064500-add-indexes-to-pagelinks.js` (`fromPage_1_toPath_1` by prefix,
     `toPage_1`)
-  - Unlike `repointInboundLinks`, neither half needs a pipeline update, so both are expressible
-    through the Prisma query API (`deleteMany` / `updateMany`) — prefer that. **If you do reach for
-    `$runCommandRaw`, its reply must go through `throwOnWriteErrors`** like every other raw write in
-    this feature: MongoDB resolves a raw write `ok: 1` with the failures inside `writeErrors` /
-    `writeConcernError`, so a discarded reply loses them silently. Not a transaction (derived cache,
+  - **The two halves cannot share an API.** The delete is `deleteMany` through the Prisma query API.
+    The inbound null **must** be `$runCommandRaw` + `throwOnWriteErrors`: `pagelinks.updateMany`'s
+    generated data input accepts only `toPath` (relation scalars are not settable through it, nor via
+    the relation), **and** `utils/prisma.ts`'s client-wide `$allModels.updateMany` extension injects
+    `v: { increment: 1 }`, which this prisma-only collection has no field for. Any query-API update on
+    `pagelinks` is therefore a `PrismaClientValidationError` — verified against the database, since no
+    `v`-less prisma-only model had ever been updated before. Not a transaction (derived cache,
     idempotent halves, standalone-MongoDB compatible — the trade `replaceOutboundLinks` documents)
-  - Implement the `LinkTargetState` derivation helper (`toPage == null` → `broken`; target trashed →
-    `trashed`; else `normal`) — state is derived, never stored. It lands in a pure
+  - Implement `deriveLinkTargetState` (`toPage == null` → `broken`, outranking any status passed
+    alongside; target status `deleted` → `trashed`; else `normal`, including a `null`/`undefined`
+    status, which is a v4-era published page) — state is derived, never stored. It lands in a pure
     `server/services/link-target-state.ts` on the **read** path, not in `page-link-sync`: nothing on
     the write path derives this, and B5.4 consumes it inside the target query it already issues
   - **Declare the `LinkTargetState` union here** (deferred from B1.1) in `interfaces/backlink.ts`, in the
     shape the design's § Data Models DTO section specifies
-  - Done when unit tests cover the three derived states from `toPage`/target status, and a test shows
-    reconcile removes the outbound rows and nulls the inbound caches for a batch of page ids
+  - Done when unit tests cover the derived states from `toPage`/target status, and an integration test
+    shows the primitive removes the outbound rows and nulls the inbound caches for a batch of page
+    ids while leaving unrelated rows alone
   - _Requirements: 6.1, 6.2, 6.3_
   - _Boundary: pagelinks Prisma extension (page-link.ts), link-target-state.ts, interfaces/backlink.ts_
   - _Depends: B1.2_
 
 - [ ] B5.2 Implement the reconcile-deleted sync operation
   - Implement the reconcile op deferred from B1.5: reconcile a deleted page by checking its current DB
-    state — still trashed → no-op (derived state shows trashed); truly gone → remove its outbound rows
-    and null inbound `toPage` (broken)
+    state — still trashed → no-op (derived state shows trashed); truly gone → delegate to B5.1's
+    `removeLinksForPages` (which removes the outbound rows and nulls inbound `toPage` → broken).
+    This op keeps the name `reconcileDeletedPages` because it owns the decision; the model primitive
+    it calls is named for the write
   - **Carried over from B2.2:** delete must supersede a pending coalesced upsert. B2.2 only stops the
     drain from writing *new* rows for a page that is now `STATUS_DELETED`; the rows the page already
     owned when it was trashed are still there, so this op is what actually settles them. The upsert

--- a/.kiro/specs/backlinks/tasks.md
+++ b/.kiro/specs/backlinks/tasks.md
@@ -56,6 +56,15 @@ extraction and resolution for all of them as one unit; there is no separable "na
     (implemented in B5) now, but do not implement them here
   - Done when the model registers, its indexes exist, and a unit test confirms the unique index
     rejects a duplicate `{fromPage, toPath}` insert
+  - **Superseded after this task shipped (do not act on the Mongoose text above).** `pagelinks` was
+    moved to a **Prisma-only** model — `Prisma.defineExtension` in `server/models/page-link.ts`, no
+    mongoose schema, no `getOrCreateModel`. Consequently the "no migrate-mongo migration is needed"
+    claim is now false: `prisma db push` is never run, so the indexes are provisioned by
+    `migrations/20260901064500-add-indexes-to-pagelinks.js`, and `server/models/page-link-indexes.ts`
+    repeats the list for the integ harness (which skips migrations on in-memory MongoDB). Three
+    indexes exist, not four — unique `fromPage_1_toPath_1`, `toPage_1`, `toPath_1`; there is no
+    standalone `fromPage_1` (the compound's prefix serves it). See design.md § PageLink model
+    (State Management) for the current contract, and B5.1 for what this means for reconcile
   - _Requirements: 1.5, 3.4_
   - _Depends: B1.1_
 
@@ -598,15 +607,38 @@ B3/B5.
 forward-link-health read, and the UI that surfaces it. Restore needs no write — derived state reads
 the restored page's status. Independent of B3/B4.
 
-- [ ] B5.1 Add the reconcile static and target-state derivation
-  - Implement the reconcile-deleted static on the model (signature declared in B1.2) and the
-    `LinkTargetState` derivation helper (`toPage == null` → `broken`; target trashed → `trashed`; else
-    `normal`) — state is derived, never stored
+> **B5.9 is numbered out of sequence on purpose.** It was added after B5.1–B5.8 were written, to fill
+> the API/hook gap between the B5.4 server read and the B5.6 panel, and is listed below in its
+> dependency position (after B5.4) rather than at the end. B5.5–B5.8 keep their numbers because
+> already-completed B1 tasks cross-reference them by number; renumbering would break those
+> references.
+
+- [ ] B5.1 Add the reconcile model method and target-state derivation
+  - **The model is Prisma, not Mongoose** (B1.2's text is superseded — see its note). So this is not
+    a mongoose static: `reconcileDeletedPages(pageIds)` becomes a method in the
+    `Prisma.defineExtension` block in `server/models/page-link.ts`, alongside
+    `replaceOutboundLinks` / `findBacklinkSources` / `repointInboundLinks`
+  - Two writes, one per direction: delete the gone pages' outbound rows (`fromPage $in ids`) and
+    null every inbound cache pointing at them (`toPage $in ids` → `toPage: null`). **No new index** —
+    both filters ride indexes that already exist via
+    `migrations/20260901064500-add-indexes-to-pagelinks.js` (`fromPage_1_toPath_1` by prefix,
+    `toPage_1`)
+  - Unlike `repointInboundLinks`, neither half needs a pipeline update, so both are expressible
+    through the Prisma query API (`deleteMany` / `updateMany`) — prefer that. **If you do reach for
+    `$runCommandRaw`, its reply must go through `throwOnWriteErrors`** like every other raw write in
+    this feature: MongoDB resolves a raw write `ok: 1` with the failures inside `writeErrors` /
+    `writeConcernError`, so a discarded reply loses them silently. Not a transaction (derived cache,
+    idempotent halves, standalone-MongoDB compatible — the trade `replaceOutboundLinks` documents)
+  - Implement the `LinkTargetState` derivation helper (`toPage == null` → `broken`; target trashed →
+    `trashed`; else `normal`) — state is derived, never stored. It lands in a pure
+    `server/services/link-target-state.ts` on the **read** path, not in `page-link-sync`: nothing on
+    the write path derives this, and B5.4 consumes it inside the target query it already issues
   - **Declare the `LinkTargetState` union here** (deferred from B1.1) in `interfaces/backlink.ts`, in the
     shape the design's § Data Models DTO section specifies
-  - Done when unit tests cover the three derived states from `toPage`/target status
+  - Done when unit tests cover the three derived states from `toPage`/target status, and a test shows
+    reconcile removes the outbound rows and nulls the inbound caches for a batch of page ids
   - _Requirements: 6.1, 6.2, 6.3_
-  - _Boundary: PageLink, page-link-sync, interfaces/backlink.ts_
+  - _Boundary: pagelinks Prisma extension (page-link.ts), link-target-state.ts, interfaces/backlink.ts_
   - _Depends: B1.2_
 
 - [ ] B5.2 Implement the reconcile-deleted sync operation
@@ -639,29 +671,74 @@ the restored page's status. Independent of B3/B4.
 
 - [ ] B5.4 Implement the forward-link-health read query
   - **Declare the `ILinkTarget` DTO here** (deferred from B1.1) in `interfaces/backlink.ts`, in the shape
-    the design's § Data Models DTO section specifies — `targetState` required
+    the design's § Data Models DTO section specifies — `targetState` required, **`pageId` nullable**
+    (`string | null`). A `broken` row *is* `toPage == null`, so there is no page id to report; the
+    original `pageId: string` was unsatisfiable for exactly the case this read exists to surface
   - Implement `findForwardLinkHealth` (a page's outbound rows whose derived target state is
-    trashed/broken, mapped to `ILinkTarget`); derive target state from `toPage`/target status rather
-    than a stored flag
+    trashed/broken, mapped to `ILinkTarget`) in a new `server/services/find-forward-link-health.ts`,
+    sibling to `find-backlinks.ts`; derive target state via B5.1's helper from `toPage`/target status
+    rather than a stored flag
   - **Filter the targets through the shared viewer/grant filter.** `ILinkTarget` returns the
     target's `path`, and B4.1 made resolution follow the rename chain, so a `toPage` can point at a
     page that has since moved somewhere the viewer cannot read. Without this filter the endpoint
     leaks private paths to anyone who can read the linking page. `findBacklinks`' filter is on the
     *source* pages and does not cover this
+  - **One query, not two round trips.** Deriving `trashed` needs the target's `status` and the leak
+    fix needs the targets grant-filtered — the same documents — so issue a single
+    `PageQueryBuilder(Page.find({ _id: { $in: targetIds } }))` + `addViewerCondition(user)` +
+    `.select('_id path status')` and derive from its result. `broken` rows need no lookup at all
+  - **Do not reuse `buildVisibleSourcesQuery`**: it calls `addConditionToExcludeTrashed()`, and
+    trashed targets are precisely what this read reports. Add a sibling builder that applies the
+    grant condition only and selects `status` too
+  - Two shape rules the mapping must follow: `path` is the **target page's current path** for a
+    trashed row but the row's **own `toPath`** for a broken one (no page exists; and `toPath` is text
+    the linking author wrote, so it leaks nothing); and a **non-null `toPage` missing from the query
+    result is omitted, never reported as broken** — "unreadable" and "gone" are indistinguishable
+    there, and a truly permanently-deleted target becomes broken via B5.2's reconcile instead
   - A row whose own source is the target caches `null` (B4.2 clears it so a stale target cannot
     survive as a phantom backlink), so it reads as `broken` although the path resolves. Do **not**
     report it as a broken link — it is transient and `dropSelfLinks` removes the row on the source's
     next save
   - Done when an integration test shows forward health reports trashed/broken targets with the correct
-    state, **and** that a target the viewer cannot read is omitted, **and** that a self row is not
+    state, that a broken row carries `pageId: null` and its `toPath` as `path`, **and** that a target
+    the viewer cannot read is omitted (distinct from a broken one), **and** that a self row is not
     reported as broken
   - _Requirements: 5.3, 6.1, 6.2, 6.3, 6.4, 2.1_
-  - _Boundary: PageLinkService, interfaces/backlink.ts_
+  - _Boundary: find-forward-link-health.ts, PageLinkService, interfaces/backlink.ts_
   - _Depends: B5.1, B1.7_
+
+- [ ] B5.9 Expose forward-link health over the API and the client hook
+  - **Closes the gap between B5.4 (server read) and B5.6 (panel).** B5.4 produces `ILinkTarget[]` and
+    B5.6 renders it, but nothing carried it across the wire: the B1 endpoint returns
+    `{ backlinks }` only and `useSWRxBacklinks` resolves to `IBacklink[]`. Without this task B5.6 has
+    no data source
+  - **Extend the existing `GET /_api/v3/page/backlinks`, do not add a second route.** Same `pageId`,
+    same viewer, same 403 semantics, and the panel renders both sections together — a separate route
+    would cost a second round trip per panel open, a second hook, and a second registration in
+    `apiv3/index.js`, with no independent cacheability. Add `linkTargets: ILinkTarget[]` to
+    `IBacklinkResponse` and have the handler call `findBacklinks` and `findForwardLinkHealth`
+    concurrently (`Promise.all`) so the added field costs no extra latency
+  - Widen `useSWRxBacklinks` to return `IBacklinkResponse` instead of `IBacklink[]` (keep the
+    existing key and plain `useSWR` — grants change under a stable key, so it must stay revalidating).
+    `BacklinksPanel.tsx` is the only production consumer (verified), so the breaking call-site change
+    is absorbed by B5.6; the hook's own `backlinks.spec.tsx` and `BacklinksPanel.spec.tsx` mock the
+    old return shape and are updated here
+  - No new route registration and no new requirement: 6.4 already requires surfacing the indicator,
+    and 1.1/2.1 already govern this endpoint
+  - Done when an integration/route test shows the endpoint returns both `backlinks` and `linkTargets`
+    for a readable page (with the same 400/403 behavior as before), a viewer who cannot read a target
+    sees it omitted from `linkTargets` while `backlinks` is unaffected, and the hook test shows the
+    response object is returned and revalidates on page-id change
+  - _Requirements: 1.1, 2.1, 6.4_
+  - _Boundary: getBacklinksHandlerFactory (routes/backlinks.ts), useSWRxBacklinks, interfaces/backlink.ts_
+  - _Depends: B5.4_
 
 - [ ] B5.5 Add the target-state badge to the list-item
   - Extend `BacklinkListItem` (from B1.10) with a trashed/broken target-state badge
-  - Done when the component shows the badge for trashed/broken targets and renders unchanged for normal ones
+  - A **broken** row has `pageId: null` (B5.4) — there is no page to navigate to, so render its `path`
+    as plain text rather than a link. Only trashed and normal rows stay clickable
+  - Done when the component shows the badge for trashed/broken targets, renders a broken row's path
+    unlinked, and renders unchanged for normal ones
   - _Requirements: 6.4_
   - _Boundary: BacklinkListItem_
   - _Depends: B1.10_
@@ -669,10 +746,13 @@ the restored page's status. Independent of B3/B4.
 - [ ] B5.6 Add the forward-health section to the panel
   - Extend `BacklinksPanel` (from B1.11) with the secondary "outgoing links needing attention" section
     that flags trashed/broken outgoing links from the forward-health read
+  - Reads `linkTargets` off the B5.9 hook payload. B5.9 widens the hook's return type from
+    `IBacklink[]` to the whole response, so the incoming-list call site changes here too — deliberate
+    churn placed in the task that is already rewriting this panel, not an unplanned break of B1.11
   - Done when the panel flags trashed/broken outgoing links; the incoming list and empty state are unchanged
   - _Requirements: 6.4_
   - _Boundary: BacklinksPanel_
-  - _Depends: B5.4, B5.5, B1.11_
+  - _Depends: B5.9, B5.5, B1.11_
 
 - [ ] B5.7 Subscribe the delete-family lifecycle events
   - Extend the B1.12 subscription with delete/deleteCompletely/syncDescendantsDelete → the B5.3 handlers

--- a/.kiro/specs/backlinks/tasks.md
+++ b/.kiro/specs/backlinks/tasks.md
@@ -661,9 +661,17 @@ the restored page's status. Independent of B3/B4.
     owned when it was trashed are still there, so this op is what actually settles them. The upsert
     path uses `upsert: true`, so a stale upsert for a since-gone page would re-create rows for a
     non-existent source — orphan rows a reader could surface as phantom backlinks.
+  - **Raised in review of B5.1 — pass the batch through, do not accumulate it.** `removeLinksForPages`
+    sends all of `pageIds` in one command, so an unbounded array would approach MongoDB's 16MB command
+    cap and be rejected whole. This op must hand it the ids of the event payload it was called with and
+    nothing more; it must not collect ids across events/batches into one call. That is safe because
+    every recursive delete path funnels through `createBatchStream(BULK_REINDEX_SIZE)` (100) before the
+    delete-family events fire. The primitives stay unchunked on purpose — see design.md § *Batching is
+    the caller's job* for the posture and for what would flip it
   - Done when unit tests show reconcile no-ops a trashed page and nulls inbound `toPage` for a
-    permanently-gone page, and a delete landing while an upsert is pending ends in the reconciled
-    state rather than a re-created row
+    permanently-gone page, a delete landing while an upsert is pending ends in the reconciled
+    state rather than a re-created row, and the op issues one `removeLinksForPages` call per event
+    payload rather than an accumulated id list
   - _Requirements: 3.3, 3.5, 6.1, 6.2_
   - _Boundary: page-link-sync_
   - _Depends: B5.1_

--- a/apps/app/src/features/backlinks/interfaces/backlink.ts
+++ b/apps/app/src/features/backlinks/interfaces/backlink.ts
@@ -6,3 +6,9 @@ export interface IBacklink {
 export interface IBacklinkResponse {
   backlinks: IBacklink[];
 }
+
+/**
+ * The health of one outbound link, derived at read time and never stored — which is what
+ * makes a restore free: it flips inbound links back to `normal` with no write.
+ */
+export type LinkTargetState = 'normal' | 'trashed' | 'broken';

--- a/apps/app/src/features/backlinks/server/models/page-link.integ.ts
+++ b/apps/app/src/features/backlinks/server/models/page-link.integ.ts
@@ -1,0 +1,165 @@
+import mongoose, { Types } from 'mongoose';
+
+import { prisma } from '~/utils/prisma';
+
+import { ensurePageLinkIndexes } from './page-link-indexes';
+
+// pagelinks is prisma-only, and the harness skips migrations on the in-memory
+// MongoDB, so the indexes have to be applied here.
+beforeAll(async () => {
+  const db = mongoose.connection.db;
+  if (db == null) throw new Error('no mongoose connection');
+  await ensurePageLinkIndexes(db);
+});
+
+describe('removeLinksForPages (integration)', () => {
+  // Reads the whole collection, not just the rows expected to change — otherwise an
+  // over-broad filter would pass.
+  const allRows = async () => {
+    const rows = await prisma.pagelinks.findMany({
+      select: { fromPageId: true, toPath: true, toPageId: true },
+      orderBy: [{ fromPageId: 'asc' }, { toPath: 'asc' }],
+    });
+    return rows;
+  };
+
+  beforeEach(async () => {
+    await prisma.pagelinks.deleteMany({});
+  });
+
+  it('deletes the gone pages outbound rows and nulls inbound caches pointing at them', async () => {
+    const gone = new Types.ObjectId();
+    const survivor = new Types.ObjectId();
+
+    await prisma.pagelinks.createMany({
+      data: [
+        { fromPageId: gone.toString(), toPath: '/target-a', toPageId: null },
+        {
+          fromPageId: gone.toString(),
+          toPath: '/target-b',
+          toPageId: survivor.toString(),
+        },
+        {
+          fromPageId: survivor.toString(),
+          toPath: '/gone',
+          toPageId: gone.toString(),
+        },
+      ],
+    });
+
+    await prisma.pagelinks.removeLinksForPages([gone]);
+
+    expect(await allRows()).toEqual([
+      // toPath survives; only the cache is cleared, which is what makes it `broken`
+      {
+        fromPageId: survivor.toString(),
+        toPath: '/gone',
+        toPageId: null,
+      },
+    ]);
+  });
+
+  it('leaves rows unrelated to the given pages untouched', async () => {
+    const gone = new Types.ObjectId();
+    const other = new Types.ObjectId();
+    const otherTarget = new Types.ObjectId();
+
+    await prisma.pagelinks.createMany({
+      data: [
+        { fromPageId: gone.toString(), toPath: '/x', toPageId: null },
+        {
+          fromPageId: other.toString(),
+          toPath: '/y',
+          toPageId: otherTarget.toString(),
+        },
+      ],
+    });
+
+    await prisma.pagelinks.removeLinksForPages([gone]);
+
+    expect(await allRows()).toEqual([
+      {
+        fromPageId: other.toString(),
+        toPath: '/y',
+        toPageId: otherTarget.toString(),
+      },
+    ]);
+  });
+
+  it('handles a batch, including a row that is both a gone source and a gone target', async () => {
+    const goneA = new Types.ObjectId();
+    const goneB = new Types.ObjectId();
+    const survivor = new Types.ObjectId();
+
+    await prisma.pagelinks.createMany({
+      data: [
+        // Both gone: deleted rather than nulled, so no orphan row is left behind
+        {
+          fromPageId: goneA.toString(),
+          toPath: '/gone-b',
+          toPageId: goneB.toString(),
+        },
+        {
+          fromPageId: survivor.toString(),
+          toPath: '/gone-a',
+          toPageId: goneA.toString(),
+        },
+        {
+          fromPageId: survivor.toString(),
+          toPath: '/gone-b',
+          toPageId: goneB.toString(),
+        },
+      ],
+    });
+
+    await prisma.pagelinks.removeLinksForPages([goneA, goneB]);
+
+    expect(await allRows()).toEqual([
+      { fromPageId: survivor.toString(), toPath: '/gone-a', toPageId: null },
+      { fromPageId: survivor.toString(), toPath: '/gone-b', toPageId: null },
+    ]);
+  });
+
+  it('is idempotent', async () => {
+    const gone = new Types.ObjectId();
+    const survivor = new Types.ObjectId();
+
+    await prisma.pagelinks.createMany({
+      data: [
+        { fromPageId: gone.toString(), toPath: '/x', toPageId: null },
+        {
+          fromPageId: survivor.toString(),
+          toPath: '/gone',
+          toPageId: gone.toString(),
+        },
+      ],
+    });
+
+    await prisma.pagelinks.removeLinksForPages([gone]);
+    const afterFirst = await allRows();
+    await prisma.pagelinks.removeLinksForPages([gone]);
+
+    expect(await allRows()).toEqual(afterFirst);
+  });
+
+  // Pins the contract, not the guard clause — `$in: []` matches nothing, so this stays
+  // green without the early return (verified by mutation). It catches a filter that
+  // stopped narrowing by id.
+  it('writes nothing when given no page ids', async () => {
+    const from = new Types.ObjectId();
+    const to = new Types.ObjectId();
+    await prisma.pagelinks.create({
+      data: {
+        fromPageId: from.toString(),
+        toPath: '/kept',
+        toPageId: to.toString(),
+      },
+    });
+
+    await prisma.pagelinks.removeLinksForPages([]);
+
+    expect(await allRows()).toEqual([
+      { fromPageId: from.toString(), toPath: '/kept', toPageId: to.toString() },
+    ]);
+  });
+});

--- a/apps/app/src/features/backlinks/server/models/page-link.ts
+++ b/apps/app/src/features/backlinks/server/models/page-link.ts
@@ -97,6 +97,49 @@ export const extension = Prisma.defineExtension((client) => {
         },
 
         /**
+         * Delete the given pages' outbound rows, and null any inbound cache pointing at
+         * them (which is what makes those rows' derived state `broken`).
+         *
+         * Low-level primitive: writes unconditionally. The trashed-vs-gone decision is
+         * the reconcile service's — a merely-trashed page needs no write at all, since
+         * its derived state already reads `trashed`. Do NOT call this from event handlers.
+         */
+        async removeLinksForPages(pageIds: Types.ObjectId[]): Promise<void> {
+          // Only saves two no-op round trips; the filters below narrow by id either way.
+          if (pageIds.length === 0) {
+            return;
+          }
+
+          const ids = pageIds.map((id) => id.toString());
+
+          // Outbound first: these rows have lost their source, so they are the ones a
+          // reader could still surface as a phantom backlink. Ids need no validation
+          // here or below — each is stringified then cast (or `$oid`-wrapped), so an
+          // operator object from an untyped caller degrades to a malformed id.
+          await client.pagelinks.deleteMany({
+            where: { fromPageId: { in: ids } },
+          });
+
+          // Raw because the query API cannot express this at all: `pagelinks.updateMany`
+          // accepts only `toPath` in `data` (relation scalars are not settable), and
+          // `utils/prisma.ts` injects `v: { increment: 1 }` into every update — a field
+          // this collection lacks. That block leaves `deleteMany` alone, hence the split.
+          //
+          // Clears only the cache; `toPath` stays faithful to the body.
+          const result = await client.$runCommandRaw({
+            update: 'pagelinks',
+            updates: [
+              {
+                q: { toPage: { $in: ids.map((id) => ({ $oid: id })) } },
+                u: { $set: { toPage: null } },
+                multi: true,
+              },
+            ],
+          });
+          throwOnWriteErrors(result, 'removeLinksForPages');
+        },
+
+        /**
          * Point every row whose `toPath` field equals `toPath` at `toPage` (null =
          * broken). One bulk update, matched by text — not per-source-page.
          *

--- a/apps/app/src/features/backlinks/server/models/page-link.ts
+++ b/apps/app/src/features/backlinks/server/models/page-link.ts
@@ -103,6 +103,13 @@ export const extension = Prisma.defineExtension((client) => {
          * Low-level primitive: writes unconditionally. The trashed-vs-gone decision is
          * the reconcile service's — a merely-trashed page needs no write at all, since
          * its derived state already reads `trashed`. Do NOT call this from event handlers.
+         *
+         * Precondition: `pageIds` is an already-batched set. Both writes send the whole
+         * array in a single command, so an unbounded one approaches MongoDB's 16MB
+         * command cap and is then rejected whole (the write throws; rows stay stale
+         * until the next save or a backfill). Every recursive delete path in PageService
+         * funnels through `createBatchStream(BULK_REINDEX_SIZE)`, so today's callers
+         * cannot exceed 100 — a caller that assembles ids some other way must chunk.
          */
         async removeLinksForPages(pageIds: Types.ObjectId[]): Promise<void> {
           // Only saves two no-op round trips; the filters below narrow by id either way.

--- a/apps/app/src/features/backlinks/server/services/link-target-state.spec.ts
+++ b/apps/app/src/features/backlinks/server/services/link-target-state.spec.ts
@@ -1,0 +1,39 @@
+import { PageStatus } from '@growi/core';
+import { Types } from 'mongoose';
+
+import { deriveLinkTargetState } from './link-target-state';
+
+describe('deriveLinkTargetState', () => {
+  const target = new Types.ObjectId();
+
+  it('reports an unresolved row as broken', () => {
+    expect(deriveLinkTargetState(null, null)).toBe('broken');
+  });
+
+  it('reports a resolved row whose target is in the trash as trashed', () => {
+    expect(deriveLinkTargetState(target, PageStatus.STATUS_DELETED)).toBe(
+      'trashed',
+    );
+  });
+
+  it('reports a resolved row whose target is published as normal', () => {
+    expect(deriveLinkTargetState(target, PageStatus.STATUS_PUBLISHED)).toBe(
+      'normal',
+    );
+  });
+
+  // A v4-era page has no `status` field, and the trashed filter counts that as published.
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+  ])('treats a %s status as normal, not trashed', (_label, status) => {
+    expect(deriveLinkTargetState(target, status)).toBe('normal');
+  });
+
+  // A stale status from a caller must not turn a broken row into a trashed one.
+  it('reports broken even when a target status is supplied', () => {
+    expect(deriveLinkTargetState(null, PageStatus.STATUS_DELETED)).toBe(
+      'broken',
+    );
+  });
+});

--- a/apps/app/src/features/backlinks/server/services/link-target-state.ts
+++ b/apps/app/src/features/backlinks/server/services/link-target-state.ts
@@ -1,0 +1,24 @@
+import { PageStatus } from '@growi/core';
+import type { Types } from 'mongoose';
+
+import type { LinkTargetState } from '../../interfaces/backlink';
+
+/**
+ * Derive one outbound link's target state. Nothing is stored, so a restore needs no write.
+ *
+ * The caller must already have established that `toPage`'s page exists and is readable —
+ * a row whose target was not found is *omitted* from a health read, never derived (see
+ * `find-forward-link-health`). A `null`/`undefined` status is a v4-era page, which
+ * `addConditionToExcludeTrashed` counts as published.
+ */
+export const deriveLinkTargetState = (
+  toPage: Types.ObjectId | null,
+  targetStatus: string | null | undefined,
+): LinkTargetState => {
+  // Outranks the status check: with no cached target, a status describes no page.
+  if (toPage == null) {
+    return 'broken';
+  }
+
+  return targetStatus === PageStatus.STATUS_DELETED ? 'trashed' : 'normal';
+};


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/185826
┗ https://redmine.weseek.co.jp/issues/189206

Implements **B5.1** of the backlinks spec, plus the spec corrections that had to land with it. Two commits: the spec update, then the code.

Base is `feat/185872-backlinks`. The branch was cut before the Prisma model landed, so it was fast-forwarded through `feat/188157-re-resolve-by-path-sync` first — which also avoided clobbering the newer B5.4 self-row note and `repointInboundLinks` design block that did not exist at the original cut point. `feat/188157` has since merged into this base (#11656).

---

## Code (commit 2)

### `removeLinksForPages(pageIds)` — named for the mechanism, not the decision

The spec called this `reconcileDeletedPages`, but "reconcile" describes the trashed-vs-gone *check*, which lives one layer up in B5.2's service op. Both siblings are named for their write and documented as low-level primitives, so this one follows suit:

| Model primitive (writes) | Service (decides) |
|---|---|
| `replaceOutboundLinks` | `syncOutboundLinks` — drops self-links |
| `repointInboundLinks` | `reResolveByToPath` — resolves the target |
| **`removeLinksForPages`** ← new | `reconcileDeletedPages` (B5.2) — trashed vs. gone |

The service keeps the `reconcileDeletedPages` name. Both names now exist on purpose; design.md says so.

It does two writes: delete the gone pages' outbound rows (`fromPage $in ids`), then null every inbound cache pointing at them (`toPage $in ids` → `toPage: null`), which is what makes those rows read as `broken`. Outbound goes first — those rows have lost their source and are the ones a reader could still surface as a phantom backlink. No new index: both filters ride `fromPage_1_toPath_1` (by prefix) and `toPage_1`.

### The two halves cannot share an API — and this is worth knowing beyond this PR

The spec's first draft said to prefer the Prisma query API for both halves since neither needs a pipeline update. **That is wrong, and I measured it rather than assuming.** `prisma.pagelinks.updateMany` fails with `PrismaClientValidationError` for two independent reasons:

```
data: {
  toPageId: null,
  ~~~~~~~~
  v: { increment: 1 },
?   toPath?: String | StringFieldUpdateOperationsInput
}
Unknown argument `toPageId`. Available options are marked with ?.
```

1. `pagelinks`' generated `updateMany` data input accepts **only `toPath`** — the relation scalars are not settable through it, and neither is the relation (`toPage: { disconnect: true }` → `Unknown argument 'toPage'`).
2. `utils/prisma.ts`'s client-wide `query.$allModels.updateMany` extension injects `v: { increment: 1 }` for mongoose optimistic-concurrency parity — a field this prisma-only collection deliberately does not have (see the schema comment).

So **any** update on `pagelinks` through the query API is a validation error, independent of whether a pipeline update is needed. The inbound half uses `$runCommandRaw` + `throwOnWriteErrors` like the other raw writes here. The delete half stays on `deleteMany` because that same `$allModels` block wraps only `update`/`updateMany` — a delete passes through untouched.

No `v`-less prisma-only model (`pagelinks`, `auditlog_es_sync_status`, `changestream_resume_tokens`) had ever been written through `updateMany`, so this trap was entirely unexercised. It is now recorded in design.md.

### `deriveLinkTargetState` — pure, on the read path

`toPage == null` → `broken` (outranking any status passed alongside, since there is no page for one to describe); target status `deleted` → `trashed`; otherwise `normal`. It lives in `server/services/link-target-state.ts`, **not** `page-link-sync`: nothing on the write path derives this, and B5.4 will fold it into the grant-filtered target query it already has to issue.

A `null`/`undefined` status is a v4-era page, which `addConditionToExcludeTrashed` counts as published — so it derives `normal`, not `trashed`. That case is pinned by a test.

### Tests

Row-level integration test (the observable contract is which rows survive), plus a unit spec for the pure helper. **Mutation-checked** — an over-broad `deleteMany` filter fails 3 of the 5 cases, an over-broad update filter fails the "leaves unrelated rows untouched" case.

Also verified honestly: the empty-batch test pins the *contract* but not the guard clause, because `$in: []` matches nothing either way. Deleting the early return keeps the suite green. Both the code comment and the test comment say so rather than implying the guard is load-bearing — it exists to skip two no-op round trips.

---

## Spec corrections (commit 1)

- **B5.1 was written for Mongoose.** design.md had zero occurrences of "prisma" and asserted `autoIndex` in seven places, including a "No migration" heading that is now false — `pagelinks` is prisma-only, nothing runs `prisma db push`, and the indexes come from `20260901064500-add-indexes-to-pagelinks.js`. Also fixed: the index list said four (there are three — no standalone `fromPage_1`), and the hook summary still claimed `useSWRImmutable`. B1.2 gets a supersession note rather than a rewrite, since it shipped.
- **B5.4 now folds the `trashed` derivation into the query it already issues.** It has to read the target pages anyway for the grant filter (the leak fix) — same documents, so one query, not two round trips. It cannot reuse `buildVisibleSourcesQuery`, which calls `addConditionToExcludeTrashed()`; trashed targets are precisely what that read reports.
- **`ILinkTarget.pageId` becomes `string | null`.** A `broken` row *is* `toPage == null`, so the required-`string` version was unsatisfiable for the one case the read exists to surface. Propagated to B5.5: a broken row's path renders unlinked.
- **New task B5.9 — work that was unassigned.** B5.4 produced `ILinkTarget[]` and B5.6 rendered it, but nothing carried it across the wire; no task added the route field or the hook, so B5.6 had no data source. B5.9 extends the existing `GET /_api/v3/page/backlinks` rather than adding a route — same `pageId`, same viewer, same 403, and the panel renders both sections, so a second endpoint buys a second round trip for no independent cacheability. It is numbered out of sequence because B5.5–B5.8 are cross-referenced by number from completed B1 tasks.

---

## Verification

- `pnpm vitest run src/features/backlinks` (excluding component specs) — **172 passed**, 16 files
- `pnpm run lint:typecheck` — clean
- `pnpm run lint:biome` — clean (2464 files)
- `pnpm run lint:import-convention` — clean

The three `client/` component specs (`BacklinkListItem`, `BacklinksPanel`, `stores/backlinks`) fail to load with `Cannot find module 'react'` from inside `@testing-library/react`. **Pre-existing and unrelated** — verified by stashing these changes and reproducing it; no client code is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)