### PR TITLE
fix(page): keep a page on the tree when a rename fails midway

### DIFF
--- a/apps/app/src/server/service/page/index.ts
+++ b/apps/app/src/server/service/page/index.ts
@@ -725,36 +725,67 @@ class PageService implements IPageService {
     }
 
     // 1. Take target off from tree
+    //
+    // This commits `parent: null` on its own, and no mongo session wraps the steps
+    // below, so steps 2-3 are not atomic with it. Remember the original parent: if
+    // either of them throws, the page has to be put back, otherwise it is stranded
+    // off-tree at its old path and drops out of the page tree entirely -- present in
+    // the database but absent from the sidebar and from any parent-based lookup.
+    // See https://github.com/growilabs/growi/issues/9755
+    const exParentId = page.parent;
     await Page.takeOffFromTree(page._id);
 
-    // 2. Find new parent
     let newParent: PageDocument | undefined;
-    // If renaming to under target, run getParentAndforceCreateEmptyTree to fill new ancestors
-    if (this.isRenamingToUnderTarget(page.path, newPagePathSanitized)) {
-      newParent = await this.getParentAndforceCreateEmptyTree(
-        page,
-        newPagePathSanitized,
-      );
-    } else {
-      newParent = await this.getParentAndFillAncestorsByUser(
-        user,
-        newPagePathSanitized,
-      );
-    }
+    let renamedPage: PageDocument | null = null;
+    try {
+      // 2. Find new parent
+      // If renaming to under target, run getParentAndforceCreateEmptyTree to fill new ancestors
+      if (this.isRenamingToUnderTarget(page.path, newPagePathSanitized)) {
+        newParent = await this.getParentAndforceCreateEmptyTree(
+          page,
+          newPagePathSanitized,
+        );
+      } else {
+        newParent = await this.getParentAndFillAncestorsByUser(
+          user,
+          newPagePathSanitized,
+        );
+      }
 
-    // 3. Put back target page to tree (also update the other attrs)
-    const update: Partial<IPage> = {};
-    update.path = newPagePathSanitized;
-    update.parent = newParent?._id;
-    if (updateMetadata) {
-      update.lastUpdateUser = user;
-      update.updatedAt = new Date();
+      // 3. Put back target page to tree (also update the other attrs)
+      const update: Partial<IPage> = {};
+      update.path = newPagePathSanitized;
+      update.parent = newParent?._id;
+      if (updateMetadata) {
+        update.lastUpdateUser = user;
+        update.updatedAt = new Date();
+      }
+      renamedPage = await Page.findByIdAndUpdate(
+        page._id,
+        { $set: update },
+        { new: true },
+      );
+    } catch (err) {
+      // Undo step 1 only. The rename still fails and the caller still sees the
+      // error -- what changes is that the page stays where it was instead of
+      // vanishing from the tree. Steps after this block run only once step 3 has
+      // committed the new parent, so they must not be covered by this rollback.
+      try {
+        await Page.findByIdAndUpdate(page._id, {
+          $set: { parent: exParentId },
+        });
+      } catch (rollbackErr) {
+        // Log and fall through: the original error is the one worth propagating,
+        // but the page is now off-tree and needs Admin > App Settings > V5 page
+        // migration to be reattached, so that must not be swallowed silently.
+        logger.error(
+          `Failed to reattach "${page.path}" to its original parent after a failed rename. ` +
+            'The page is off-tree and will not appear in the page tree until it is normalized.',
+          rollbackErr,
+        );
+      }
+      throw err;
     }
-    const renamedPage = await Page.findByIdAndUpdate(
-      page._id,
-      { $set: update },
-      { new: true },
-    );
 
     // 5.increase parent's descendantCount.
     // see: https://dev.growi.org/62149d019311629d4ecd91cf#Handling%20of%20descendantCount%20in%20case%20of%20unexpected%20process%20interruption

--- a/apps/app/src/server/service/page/rename-orphan-invariant.integ.ts
+++ b/apps/app/src/server/service/page/rename-orphan-invariant.integ.ts
@@ -1,0 +1,146 @@
+/**
+ * Integration test for issue #9755: a rename that fails must not leave the page
+ * detached from the page tree.
+ *
+ * WHY this needs guarding: renameMainOperation performs
+ *   1. takeOffFromTree(page._id)   -- commits parent: null
+ *   2. resolve/create the new parent  -- can throw
+ *   3. findByIdAndUpdate(new path + new parent)
+ * with no mongo session and no rollback. When step 2 throws, step 1 stays committed
+ * and the page is stranded off-tree at its OLD path: invisible in the sidebar (which
+ * walks `parent`) and missed by a `pages/list` query rooted at the intended
+ * destination (which is a path-prefix match).
+ *
+ * A page in the trash is the reachable trigger: deleteNonEmptyTarget sets
+ * `status: deleted` and `parent: null` while leaving `grant` public. That state falls
+ * into a gap between two filters that disagree:
+ *   - createEmptyPagesByPaths' "already exists" filter matches on
+ *     `{$or: [{grant: PUBLIC}, {parent: {$ne: null}}, {path: '/'}]}` -- no status
+ *     check, so it treats the trashed page as existing and back-fills nothing.
+ *   - connectPageTree's addConditionToFilterByApplicableAncestors requires
+ *     `status: STATUS_PUBLISHED` in every clause, so it never re-parents it.
+ * getParentAndFillAncestorsByUser is then left with no on-tree parent to return and
+ * throws 'Failed to find the created parent by getParentAndFillAncestorsByUser'.
+ *
+ * The assertion is on observable page state after an ordinary rename call, not on the
+ * mechanism, so moving where the invariant is enforced will not break it.
+ */
+
+import type { Model } from 'mongoose';
+import mongoose from 'mongoose';
+import { vi } from 'vitest';
+
+import { getInstance } from '^/test/setup/crowi';
+
+import type Crowi from '~/server/crowi';
+import type { PageDocument, PageModel } from '~/server/models/page';
+
+describe('a failed rename must not orphan the page (#9755)', () => {
+  let crowi: Crowi;
+  let Page: PageModel;
+  // biome-ignore lint/suspicious/noExplicitAny: the User model is an untyped JS module
+  let User: Model<any>;
+  // biome-ignore lint/suspicious/noExplicitAny: no User document type is available
+  let user: any;
+
+  const base = '/test-rename-orphan';
+
+  const create = async (path: string, body: string, options = {}) => {
+    const mocked = vi
+      .spyOn(crowi.pageService, 'createSubOperation')
+      .mockReturnValue(Promise.resolve());
+    const createdPage = await crowi.pageService.create(
+      path,
+      body,
+      user,
+      options,
+    );
+    const args = mocked.mock.calls[0];
+    mocked.mockRestore();
+    await crowi.pageService.createSubOperation(
+      ...(args as Parameters<typeof crowi.pageService.createSubOperation>),
+    );
+    return createdPage;
+  };
+
+  // renameMainOperation fires renameSubOperation WITHOUT awaiting it, so a test that
+  // asserts straight after renamePage() races it. Capture and run it explicitly.
+  const rename = async (page, newPagePath: string, options = {}) => {
+    const mocked = vi
+      .spyOn(crowi.pageService, 'renameSubOperation')
+      .mockReturnValue(Promise.resolve());
+    try {
+      await crowi.pageService.renamePage(page, newPagePath, user, options, {
+        ip: '::ffff:127.0.0.1',
+        endpoint: '/_api/v3/pages/rename',
+      });
+      const args = mocked.mock.calls[0];
+      mocked.mockRestore();
+      if (args != null) {
+        await crowi.pageService.renameSubOperation(
+          ...(args as Parameters<typeof crowi.pageService.renameSubOperation>),
+        );
+      }
+      return null;
+    } catch (err) {
+      mocked.mockRestore();
+      return err as Error;
+    }
+  };
+
+  beforeAll(async () => {
+    crowi = await getInstance();
+    await crowi.configManager.updateConfig('app:isV5Compatible', true);
+
+    Page = mongoose.model<PageDocument, PageModel>('Page');
+    User = mongoose.model('User');
+
+    if ((await Page.findOne({ path: '/' })) == null) {
+      await Page.create({ path: '/', grant: Page.GRANT_PUBLIC });
+    }
+
+    user =
+      (await User.findOne({ username: 'renameOrphanUser' })) ??
+      (await User.create({
+        name: 'renameOrphanUser',
+        username: 'renameOrphanUser',
+        email: 'rename-orphan@example.com',
+      }));
+  });
+
+  afterEach(async () => {
+    // the trash copy lives under /trash<base>, so both prefixes need clearing
+    await Page.deleteMany({
+      path: { $in: [new RegExp(`^${base}`), new RegExp(`^/trash${base}`)] },
+    });
+  });
+
+  it('leaves the page on the tree when the destination parent is a trashed page', async () => {
+    await create(base, 'base body');
+    const victim = await create(`${base}/deleted-later`, 'body');
+    const target = await create(`${base}/target`, 'body');
+
+    // real deletion -> path becomes /trash<path>, status deleted, parent null,
+    // grant left public: the exact state the two filters disagree about
+    await crowi.pageService.deletePage(victim, user, {}, false, {
+      ip: '::ffff:127.0.0.1',
+      endpoint: '/_api/v3/pages/delete',
+    });
+    const trashed = await Page.findById(victim._id);
+    expect(trashed?.parent).toBeNull();
+    expect(trashed?.status).toBe('deleted');
+
+    const err = await rename(target, `${trashed?.path}/moved`);
+
+    const after = await Page.findById(target._id);
+
+    // The rename is allowed to fail. What it must not do is strand the page:
+    // whether it moved or stayed put, it must still be reachable from the tree.
+    expect(after).not.toBeNull();
+    expect(
+      after?.parent,
+      `rename failed with "${err?.message}" and left the page off-tree at ` +
+        `"${after?.path}" (parent: null) — it is now invisible in the page tree`,
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Tickets
- https://redmine.weseek.co.jp/issues/189202
- https://redmine.weseek.co.jp/issues/189754

## Summary

A failed page move (rename) could leave the page **detached from the page tree** — still in the database, but gone from the sidebar and from any parent-based lookup. To the user, the page had simply disappeared.

This adds the missing rollback so a failed rename leaves the page where it was, plus an integration test pinning the invariant.

Fixes #9755

## Root cause

`renameMainOperation` detaches the page *before* resolving its new parent:

```js
// 1. commits `parent: null`
await Page.takeOffFromTree(page._id);
// 2. resolve/create the new parent  <-- can throw
// 3. findByIdAndUpdate(new path + new parent)
```

No mongo session wraps these (there is no `startSession` / `withTransaction` anywhere in the file), so a throw in step 2 left step 1 committed and the page stranded off-tree **at its old path**. `renamePage`'s `catch` deletes the `PageOperation` and rethrows — it never restored `parent`.

That state is hard to spot, which is why the original report looked like a deletion:

| Where the user looked | Why it was not there |
|---|---|
| Sidebar page tree | built by walking `parent`; an orphan has `parent: null` |
| `pages/list?path=<destination>` | path-prefix query, but the page is still at its **old** path |
| same, from a broad root | `limit` defaults to `customize:showPageLimitationS` (10) and paginates |
| Trash | nothing was deleted, so nothing went there |
| Audit log | create + update present, no delete entry — because nothing was deleted |

### Step 2 throws without any crash

A page in the trash is one reachable trigger. `deleteNonEmptyTarget` sets `status: 'deleted'` and `parent: null` but leaves `grant` public — and that state falls into a gap between two filters that disagree about it:

- `createEmptyPagesByPaths`' "already exists" filter matches on `{$or: [{grant: PUBLIC}, {parent: {$ne: null}}, {path: '/'}]}` and **does not look at `status`**, so it treats the page as existing and back-fills nothing.
- `connectPageTree`'s `addConditionToFilterByApplicableAncestors` requires `status: STATUS_PUBLISHED` in **every** clause, so it never re-parents it.

`getParentAndFillAncestorsByUser` is then left with no on-tree parent and throws `Failed to find the created parent by getParentAndFillAncestorsByUser`.

Verified precondition matrix (run on `master`) — moving a page under a parent seeded in each state:

| Parent state | Threw? | Moved page orphaned? |
|---|---|---|
| off-tree + **public** + **status deleted** | yes | **yes** |
| off-tree + public + published | no | no (self-heals) |
| off-tree + `isEmpty` + public | no | no (self-heals) |
| **on-tree** + status deleted | no | no |
| off-tree + `GRANT_OWNER` / `GRANT_USER_GROUP` / `GRANT_RESTRICTED` | no | no — but creates a **duplicate page** at that path |

Orphaning needs all three conditions; off-tree alone self-heals because `createEmptyPagesByPaths` back-fills the gap.

## Changes

- `apps/app/src/server/service/page/index.ts` — capture the original parent before `takeOffFromTree`, and restore it if step 2 or 3 throws. The rename still fails and the caller still sees the error; what changes is that the page stays reachable from the tree.
  - The rollback covers **steps 2–3 only** — everything after them runs once step 3 has committed the new parent, so it must not be undone.
  - A failure of the rollback write itself is logged, not propagated, so it cannot mask the original error.
- `apps/app/src/server/service/page/rename-orphan-invariant.integ.ts` — new integration test. It builds the precondition through the **real** `deletePage` API (no hand-written DB state) and asserts on observable page state rather than on the mechanism, so relocating where the invariant is enforced will not break it.

This fixes the data-integrity invariant for **every** route into that window, not just the trashed-page one.

## Deliberately out of scope

- **Aligning the two filters' `status` conditions** would additionally let the rename *succeed* in the trashed-parent case rather than fail cleanly. It touches shared helpers used by page creation and by the v5 migration, so it belongs in its own change.
- **Duplicate pages at one path** (last row of the matrix): a non-public off-tree ancestor gets an empty page created over it, shadowing its content. Same `onlyMigratedAsExistingPages` filter, separate defect — worth its own issue.
- **The under-target branch is only partly protected.** When a page is moved beneath *itself*, step 2 goes through `getParentAndforceCreateEmptyTree`, which `insertMany`s the intermediate empty pages and then `bulkWrite`s their parents. Its own `throw Error('Original parent not found')` fires *before* the insert, so nothing is left behind there — but if the `bulkWrite` throws (a DB-level error), this rollback restores the target page's `parent` and those freshly inserted empty pages stay. Narrow, and strictly better than the current behaviour, but not a full undo.
- **No test covers `isRenamingToUnderTarget`.** The existing "rename/move to under …" tests move a page beneath a *different* page, which takes the `getParentAndFillAncestorsByUser` branch; the under-target branch has no coverage in the repo today, and the precondition matrix above does not exercise it either. Pre-existing gap, called out here because this change wraps that branch in the new `try`.
- **`renamedPage == null` still returns 200 OK** from `apiv3/pages/index.js` with stale data. Reachable only if the page is concurrently deleted; unchanged here.

## Test plan

- [x] `pnpm vitest run rename-orphan-invariant` — fails on `master` (RED), passes with this change (GREEN)
- [x] `pnpm vitest run v5.public-page v5.page v5.non-public-page v5.migration page.integ wip-expiration-invariant rename.integ page-redirect rename-orphan-invariant` — 179 tests across 15 files pass
- [x] `turbo run lint --filter @growi/app` — 22/22 tasks pass (includes `tsgo --noEmit` typecheck and biome)

Manual check: create `/foo` and `/target`, delete `/foo` (it becomes `/trash/foo`), then move `/target` to `/trash/foo/moved`. Before: the move errors and `/target` disappears from the sidebar while still opening by exact path. After: the move still errors, but `/target` stays in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
