### PR TITLE
fix(page-bulk-export): Embed attachment images in exported PDFs (RELAY mode)

### DIFF
--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/embed-images.spec.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/embed-images.spec.ts
@@ -1,0 +1,200 @@
+/**
+ * Unit tests for embedAttachmentImages.
+ *
+ * Observable contract verified here:
+ *  - Attachment `<img>` sources are only rewritten when the exporting user
+ *    can access the page the attachment belongs to (permission bypass fix).
+ *  - A stream error while downloading an attachment does not leave a
+ *    truncated asset file behind that a later reference would treat as
+ *    "already downloaded".
+ *  - Non-RELAY response modes and html with no attachment references are
+ *    left untouched.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import type { IUser } from '@growi/core';
+import type { HydratedDocument } from 'mongoose';
+import { mock } from 'vitest-mock-extended';
+
+import type Crowi from '~/server/crowi';
+import { ResponseMode } from '~/server/interfaces/attachment';
+import {
+  Attachment,
+  type IAttachmentDocument,
+} from '~/server/models/attachment';
+import { isAttachmentAccessibleToViewer } from '~/server/service/attachment/resolve-accessible-attachment';
+import type { FileUploader } from '~/server/service/file-uploader/file-uploader';
+
+import { embedAttachmentImages } from './embed-images';
+
+vi.mock('~/server/models/attachment', () => ({
+  Attachment: { find: vi.fn() },
+}));
+
+vi.mock('~/server/service/attachment/resolve-accessible-attachment', () => ({
+  isAttachmentAccessibleToViewer: vi.fn(),
+}));
+
+describe('embedAttachmentImages', () => {
+  const attachmentId = '000000000000000000000001';
+  const exportingUser = mock<HydratedDocument<IUser>>();
+  let outputDir: string;
+
+  beforeEach(async () => {
+    outputDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'embed-images-spec-'),
+    );
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(outputDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  const buildCrowi = (fileUploadService: FileUploader): Crowi =>
+    mock<Crowi>({ fileUploadService });
+
+  const htmlWithAttachment = (id: string) =>
+    `<p><img src="/attachment/${id}" alt=""></p>`;
+
+  it('returns the html unchanged when it has no attachment image references', async () => {
+    const html = '<p>no images here</p>';
+    const crowi = buildCrowi(mock<FileUploader>());
+
+    const result = await embedAttachmentImages(html, {
+      fileOutputPath: path.join(outputDir, 'page.html'),
+      outputDir,
+      crowi,
+      exportingUser,
+    });
+
+    expect(result).toBe(html);
+    expect(Attachment.find).not.toHaveBeenCalled();
+  });
+
+  it('leaves the html unchanged for non-RELAY response modes', async () => {
+    const fileUploadService = mock<FileUploader>({
+      determineResponseMode: vi.fn().mockReturnValue(ResponseMode.REDIRECT),
+    });
+    const crowi = buildCrowi(fileUploadService);
+    const html = htmlWithAttachment(attachmentId);
+
+    const result = await embedAttachmentImages(html, {
+      fileOutputPath: path.join(outputDir, 'page.html'),
+      outputDir,
+      crowi,
+      exportingUser,
+    });
+
+    expect(result).toBe(html);
+    expect(Attachment.find).not.toHaveBeenCalled();
+  });
+
+  it('does not embed an attachment the exporting user cannot access', async () => {
+    const attachment = mock<IAttachmentDocument>({
+      _id: attachmentId,
+      fileName: 'secret.png',
+      page: '000000000000000000000099',
+    });
+    vi.mocked(Attachment.find).mockResolvedValue([attachment]);
+    vi.mocked(isAttachmentAccessibleToViewer).mockResolvedValue(false);
+    const findDeliveryFile = vi.fn();
+    const fileUploadService = mock<FileUploader>({
+      determineResponseMode: vi.fn().mockReturnValue(ResponseMode.RELAY),
+      findDeliveryFile,
+    });
+    const crowi = buildCrowi(fileUploadService);
+    const html = htmlWithAttachment(attachmentId);
+
+    const result = await embedAttachmentImages(html, {
+      fileOutputPath: path.join(outputDir, 'page.html'),
+      outputDir,
+      crowi,
+      exportingUser,
+    });
+
+    expect(result).toBe(html);
+    expect(findDeliveryFile).not.toHaveBeenCalled();
+    expect(isAttachmentAccessibleToViewer).toHaveBeenCalledWith(
+      attachment,
+      exportingUser,
+      false,
+    );
+  });
+
+  it('downloads and rewrites the src for an accessible attachment', async () => {
+    const attachment = mock<IAttachmentDocument>({
+      _id: attachmentId,
+      fileName: 'photo.png',
+      page: '000000000000000000000099',
+    });
+    vi.mocked(Attachment.find).mockResolvedValue([attachment]);
+    vi.mocked(isAttachmentAccessibleToViewer).mockResolvedValue(true);
+    const fileUploadService = mock<FileUploader>({
+      determineResponseMode: vi.fn().mockReturnValue(ResponseMode.RELAY),
+      findDeliveryFile: vi
+        .fn()
+        .mockResolvedValue(Readable.from(Buffer.from('binary-image-data'))),
+    });
+    const crowi = buildCrowi(fileUploadService);
+    const fileOutputPath = path.join(outputDir, 'page.html');
+
+    const result = await embedAttachmentImages(
+      htmlWithAttachment(attachmentId),
+      { fileOutputPath, outputDir, crowi, exportingUser },
+    );
+
+    expect(result).not.toContain(`/attachment/${attachmentId}`);
+    expect(Attachment.find).toHaveBeenCalledWith({
+      _id: { $in: [attachmentId] },
+    });
+    const assetFilePath = path.join(
+      outputDir,
+      '_bulk-export-assets',
+      `${attachmentId}.png`,
+    );
+    await expect(fs.promises.readFile(assetFilePath, 'utf-8')).resolves.toBe(
+      'binary-image-data',
+    );
+  });
+
+  it('does not leave a truncated asset file behind when the download stream errors', async () => {
+    const attachment = mock<IAttachmentDocument>({
+      _id: attachmentId,
+      fileName: 'photo.png',
+      page: '000000000000000000000099',
+    });
+    vi.mocked(Attachment.find).mockResolvedValue([attachment]);
+    vi.mocked(isAttachmentAccessibleToViewer).mockResolvedValue(true);
+
+    const failingReadable = new Readable({
+      read() {
+        this.destroy(new Error('boom'));
+      },
+    });
+    const fileUploadService = mock<FileUploader>({
+      determineResponseMode: vi.fn().mockReturnValue(ResponseMode.RELAY),
+      findDeliveryFile: vi.fn().mockResolvedValue(failingReadable),
+    });
+    const crowi = buildCrowi(fileUploadService);
+    const html = htmlWithAttachment(attachmentId);
+
+    const result = await embedAttachmentImages(html, {
+      fileOutputPath: path.join(outputDir, 'page.html'),
+      outputDir,
+      crowi,
+      exportingUser,
+    });
+
+    // The failure is caught and logged; the src is left untouched (best effort).
+    expect(result).toBe(html);
+    const assetFilePath = path.join(
+      outputDir,
+      '_bulk-export-assets',
+      `${attachmentId}.png`,
+    );
+    expect(fs.existsSync(assetFilePath)).toBe(false);
+  });
+});

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/embed-images.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/embed-images.ts
@@ -1,9 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
-import { getIdStringForRef, type IPage, type IUser } from '@growi/core';
+import type { IUser } from '@growi/core';
 import type { HydratedDocument } from 'mongoose';
-import mongoose from 'mongoose';
 
 import type Crowi from '~/server/crowi';
 import { ResponseMode } from '~/server/interfaces/attachment';
@@ -11,19 +10,10 @@ import {
   Attachment,
   type IAttachmentDocument,
 } from '~/server/models/attachment';
+import { isAttachmentAccessibleToViewer } from '~/server/service/attachment/resolve-accessible-attachment';
 import loggerFactory from '~/utils/logger';
 
 const logger = loggerFactory('growi:features:page-bulk-export:embed-images');
-
-// TODO: remove this local interface when models/page has typescriptized
-// (see the identical TODO in apps/app/src/server/routes/attachment/get.ts,
-// whose permission check this mirrors).
-interface PageModel {
-  isAccessiblePageByViewer: (
-    pageId: string,
-    user: HydratedDocument<IUser> | undefined,
-  ) => Promise<boolean>;
-}
 
 /**
  * Matches `<img ... src="/attachment/<24-char hex id>" ...>` — the app-root
@@ -62,14 +52,13 @@ const ASSETS_DIRNAME = '_bulk-export-assets';
  * but the page still converts). See growilabs/growi#<ISSUE_NUMBER> for
  * background and follow-up on those modes.
  *
- * Mirrors the same page-viewer permission check the `/attachment/:id` route
- * enforces (see retrieveAttachmentFromIdParam in
- * apps/app/src/server/routes/attachment/get.ts): an attachment ID parsed out
- * of the rendered HTML could belong to a different, private page the
- * exporting user isn't allowed to read, so each attachment's `page` is
- * checked via `Page.isAccessiblePageByViewer` before it is fetched/embedded.
- * Attachments with no `page` (e.g. profile images) skip this check, same as
- * the attachment route does.
+ * Reuses `isAttachmentAccessibleToViewer` — the same page-viewer permission
+ * check the `/attachment/:id` route enforces via `resolveAccessibleAttachment`
+ * (see retrieveAttachmentFromIdParam in apps/app/src/server/routes/attachment/get.ts):
+ * an attachment ID parsed out of the rendered HTML could belong to a
+ * different, private page the exporting user isn't allowed to read, so each
+ * attachment is checked before it is fetched/embedded. Attachments with no
+ * `page` (e.g. profile images) skip this check, same as the attachment route.
  */
 export async function embedAttachmentImages(
   htmlString: string,
@@ -115,8 +104,6 @@ export async function embedAttachmentImages(
     attachments.map((a) => [a._id.toString(), a]),
   );
 
-  const Page = mongoose.model<IPage, PageModel>('Page');
-
   const replacements = new Map<string, string>();
 
   await Promise.all(
@@ -125,19 +112,17 @@ export async function embedAttachmentImages(
         const attachment = attachmentById.get(id);
         if (attachment == null) return;
 
-        if (attachment.page != null) {
-          const isAccessible = await Page.isAccessiblePageByViewer(
-            getIdStringForRef(attachment.page),
-            exportingUser,
+        const isAccessible = await isAttachmentAccessibleToViewer(
+          attachment,
+          exportingUser,
+          false,
+        );
+        if (!isAccessible) {
+          logger.warn(
+            "Skipping attachment %s for bulk export: exporting user can't access the page it belongs to.",
+            id,
           );
-          if (!isAccessible) {
-            logger.warn(
-              "Skipping attachment %s for bulk export: exporting user can't " +
-                'access the page it belongs to.',
-              id,
-            );
-            return;
-          }
+          return;
         }
 
         const assetFileName = `${id}${path.extname(attachment.fileName ?? '')}`;

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/embed-images.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/embed-images.ts
@@ -1,0 +1,127 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type Crowi from '~/server/crowi';
+import { ResponseMode } from '~/server/interfaces/attachment';
+import { Attachment } from '~/server/models/attachment';
+import loggerFactory from '~/utils/logger';
+
+const logger = loggerFactory('growi:features:page-bulk-export:embed-images');
+
+/**
+ * Matches `<img ... src="/attachment/<24-char hex id>" ...>` — the app-root
+ * relative path GROWI's web renderer emits for attachment images (see
+ * apps/app/src/server/routes/attachment/get.ts's `/:id([0-9a-z]{24})` route).
+ *
+ * pdf-converter opens the exported HTML via `file://` (see
+ * apps/pdf-converter/src/service/pdf-convert.ts), which has no origin to
+ * resolve an app-root-relative path against, so these must be rewritten
+ * before the HTML is written to disk (Requirement: images must render in
+ * the exported PDF, not just links/text).
+ */
+const ATTACHMENT_IMG_SRC = /src="\/attachment\/([0-9a-z]{24})"/g;
+
+/**
+ * Directory (relative to a job's html output dir) that downloaded/relayed
+ * attachment images are written into. Mirrors `_bulk-export.css`'s
+ * leading-underscore convention so pdf-converter's `*.html`-only scan never
+ * mistakes these for pages.
+ */
+const ASSETS_DIRNAME = '_bulk-export-assets';
+
+/**
+ * Rewrite `/attachment/<id>` image sources in `htmlString` to something
+ * `pdf-converter`'s `file://` navigation can actually load. Only handles
+ * RELAY-mode storage (the local filesystem and GridFS `fileUploadService`
+ * implementations): the attachment's bytes are fetched server-side (this
+ * runs inside the `app` process, which already has full access to
+ * fileUploadService — no HTTP round-trip or session cookie needed) and
+ * saved once per job into `ASSETS_DIRNAME` on the shared
+ * `page_bulk_export_tmp` volume; the `src` becomes a relative path to that
+ * local copy, same pattern as the shared CSS file.
+ *
+ * REDIRECT-mode (S3/GCS) and DELEGATE-mode storage are not handled here and
+ * are left as-is (best effort — the image will be missing from the PDF,
+ * but the page still converts). See growilabs/growi#<ISSUE_NUMBER> for
+ * background and follow-up on those modes.
+ *
+ * @param htmlString rendered page HTML, before it is written to fileOutputPath
+ * @param fileOutputPath absolute path the HTML will be written to (used to
+ *   compute the relative href to `ASSETS_DIRNAME`)
+ * @param outputDir the job's html output dir (ASSETS_DIRNAME lives directly
+ *   under this, once per job — shared across pages, like the CSS file)
+ * @param crowi crowi instance (for fileUploadService + Attachment lookups)
+ */
+export async function embedAttachmentImages(
+  htmlString: string,
+  fileOutputPath: string,
+  outputDir: string,
+  crowi: Crowi,
+): Promise<string> {
+  const matches = [...htmlString.matchAll(ATTACHMENT_IMG_SRC)];
+  if (matches.length === 0) {
+    return htmlString;
+  }
+
+  const { fileUploadService } = crowi;
+  if (fileUploadService.determineResponseMode() !== ResponseMode.RELAY) {
+    // REDIRECT (S3/GCS) and DELEGATE modes aren't handled yet; leave the
+    // HTML untouched rather than guess.
+    return htmlString;
+  }
+
+  const assetsDir = path.join(outputDir, ASSETS_DIRNAME);
+
+  // De-dupe: the same attachment can appear more than once on a page.
+  const uniqueIds = [...new Set(matches.map((m) => m[1]))];
+
+  const replacements = new Map<string, string>();
+
+  await Promise.all(
+    uniqueIds.map(async (id) => {
+      try {
+        const attachment = await Attachment.findById(id);
+        if (attachment == null) return;
+
+        const readable = await fileUploadService.findDeliveryFile(attachment);
+        const assetFileName = `${id}${path.extname(attachment.fileName ?? '')}`;
+        const assetFilePath = path.join(assetsDir, assetFileName);
+
+        // Written once per job; subsequent pages reusing the same
+        // attachment just reference the already-written file.
+        if (!fs.existsSync(assetFilePath)) {
+          await fs.promises.mkdir(assetsDir, { recursive: true });
+          const writeStream = fs.createWriteStream(assetFilePath);
+          await new Promise<void>((resolve, reject) => {
+            readable.pipe(writeStream);
+            writeStream.on('finish', resolve);
+            writeStream.on('error', reject);
+            readable.on('error', reject);
+          });
+        }
+
+        const relativeHref = path
+          .relative(path.dirname(fileOutputPath), assetFilePath)
+          .split(path.sep)
+          .map(encodeURIComponent)
+          .join('/');
+        replacements.set(id, relativeHref);
+      } catch (err) {
+        logger.warn(
+          'Failed to embed attachment image %s for bulk export: %o',
+          id,
+          err,
+        );
+      }
+    }),
+  );
+
+  if (replacements.size === 0) {
+    return htmlString;
+  }
+
+  return htmlString.replace(ATTACHMENT_IMG_SRC, (fullMatch, id) => {
+    const replacement = replacements.get(id);
+    return replacement != null ? `src="${replacement}"` : fullMatch;
+  });
+}

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/embed-images.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/embed-images.ts
@@ -1,12 +1,29 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { getIdStringForRef, type IPage, type IUser } from '@growi/core';
+import type { HydratedDocument } from 'mongoose';
+import mongoose from 'mongoose';
 
 import type Crowi from '~/server/crowi';
 import { ResponseMode } from '~/server/interfaces/attachment';
-import { Attachment } from '~/server/models/attachment';
+import {
+  Attachment,
+  type IAttachmentDocument,
+} from '~/server/models/attachment';
 import loggerFactory from '~/utils/logger';
 
 const logger = loggerFactory('growi:features:page-bulk-export:embed-images');
+
+// TODO: remove this local interface when models/page has typescriptized
+// (see the identical TODO in apps/app/src/server/routes/attachment/get.ts,
+// whose permission check this mirrors).
+interface PageModel {
+  isAccessiblePageByViewer: (
+    pageId: string,
+    user: HydratedDocument<IUser> | undefined,
+  ) => Promise<boolean>;
+}
 
 /**
  * Matches `<img ... src="/attachment/<24-char hex id>" ...>` — the app-root
@@ -45,18 +62,35 @@ const ASSETS_DIRNAME = '_bulk-export-assets';
  * but the page still converts). See growilabs/growi#<ISSUE_NUMBER> for
  * background and follow-up on those modes.
  *
- * @param htmlString rendered page HTML, before it is written to fileOutputPath
- * @param fileOutputPath absolute path the HTML will be written to (used to
- *   compute the relative href to `ASSETS_DIRNAME`)
- * @param outputDir the job's html output dir (ASSETS_DIRNAME lives directly
- *   under this, once per job — shared across pages, like the CSS file)
- * @param crowi crowi instance (for fileUploadService + Attachment lookups)
+ * Mirrors the same page-viewer permission check the `/attachment/:id` route
+ * enforces (see retrieveAttachmentFromIdParam in
+ * apps/app/src/server/routes/attachment/get.ts): an attachment ID parsed out
+ * of the rendered HTML could belong to a different, private page the
+ * exporting user isn't allowed to read, so each attachment's `page` is
+ * checked via `Page.isAccessiblePageByViewer` before it is fetched/embedded.
+ * Attachments with no `page` (e.g. profile images) skip this check, same as
+ * the attachment route does.
  */
 export async function embedAttachmentImages(
   htmlString: string,
-  fileOutputPath: string,
-  outputDir: string,
-  crowi: Crowi,
+  {
+    fileOutputPath,
+    outputDir,
+    crowi,
+    exportingUser,
+  }: {
+    /** absolute path the HTML will be written to (used to compute the
+     * relative href to ASSETS_DIRNAME) */
+    fileOutputPath: string;
+    /** the job's html output dir (ASSETS_DIRNAME lives directly under this,
+     * once per job — shared across pages, like the CSS file) */
+    outputDir: string;
+    /** crowi instance (for fileUploadService + Attachment lookups) */
+    crowi: Crowi;
+    /** the user who requested the export (pageBulkExportJob.user, resolved
+     * once per job by the caller) — permission checks run as this user */
+    exportingUser: HydratedDocument<IUser> | undefined;
+  },
 ): Promise<string> {
   const matches = [...htmlString.matchAll(ATTACHMENT_IMG_SRC)];
   if (matches.length === 0) {
@@ -75,15 +109,37 @@ export async function embedAttachmentImages(
   // De-dupe: the same attachment can appear more than once on a page.
   const uniqueIds = [...new Set(matches.map((m) => m[1]))];
 
+  // Batch-fetch instead of one findById per id.
+  const attachments = await Attachment.find({ _id: { $in: uniqueIds } });
+  const attachmentById = new Map<string, IAttachmentDocument>(
+    attachments.map((a) => [a._id.toString(), a]),
+  );
+
+  const Page = mongoose.model<IPage, PageModel>('Page');
+
   const replacements = new Map<string, string>();
 
   await Promise.all(
     uniqueIds.map(async (id) => {
       try {
-        const attachment = await Attachment.findById(id);
+        const attachment = attachmentById.get(id);
         if (attachment == null) return;
 
-        const readable = await fileUploadService.findDeliveryFile(attachment);
+        if (attachment.page != null) {
+          const isAccessible = await Page.isAccessiblePageByViewer(
+            getIdStringForRef(attachment.page),
+            exportingUser,
+          );
+          if (!isAccessible) {
+            logger.warn(
+              "Skipping attachment %s for bulk export: exporting user can't " +
+                'access the page it belongs to.',
+              id,
+            );
+            return;
+          }
+        }
+
         const assetFileName = `${id}${path.extname(attachment.fileName ?? '')}`;
         const assetFilePath = path.join(assetsDir, assetFileName);
 
@@ -91,13 +147,18 @@ export async function embedAttachmentImages(
         // attachment just reference the already-written file.
         if (!fs.existsSync(assetFilePath)) {
           await fs.promises.mkdir(assetsDir, { recursive: true });
+          const readable = await fileUploadService.findDeliveryFile(attachment);
           const writeStream = fs.createWriteStream(assetFilePath);
-          await new Promise<void>((resolve, reject) => {
-            readable.pipe(writeStream);
-            writeStream.on('finish', resolve);
-            writeStream.on('error', reject);
-            readable.on('error', reject);
-          });
+          try {
+            await pipeline(readable, writeStream);
+          } catch (streamErr) {
+            // Don't leave a truncated file behind — a later reference to the
+            // same attachment in this job would otherwise treat it as
+            // "already downloaded" via the fs.existsSync check above, and
+            // silently embed a corrupted image.
+            await fs.promises.rm(assetFilePath, { force: true });
+            throw streamErr;
+          }
         }
 
         const relativeHref = path

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/export-pages-to-fs-async.spec.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/export-pages-to-fs-async.spec.ts
@@ -46,6 +46,27 @@ vi.mock('../../../models/page-bulk-export-page-snapshot', () => {
 });
 
 // ---------------------------------------------------------------------------
+// getPageWritable resolves the exporting user once per job via
+// `mongoose.model('User')` (User isn't registered in this unit-test process).
+// None of the fixtures below embed an attachment image, so the returned user
+// is never read.
+// ---------------------------------------------------------------------------
+vi.mock('mongoose', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('mongoose')>();
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      model: (name: string, ...rest: unknown[]) =>
+        name === 'User'
+          ? { findById: vi.fn().mockResolvedValue(undefined) }
+          : // biome-ignore lint/suspicious/noExplicitAny: forwarding to the real mongoose.model overload set
+            (actual.default.model as any)(name, ...rest),
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/export-pages-to-fs-async.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/export-pages-to-fs-async.ts
@@ -19,6 +19,7 @@ import PageBulkExportPageSnapshot from '../../../models/page-bulk-export-page-sn
 import type { IPageBulkExportJobCronService } from '..';
 import { BulkExportJobStreamDestroyedByCleanupError } from '../errors';
 import { createBulkExportMarkdownRenderer } from '../markdown';
+import { embedAttachmentImages } from './embed-images';
 
 const logger = loggerFactory(
   'growi:features:page-bulk-export:export-pages-to-fs-async',
@@ -106,6 +107,12 @@ export async function getPageWritable(
             let htmlString: string;
             try {
               htmlString = await renderer.renderToHtml(markdownBody, cssHref);
+              htmlString = await embedAttachmentImages(
+                htmlString,
+                fileOutputPath,
+                outputDir,
+                this.crowi,
+              );
             } catch (renderErr) {
               logger.warn(
                 'BulkExportMarkdownRenderer failed for page %s: %o',

--- a/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/export-pages-to-fs-async.ts
+++ b/apps/app/src/features/page-bulk-export/server/service/page-bulk-export-job-cron/steps/export-pages-to-fs-async.ts
@@ -6,6 +6,7 @@ import {
   getParentPath,
   normalizePath,
 } from '@growi/core/dist/utils/path-utils';
+import mongoose from 'mongoose';
 
 import {
   PageBulkExportFormat,
@@ -71,6 +72,11 @@ export async function getPageWritable(
   // BulkExportMarkdownRenderer caches the unified pipeline at module level.
   const renderer = createBulkExportMarkdownRenderer();
 
+  // Resolved once per job (not per page): the user embedAttachmentImages
+  // runs its per-attachment permission check as.
+  const User = mongoose.model('User');
+  const exportingUser = await User.findById(pageBulkExportJob.user);
+
   // For pdf format, write the shared stylesheet once per job. Every page links
   // to it relatively, so the (~MB) CSS is not duplicated into each page's HTML.
   const cssFilePath = path.join(outputDir, SHARED_CSS_FILENAME);
@@ -107,12 +113,12 @@ export async function getPageWritable(
             let htmlString: string;
             try {
               htmlString = await renderer.renderToHtml(markdownBody, cssHref);
-              htmlString = await embedAttachmentImages(
-                htmlString,
+              htmlString = await embedAttachmentImages(htmlString, {
                 fileOutputPath,
                 outputDir,
-                this.crowi,
-              );
+                crowi: this.crowi,
+                exportingUser,
+              });
             } catch (renderErr) {
               logger.warn(
                 'BulkExportMarkdownRenderer failed for page %s: %o',

--- a/apps/app/src/server/service/attachment/resolve-accessible-attachment.ts
+++ b/apps/app/src/server/service/attachment/resolve-accessible-attachment.ts
@@ -16,11 +16,34 @@ export type ResolveAccessibleAttachmentResult =
   | { errorCode: 'not_found' | 'forbidden' };
 
 /**
- * Fetches an attachment by id and checks whether the viewer may access it.
+ * Checks whether the viewer may access an already-fetched attachment.
  *
  * Skips the check when the request is already certified via a valid share
  * link (isSharedPage), or when the attachment is not scoped to a page
  * (PROFILE_IMAGE, BRAND_LOGO, PAGE_BULK_EXPORT, AUDIT_LOG_BULK_EXPORT).
+ *
+ * Split out from resolveAccessibleAttachment so callers that fetch the
+ * attachment themselves (e.g. a batched `Attachment.find({ $in })`) can reuse
+ * the same permission check without a second per-id `findById`.
+ */
+export const isAttachmentAccessibleToViewer = async (
+  attachment: IAttachmentDocument,
+  user: IUser | undefined,
+  isSharedPage: boolean,
+): Promise<boolean> => {
+  if (isSharedPage || attachment.page == null) {
+    return true;
+  }
+
+  const Page = mongoose.model<IPage, PageModel>('Page');
+  return Page.isAccessiblePageByViewer(
+    getIdStringForRef(attachment.page),
+    user,
+  );
+};
+
+/**
+ * Fetches an attachment by id and checks whether the viewer may access it.
  */
 export const resolveAccessibleAttachment = async (
   attachmentId: string,
@@ -38,15 +61,13 @@ export const resolveAccessibleAttachment = async (
     return { errorCode: 'not_found' };
   }
 
-  if (!isSharedPage && attachment.page != null) {
-    const Page = mongoose.model<IPage, PageModel>('Page');
-    const isAccessible = await Page.isAccessiblePageByViewer(
-      getIdStringForRef(attachment.page),
-      user,
-    );
-    if (!isAccessible) {
-      return { errorCode: 'forbidden' };
-    }
+  const isAccessible = await isAttachmentAccessibleToViewer(
+    attachment,
+    user,
+    isSharedPage,
+  );
+  if (!isAccessible) {
+    return { errorCode: 'forbidden' };
   }
 
   return { attachment };


### PR DESCRIPTION
## Summary

Embeds attachment images into bulk-exported PDFs (RELAY storage mode). Originally contributed by @gucchy55 in #11839; merged into this integration branch to add a couple of follow-up fixes before landing on master.

- `<img src="/attachment/<id>">` references in rendered page HTML are rewritten to a local, relayed copy so `pdf-converter`'s `file://` navigation can load them.
- The exporting user's page-viewer permission is checked per attachment before it is fetched/embedded (an attachment ID parsed out of the HTML could otherwise belong to a different, private page).
- Attachment lookups are batched (`$in`) instead of one `findById` per id.
- Failed downloads clean up their partial file so a later reference in the same job doesn't treat it as already-downloaded.

## Follow-up fixes on top of #11839

- Fixed a `lint:typecheck` failure: a format-string message built via string
  concatenation broke pino v10's format-string type parsing.
- Fixed `MissingSchemaError` in `export-pages-to-fs-async.spec.ts` (the User
  model wasn't registered in the unit-test process).
- Extracted `isAttachmentAccessibleToViewer` out of
  `resolveAccessibleAttachment` so the new batched permission check reuses
  the same primitive the `/attachment/:id` route uses, instead of
  duplicating it.
- Added `embed-images.spec.ts` covering the permission check, the
  accessible download/rewrite path, and stream-error cleanup.

## Test plan

- [x] `pnpm vitest run embed-images.spec resolve-accessible-attachment.spec export-pages-to-fs-async.spec` — all pass
- [x] `biome check` / `tsgo --noEmit` on all touched files — clean
- [x] CI (Node CI for app development) green on the integration branch: https://github.com/growilabs/growi/actions/runs/33853641391

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HURo1o1Qv346Mye2hSrXGM