### PR TITLE
fix(turbo): generate vendor-styles.prebuilt files before component tests

### DIFF
--- a/apps/app/turbo.json
+++ b/apps/app/turbo.json
@@ -98,7 +98,7 @@
     },
 
     "test": {
-      "dependsOn": ["^dev", "@growi/vault-manager#build", "pre:styles-bulk-export"],
+      "dependsOn": ["^dev", "@growi/vault-manager#build", "pre:styles-bulk-export", "dev:pre:styles-components"],
       "outputLogs": "new-only"
     },
     "test:unit": {
@@ -110,7 +110,7 @@
       "outputLogs": "new-only"
     },
     "test:components": {
-      "dependsOn": ["^dev", "pre:styles-bulk-export"],
+      "dependsOn": ["^dev", "pre:styles-bulk-export", "dev:pre:styles-components"],
       "outputLogs": "new-only"
     },
 


### PR DESCRIPTION
## Summary

- `apps/app/turbo.json`'s `test` and `test:components` tasks did not declare `dev:pre:styles-components` as a `dependsOn`, unlike `build` and `lint`, which both depend on the styles-components prebuild.
- This meant `src/**/*.vendor-styles.prebuilt.ts` (a git-ignored file generated by the Vite-based `pre:styles-components`/`dev:pre:styles-components` task) was not guaranteed to exist when Vitest's `app-components` project transformed a spec that imports a component relying on it (`GrowiEditor.vendor-styles.prebuilt`, used by `CommentEditor.tsx` and `PageEditor.tsx`).
- This was latent because no `.spec.tsx` on `master` previously imported `CommentEditor.tsx` or `PageEditor.tsx` directly. PR #11844 adds the first such test (`CommentEditor.spec.tsx`), which exposed the pre-existing gap — filed as a flaky-test observation in #11870, but it is actually a deterministic build-order bug, not a flake.

## Root Cause

```json
// apps/app/turbo.json (before)
"test:components": {
  "dependsOn": ["^dev", "pre:styles-bulk-export"],
  "outputLogs": "new-only"
},
```

`test:components` never triggers the task that generates the `.vendor-styles.prebuilt.ts` files its own specs can depend on, so Vite fails with:

```
Error: Failed to resolve import "../GrowiEditor.vendor-styles.prebuilt" from "src/client/components/PageComment/CommentEditor.tsx".
```

## Changes

- Added `dev:pre:styles-components` to the `dependsOn` array of the `test` and `test:components` tasks in `apps/app/turbo.json`, mirroring how `lint` already depends on it.
- `test:unit` and `test:integ` are intentionally left unchanged — their file globs (`**/*.spec.{ts,js}`, `**/*.integ.ts`) can never match a `.tsx` component import, so they don't need this dependency.

## Test Plan

- [x] Reproduced the exact CI failure locally by adding PR #11844's `CommentEditor.spec.tsx` to a checkout without the prebuilt vendor-styles files present.
- [x] Confirmed the fix: deleted all generated `*.vendor-styles.prebuilt.*` files, cleared the turbo cache, and ran `turbo run test:components --filter=@growi/app` from a clean state — `dev:pre:styles-components` now runs automatically and the previously-failing spec passes.
- [x] Full regression check: `turbo run test:components --filter=@growi/app` — 102 test files / 782 tests passed, no regressions.

Closes #11870

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2cafzX2EDGrDnKEsyaRh5


---
_Generated by [Claude Code](https://claude.ai/code/session_01N2cafzX2EDGrDnKEsyaRh5)_