### PR TITLE
chore(i18n-sync): trim spec-quoting comments

### DIFF
--- a/apps/app/tools/i18n-sync/diff-classifier.ts
+++ b/apps/app/tools/i18n-sync/diff-classifier.ts
@@ -1,12 +1,10 @@
 /**
- * DiffClassifier (design.md: Components and Interfaces > Sync Tooling >
- * DiffClassifier). Compares a locale namespace's leaf key paths before/after
- * a POEditor export and classifies the change as one of `no_change` /
+ * Compares a locale namespace's leaf key paths before/after a POEditor
+ * export and classifies the change as one of `no_change` /
  * `translation_only` / `structural`.
  *
- * This is a pure function with no I/O: no file reads, no network/API calls.
- * Reading files and calling POEditor is `PullTranslationSync`'s
- * responsibility, not this module's (design.md: "I/O を一切持たない").
+ * Pure function, no I/O — reading files and calling POEditor is
+ * `PullTranslationSync`'s responsibility, not this module's.
  */
 
 export type ClassificationResult =

--- a/apps/app/tools/i18n-sync/github-adapters.spec.ts
+++ b/apps/app/tools/i18n-sync/github-adapters.spec.ts
@@ -18,9 +18,9 @@ import type {
 // ---------------------------------------------------------------------------
 
 /**
- * Two deliberately dissimilar token strings. The whole point of task 3.2's
- * split between `TranslationOnlyPrPublisher` and `ApprovalReviewer` is that
- * these two never reach the same call, so every isolation assertion below is
+ * Two deliberately dissimilar token strings. The whole point of the split
+ * between `TranslationOnlyPrPublisher` and `ApprovalReviewer` is that these
+ * two never reach the same call, so every isolation assertion below is
  * written against these exact literals.
  */
 const PUBLISH_TOKEN = 'publish-token-PPPPPPPP';
@@ -119,7 +119,7 @@ describe('createTranslationOnlyPrPublisher', () => {
         BASE_SHA,
       ]);
       // `--` separates paths from revisions, and only the listed file is
-      // staged -- never `git add -A` (design.md's PR-granularity invariant).
+      // staged -- never `git add -A`.
       expect(gitCalls[2]).toEqual([
         'add',
         '--',
@@ -164,7 +164,7 @@ describe('createTranslationOnlyPrPublisher', () => {
       // the structural one, so the structural commit can find the other
       // group's files sitting in the index. It must not pick them up: that
       // would put a translation-only change into the human-review pull
-      // request (design.md's PR-granularity invariant).
+      // request.
       const calls: { command: string; args: readonly string[] }[] = [];
       const runCommand: RunCommand = (command, args) => {
         calls.push({ command, args });
@@ -373,15 +373,14 @@ describe('createTranslationOnlyPrPublisher', () => {
 });
 
 describe('createBaseRefResolver', () => {
-  it('resolves the base ref once and hands the same commit to every publisher (PR-granularity invariant)', async () => {
+  it('resolves the base ref once and hands the same commit to every publisher', async () => {
     const { translationOnly, structural, calls } = buildPublishers();
 
     // The real `main()` order: the translation-only branch is committed
     // first, then the structural one. If the structural publisher branched
     // off `HEAD` (or re-resolved it now), it would branch off the
-    // translation-only commit and carry those files into the
-    // human-review pull request -- exactly what design.md's PR-granularity
-    // invariant forbids.
+    // translation-only commit and carry those files into the human-review
+    // pull request.
     await translationOnly.publishBranch({
       headBranch: 'i18n-sync/translation-only',
       commitMessage: 'translation-only',
@@ -432,14 +431,13 @@ describe('createApprovalReviewer', () => {
     });
 
     // No method that could write repository content or change a pull
-    // request's contents may exist on the approving identity's adapter
-    // (design.md Security Considerations: the approval bot has no
-    // `contents: write`).
+    // request's contents may exist on the approving identity's adapter —
+    // the approval bot has no `contents: write`.
     expect(Object.keys(reviewer)).toEqual(['submitApprovalReview']);
   });
 });
 
-describe('approval token isolation (design.md Security Considerations)', () => {
+describe('approval token isolation', () => {
   it('sends the approval token only on the review call, and never sends the publish token there', async () => {
     const { runCommand, calls } = createRunCommandFake();
     const fetchFn = vi.fn();
@@ -521,8 +519,8 @@ describe('createI18nLintGate', () => {
     const result = await createI18nLintGate({ runCommand }).run();
 
     expect(result).toEqual({ ok: true });
-    // The gate is the existing i18n CI gate, invoked as-is (design.md Out of
-    // Boundary: this feature calls it and never reimplements it).
+    // The gate is the existing i18n CI gate, invoked as-is -- this feature
+    // calls it and never reimplements it.
     expect(calls).toEqual([{ command: 'pnpm', args: ['run', 'lint:i18n'] }]);
   });
 

--- a/apps/app/tools/i18n-sync/github-adapters.ts
+++ b/apps/app/tools/i18n-sync/github-adapters.ts
@@ -1,25 +1,21 @@
 /**
  * The real GitHub-side adapters behind `pull-translations.ts`'s injected
- * collaborator interfaces (design.md: Components and Interfaces > Sync
- * Tooling > PullTranslationSync). Tasks 3.2/3.3 defined
- * `TranslationOnlyPrPublisher` / `ApprovalReviewer` / `StructuralPrPublisher`
- * / `I18nLintGate` as interfaces only; this file implements all four.
+ * collaborator interfaces: implements `TranslationOnlyPrPublisher` /
+ * `ApprovalReviewer` / `StructuralPrPublisher` / `I18nLintGate`.
  *
  * **Two mechanisms, chosen per operation, not per taste.**
  * - Pull request read/write and the approving review go through the GitHub
  *   REST API with an **explicitly passed** token. That explicitness is the
- *   point: design.md's Security Considerations require the approving identity
- *   to be a different, content-write-less identity than the one that authors
- *   the pull request, and a REST call carries its token in its own
- *   `Authorization` header, so "which token authorized this call" is a value
- *   a unit test can read back. The `gh` CLI authenticates ambiently (a
- *   `GH_TOKEN` environment variable or stored login state), which would make
- *   that separation an unverifiable convention.
+ *   point: the approving identity must be a different, content-write-less
+ *   identity than the one that authors the pull request, and a REST call
+ *   carries its token in its own `Authorization` header, so "which token
+ *   authorized this call" is a value a unit test can read back. The `gh` CLI
+ *   authenticates ambiently (a `GH_TOKEN` environment variable or stored
+ *   login state), which would make that separation an unverifiable
+ *   convention.
  * - Branch publishing and the lint gate shell out, because they genuinely are
  *   local commands: `git` operating on the Actions checkout, and the existing
- *   `pnpm run lint:i18n` gate this feature only ever *calls* (design.md Out of
- *   Boundary). `apps/app/tools/i18n-audit/run-audit.ts` sets the precedent for
- *   invoking an external command from this tooling.
+ *   `pnpm run lint:i18n` gate this feature only ever *calls*.
  *
  * **Identity separation is structural here, not conventional.**
  * `createApprovalReviewer` accepts an `approvalToken` and nothing else that
@@ -121,9 +117,9 @@ export type FetchFn = typeof fetch;
  * Resolves — **once per run, shared by every publisher** — the commit both
  * sync branches are cut from.
  *
- * This is load-bearing for design.md's PR-granularity invariant. `main()`
- * publishes the translation-only branch first and the structural branch
- * second, so by the time the structural publisher runs, `HEAD` is the
+ * This is load-bearing for keeping the two sync pull requests independent.
+ * `main()` publishes the translation-only branch first and the structural
+ * branch second, so by the time the structural publisher runs, `HEAD` is the
  * translation-only commit. A publisher that branched off `HEAD` (or resolved
  * its own base ref lazily at that point) would carry the translation-only
  * locale files into the human-review pull request, and — worse in the other
@@ -174,8 +170,8 @@ interface GitHubRequestOptions {
 /**
  * One GitHub REST call, authorized by the token passed in — never by an
  * ambient credential. A non-2xx response throws, so `runPull` aggregates it
- * as a run failure (Requirement 8.1); the message carries the status and the
- * response body, and deliberately never the token.
+ * as a run failure; the message carries the status and the response body,
+ * and deliberately never the token.
  */
 const githubRequest = async (
   options: GitHubRequestOptions,
@@ -215,8 +211,7 @@ export interface PrPublisherOptions {
   /**
    * The identity that authors the sync pull requests. **Never the approval
    * token** — GitHub refuses a self-approval, so a run wired with one token
-   * for both roles cannot merge anything (design.md Boundary Commitments >
-   * Allowed Dependencies).
+   * for both roles cannot merge anything.
    */
   readonly publishToken: string;
   /** `owner/repo`, as GitHub Actions exposes it in `GITHUB_REPOSITORY`. */
@@ -299,8 +294,7 @@ const createPrPublisher = (options: PrPublisherOptions) => {
       await git(['checkout', '-B', input.headBranch, baseRef]);
       // Only the caller's paths, with `--` so a path can never be read as a
       // revision. Staging the working tree wholesale would sweep the other
-      // group's locale files into this pull request and break design.md's
-      // PR-granularity invariant (Requirement 3.2).
+      // group's locale files into this pull request.
       await git(['add', '--', ...input.filePaths]);
       // Authorship is set per-invocation rather than by mutating the
       // repository's git config, so this adapter leaves no state behind.
@@ -311,9 +305,7 @@ const createPrPublisher = (options: PrPublisherOptions) => {
       // succeeded but its `commit` did not -- `runPull` reports that failure
       // and carries on to the other group), a bare commit here would sweep
       // the other group's locale files into this pull request. Naming the
-      // paths makes the commit contain exactly them, which is what
-      // publishBranch's contract promises and what design.md's
-      // PR-granularity invariant requires.
+      // paths makes the commit contain exactly them.
       await git([
         '-c',
         `user.name=${gitAuthorName}`,
@@ -394,8 +386,8 @@ export interface ApprovalReviewerOptions {
   /**
    * The approving bot's token (`secrets.I18N_SYNC_APPROVAL_TOKEN`). This is
    * the only credential this adapter is given, and submitting an approving
-   * review is the only thing it can do with it — matching design.md's
-   * Security Considerations, where this identity holds no `contents: write`.
+   * review is the only thing it can do with it — this identity holds no
+   * `contents: write`.
    */
   readonly approvalToken: string;
   /** `owner/repo`, as GitHub Actions exposes it in `GITHUB_REPOSITORY`. */
@@ -413,7 +405,7 @@ export interface ApprovalReviewerOptions {
  * Approving only puts the pull request into the merge queue; the queue's own
  * `queue_conditions` / `merge_conditions` still require
  * `check-success ~= ci-app-lint` before anything merges, so this adds no
- * route around the i18n CI gate (Requirement 3.4).
+ * route around the i18n CI gate.
  *
  * The returned object has exactly one method on purpose: there is no code
  * path from this adapter to repository content, so the approval token cannot
@@ -457,12 +449,10 @@ export interface I18nLintGateOptions {
 
 /**
  * Runs the repository's existing i18n CI gate as-is
- * (`pnpm run lint:i18n` → `apps/app/tools/i18n-audit/`). design.md's Out of
- * Boundary is explicit that this feature calls the gate and never touches
- * its detection logic, so this adapter does nothing but invoke the script and
- * map its exit code: 0 passes, anything else fails and carries the captured
- * output so a maintainer can see *why* from the workflow log
- * (Requirement 3.3, 8.1).
+ * (`pnpm run lint:i18n` → `apps/app/tools/i18n-audit/`) — this feature calls
+ * the gate and never touches its detection logic. Maps the exit code: 0
+ * passes, anything else fails and carries the captured output so a
+ * maintainer can see *why* from the workflow log.
  */
 export const createI18nLintGate = (
   options: I18nLintGateOptions = {},

--- a/apps/app/tools/i18n-sync/no-runtime-dependency.spec.ts
+++ b/apps/app/tools/i18n-sync/no-runtime-dependency.spec.ts
@@ -4,14 +4,13 @@ import { fileURLToPath } from 'node:url';
 
 // --- Contract --------------------------------------------------------------
 //
-// Requirement 4 (実行時の外部サービス非依存): the running GROWI application
-// must never talk to POEditor itself — only the sync tooling in this
-// directory (`apps/app/tools/i18n-sync/`), which runs from GitHub Actions,
-// is allowed to call the POEditor API. If anyone ever imports
-// `poeditor-client.ts` (or another file from this directory) into
-// `apps/app/src/`, or hardcodes the POEditor domain into application code,
-// the running app would gain a runtime dependency on POEditor's
-// availability — exactly what Requirement 4 forbids.
+// The running GROWI application must never talk to POEditor itself — only
+// the sync tooling in this directory (`apps/app/tools/i18n-sync/`), which
+// runs from GitHub Actions, is allowed to call the POEditor API. If anyone
+// ever imports `poeditor-client.ts` (or another file from this directory)
+// into `apps/app/src/`, or hardcodes the POEditor domain into application
+// code, the running app would gain a runtime dependency on POEditor's
+// availability.
 //
 // This is a drift test with no natural RED state: today `apps/app/src/`
 // has zero references to POEditor, so this spec passes trivially on the

--- a/apps/app/tools/i18n-sync/poeditor-client.spec.ts
+++ b/apps/app/tools/i18n-sync/poeditor-client.spec.ts
@@ -149,8 +149,8 @@ describe('createPoeditorClient', () => {
       // the real clock is inherently subject to sub-millisecond scheduling
       // jitter between the two awaited uploadTerms() calls below — this is
       // what made the test intermittently fail with e.g. "19999 to be
-      // greater than or equal to 20000" (tasks.md 6.3 / 3.2 review notes).
-      // Freezing the clock with fake timers removes that jitter entirely:
+      // greater than or equal to 20000". Freezing the clock with fake timers
+      // removes that jitter entirely:
       // Date.now() returns the same value for both calls, so the elapsed
       // time between them is exactly 0 and the computed remaining wait is
       // deterministically 20000, every run.

--- a/apps/app/tools/i18n-sync/poeditor-client.ts
+++ b/apps/app/tools/i18n-sync/poeditor-client.ts
@@ -1,31 +1,24 @@
 /**
- * PoeditorClient (design.md: Components and Interfaces > Sync Tooling >
- * PoeditorClient). A thin wrapper around the POEditor API v2's
- * upload/export/languages endpoints.
+ * A thin wrapper around the POEditor API v2's upload/export/languages
+ * endpoints.
  *
- * Responsibilities & constraints this file must uphold (design.md):
- * - The API token is injected by the caller (via `createPoeditorClient`'s
- *   `apiToken` parameter) — this file never reads `process.env` directly.
- *   Reading the env var is a Config layer concern, out of this task's
- *   boundary.
+ * - The API token is injected by the caller (`createPoeditorClient`'s
+ *   `apiToken`) — this file never reads `process.env` directly.
  * - `uploadTerms` enforces at least a 20-second gap between successive
- *   upload calls (POEditor's documented upload rate limit, research.md).
- *   The wait mechanism is injected as `sleep` so tests can fake it instead
- *   of actually waiting 20 real seconds.
+ *   upload calls (POEditor's documented upload rate limit). The wait is
+ *   injected as `sleep` so tests can fake it instead of waiting 20 real
+ *   seconds.
  * - `exportTranslations` resolves the download URL from POEditor, then
- *   fetches that URL itself and resolves to the downloaded file content —
- *   callers never see the intermediate URL.
- * - Errors are returned as a `Result<T, PoeditorApiError>` discriminated
- *   union rather than thrown; only a genuinely unexpected failure (a
- *   rejected/throwing fetch call) is caught and turned into a
- *   `network_error`, per design.md's Invariants ("呼び出し元は
- *   PoeditorApiError を握りつぶさず...").
+ *   fetches that URL itself so callers never see the intermediate URL.
+ * - Errors are returned as a `Result<T, PoeditorApiError>` rather than
+ *   thrown; only a genuinely unexpected failure (a rejected/throwing fetch
+ *   call) is caught and turned into a `network_error`.
  */
 
 const POEDITOR_API_BASE = 'https://api.poeditor.com/v2';
 
 // POEditor's documented upload rate limit: no more than one request every
-// 20 seconds (research.md).
+// 20 seconds.
 const UPLOAD_THROTTLE_MS = 20_000;
 
 export type Result<T, E> =

--- a/apps/app/tools/i18n-sync/pull-translations.spec.ts
+++ b/apps/app/tools/i18n-sync/pull-translations.spec.ts
@@ -138,14 +138,11 @@ describe('collectClassifications', () => {
   });
 
   it('separates translation_only and structural combinations into two disjoint groups with no mixing, from a 12-combination input mixing all 3 classification kinds', async () => {
-    // This is the task's named critical invariant test (design.md's
-    // PR-granularity invariant): a real pull run mixes no_change,
-    // translation_only, and structural results across the 12 combinations,
-    // and the two output groups must never let a structural result leak
-    // into the translationOnly group (or vice versa) -- doing so would let
-    // a structural, key-adding-or-removing change auto-merge via the
-    // translation_only PR's no-human-review path, silently breaking
-    // Requirement 3.2.
+    // A real pull run mixes no_change, translation_only, and structural
+    // results across the 12 combinations, and the two output groups must
+    // never let a structural result leak into the translationOnly group (or
+    // vice versa) -- doing so would let a structural, key-adding-or-removing
+    // change auto-merge via the translation_only PR's no-human-review path.
     const poeditorClient = buildPoeditorClient();
     const readNamespaceFile = buildReadNamespaceFile();
 
@@ -223,8 +220,8 @@ describe('collectClassifications', () => {
       addedKeys: ['k3'],
       removedKeys: ['k2'],
       // Same reasoning as translationOnly's absoluteFilePath/content above,
-      // under different field names (task 3.2's Implementation Notes; see
-      // StructuralCombination's doc comment).
+      // under different field names (see StructuralCombination's doc
+      // comment).
       filePath: '/base/locales/zh_CN/admin.json',
       exportedContent: { k1: 'v1', k3: 'v3' },
     });
@@ -338,11 +335,9 @@ describe('collectClassifications', () => {
   });
 
   it('does not abort the run when one combination has invalid-JSON export content -- only that combination is skipped, the rest classify normally', async () => {
-    // design.md "Error Handling > Error Categories and Responses" >
-    // 「不正な形式のexportデータ」: unlike read_failed/export_failed,
-    // invalid_json only excludes its own (namespace, language) combination
-    // -- export is read-only, so a single malformed combination is
-    // tolerated rather than aborting the whole run.
+    // Unlike read_failed/export_failed, invalid_json only excludes its own
+    // (namespace, language) combination -- export is read-only, so a single
+    // malformed combination is tolerated rather than aborting the whole run.
     const poeditorClient = mock<PoeditorClient>();
     poeditorClient.exportTranslations.mockImplementation(
       // biome-ignore lint/suspicious/useAwait: must match PoeditorClient's Promise-returning signature.
@@ -581,8 +576,7 @@ describe('applyTranslationOnlyChanges', () => {
     // The branch carries exactly this group's files and nothing else. The
     // structural group is classified against the same checkout, so a
     // publisher told to stage the whole working tree would sweep a structural
-    // change into this no-human-review pull request -- the one thing
-    // design.md's PR-granularity invariant forbids.
+    // change into this no-human-review pull request.
     expect(harness.prPublisher.publishBranch).toHaveBeenCalledWith(
       expect.objectContaining({
         headBranch: TRANSLATION_ONLY_BRANCH,
@@ -595,11 +589,11 @@ describe('applyTranslationOnlyChanges', () => {
   });
 
   it('submits no approving review at all and surfaces the failure when the i18n lint gate fails', async () => {
-    // Requirement 3.3 / 3.4: a failing i18n CI gate must stop the change from
-    // reaching the default branch. Since the only thing moving this PR into
-    // the merge queue is the bot's approving review, "not approving" is
-    // exactly what blocks it -- so this test fails loudly if the approval
-    // collaborator is touched even once on the failing path.
+    // A failing i18n CI gate must stop the change from reaching the default
+    // branch. Since the only thing moving this PR into the merge queue is
+    // the bot's approving review, "not approving" is exactly what blocks it
+    // -- so this test fails loudly if the approval collaborator is touched
+    // even once on the failing path.
     const harness = buildApplyHarness({ lintGatePasses: false });
 
     const result = await applyTranslationOnlyChanges({
@@ -622,9 +616,8 @@ describe('applyTranslationOnlyChanges', () => {
       message: 'lint:i18n failed: 3 missing keys in ko_KR/commons.json',
     });
 
-    // The PR is deliberately left open with its failing check on it
-    // (design.md Error Handling: 「自動反映経路であってもPRを自動マージせず、
-    // 失敗したチェックとして残す」), so the maintainer can see what failed.
+    // The PR is deliberately left open with its failing check on it, so the
+    // maintainer can see what failed.
     expect(harness.prPublisher.createPr).toHaveBeenCalledTimes(1);
   });
 
@@ -810,12 +803,10 @@ describe('applyStructuralChanges', () => {
   });
 });
 
-describe('translation-only-empty / structural-only integration (task 3.3 observable completion state)', () => {
+describe('translation-only-empty / structural-only integration', () => {
   it('creates only the structural review PR and never touches the approval bot or the translation-only publisher when the translation-only group is empty', async () => {
-    // This is the task's named integration test: 訳文のみのグループが空でも
-    // 構造変更のグループが存在する場合は、構造変更側の変更提案だけが作られる
-    // ことを検証する. Runs both apply functions the way `runPull`/`main()`
-    // would, against a translationOnly=[] / structural=[...] split.
+    // Runs both apply functions the way `runPull`/`main()` would, against a
+    // translationOnly=[] / structural=[...] split.
     const translationOnlyHarness = buildApplyHarness({ lintGatePasses: true });
     const structuralHarness = buildStructuralHarness();
     const structuralCombinations = [buildStructuralCombination()];
@@ -1082,9 +1073,9 @@ describe('main', () => {
   it('refuses to run when the approval bot token and the publishing token are the same value', async () => {
     // The separation between the pull-request author and the approving
     // identity is the whole reason `ApprovalReviewer` exists as its own
-    // interface (design.md Security Considerations). One value wired to both
-    // roles would silently defeat it -- and GitHub refuses a self-approval
-    // anyway, so such a run could never merge.
+    // interface. One value wired to both roles would silently defeat it --
+    // and GitHub refuses a self-approval anyway, so such a run could never
+    // merge.
     process.env.I18N_SYNC_PUBLISH_TOKEN = 'same-token';
     process.env.I18N_SYNC_APPROVAL_TOKEN = 'same-token';
     const collectClassificationsFn = vi.fn();
@@ -1208,7 +1199,7 @@ describe('main', () => {
     expect(process.exitCode).toBeUndefined();
   });
 
-  it('sets a non-zero exit code when any step reports failure (task 3.3 observable completion state)', async () => {
+  it('sets a non-zero exit code when any step reports failure', async () => {
     await main({
       collectClassificationsFn: vi.fn(async () => ({
         ok: true as const,
@@ -1229,7 +1220,7 @@ describe('main', () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it('warns about skipped (invalid_json) combinations on the success path, but leaves the exit code unset (design.md 「不正な形式のexportデータ」, Requirement 8.1)', async () => {
+  it('warns about skipped (invalid_json) combinations on the success path, but leaves the exit code unset', async () => {
     // A combination whose POEditor export failed to parse must never
     // disappear silently even though the overall run still succeeds -- see
     // this file's header comment and the `skipped` field's doc comment.

--- a/apps/app/tools/i18n-sync/pull-translations.ts
+++ b/apps/app/tools/i18n-sync/pull-translations.ts
@@ -1,15 +1,11 @@
 /**
- * PullTranslationSync (design.md: Components and Interfaces > Sync Tooling >
- * PullTranslationSync（CLI）). Exports each namespace x non-source language
- * combination's translations from POEditor, classifies each combination
- * against the current repository content via `DiffClassifier`, and groups
- * the results into exactly two collections per design.md's Pull Flow
- * PR-granularity invariant ("PRの粒度（不変条件）"):
- *
- *   1回のpull実行で対象になる最大12通り（namespace3×非ソース言語4）の判定結果は、
- *   必ず2本以下のPRに分ける。「訳文のみ」の組み合わせは1本のPRにまとめ、
- *   「構造変更」の組み合わせは別の1本のPRにまとめる。同一PRの中に構造変更の
- *   組み合わせを1件でも含めてはならない。
+ * Exports each namespace x non-source language combination's translations
+ * from POEditor, classifies each combination against the current repository
+ * content via `DiffClassifier`, and groups the results into exactly two
+ * collections: every combination that only changed translation values goes
+ * into one pull request, and every combination that added or removed a key
+ * goes into a separate one — a structural change must never ride along in
+ * the same pull request as a translation-only one.
  *
  * `collectClassifications` builds exactly that grouping as data: every
  * `translation_only` combination goes into `translationOnly`, every
@@ -21,20 +17,12 @@
  * without a type error, not just a runtime check. A combination whose
  * POEditor export failed to parse as JSON (`invalid_json`) is excluded from
  * both groups too, but — unlike a read/export failure — does not abort the
- * run; it is reported separately via the result's `skipped` list (design.md
- * "Error Handling > Error Categories and Responses" > 「不正な形式の
- * exportデータ」).
+ * run; it is reported separately via the result's `skipped` list.
  *
  * `applyTranslationOnlyChanges` then takes the `translationOnly` group and
- * carries it all the way to an approved, auto-mergeable PR (design.md
- * "PullTranslationSync（CLI）" Responsibilities & Constraints). The
- * `structural` group's review-required PR remains task 3.3's scope.
- *
- * Follows the dependency direction SyncConfig -> PoeditorClient ->
- * PullTranslationSync (design.md "依存方向: SyncConfig → PoeditorClient →
- * PushSourceSync / PullTranslationSync"): this file reads `SYNC_TARGETS`,
- * calls `PoeditorClient`, and calls `DiffClassifier`'s `classify`, never the
- * reverse.
+ * carries it all the way to an approved, auto-mergeable PR. The `structural`
+ * group instead goes through `applyStructuralChanges`, whose PR always
+ * awaits human review.
  */
 
 import { readFile, writeFile } from 'node:fs/promises';
@@ -57,8 +45,7 @@ import {
 import { type NamespaceSyncEntry, SYNC_TARGETS } from './sync-config.ts';
 
 /**
- * The 4 non-source languages this CLI pulls translations for (design.md:
- * "namespace × 非ソース言語（4言語）それぞれについて export"). en_US is
+ * The 4 non-source languages this CLI pulls translations for. en_US is
  * GROWI's source language, pushed (not pulled) by `PushSourceSync`.
  */
 export const NON_SOURCE_LANGUAGES = [
@@ -110,8 +97,8 @@ export interface TranslationOnlyCombination {
    * where a contributor can add or remove a term at any moment, so a second
    * export could return content with a *different* key set than the one
    * classified as `translation_only` — and that content would then take the
-   * auto-merge path with no human review, breaking design.md's PR-granularity
-   * invariant and Requirement 3.2.
+   * auto-merge path with no human review, even though it might in fact
+   * contain a structural change.
    */
   readonly content: Readonly<Record<string, unknown>>;
 }
@@ -126,14 +113,11 @@ export interface StructuralCombination {
    * `applyStructuralChanges` writes back to.
    *
    * Deliberately named differently from `TranslationOnlyCombination`'s
-   * `absoluteFilePath` (task 3.2's Implementation Notes: keep the two
-   * combination types non-interchangeable in field naming, not just in
-   * their surrounding types). This is a naming-level safety margin on top
-   * of the existing structural one -- `StructuralCombination` and
-   * `TranslationOnlyCombination` are already distinct types, so nothing
-   * type-checks a swap between them, but matching field names would still
-   * let a careless refactor rename one type to the other without a compile
-   * error. Different names make that refactor fail loudly instead.
+   * `absoluteFilePath`: `StructuralCombination` and `TranslationOnlyCombination`
+   * are already distinct types, so nothing type-checks a swap between them,
+   * but matching field names would still let a careless refactor rename one
+   * type to the other without a compile error. Different names make that
+   * refactor fail loudly instead.
    */
   readonly filePath: string;
   /**
@@ -166,13 +150,13 @@ type CombinationFailure =
       readonly message: string;
     };
 
-/** The subset of `CombinationFailure` that is surfaced but does not abort the run (design.md: 「不正な形式のexportデータ」). */
+/** The subset of `CombinationFailure` that is surfaced but does not abort the run. */
 type InvalidJsonFailure = Extract<
   CombinationFailure,
   { reason: 'invalid_json' }
 >;
 
-/** The subset of `CombinationFailure` that aborts the whole run (design.md: read/export failures, "いずれかの namespace で失敗したら残りの処理を中止する"). */
+/** The subset of `CombinationFailure` (read/export failures) that aborts the whole run. */
 type AbortingFailure = Exclude<CombinationFailure, InvalidJsonFailure>;
 
 export type CollectClassificationsResult =
@@ -182,12 +166,11 @@ export type CollectClassificationsResult =
       readonly structural: readonly StructuralCombination[];
       /**
        * (namespace, language) combinations excluded from classification
-       * because the POEditor export content failed to JSON.parse
-       * (design.md "Error Handling > Error Categories and Responses" >
-       * 「不正な形式のexportデータ」). Unlike `read_failed`/`export_failed`,
-       * this does not abort the run: export is read-only and never mutates
-       * the repository, so a single malformed combination is tolerated
-       * rather than blocking the other (up to 11) combinations.
+       * because the POEditor export content failed to JSON.parse. Unlike
+       * `read_failed`/`export_failed`, this does not abort the run: export
+       * is read-only and never mutates the repository, so a single
+       * malformed combination is tolerated rather than blocking the other
+       * (up to 11) combinations.
        */
       readonly skipped: readonly InvalidJsonFailure[];
     }
@@ -238,8 +221,7 @@ const safeJsonParse = (
  * and the export call run concurrently since they are independent I/O
  * operations on unrelated systems; only `PoeditorClient.uploadTerms`
  * (a different method, used by `PushSourceSync`) is subject to POEditor's
- * upload rate limit — `exportTranslations` is not (design.md's throttle note
- * is scoped to uploads).
+ * upload rate limit — `exportTranslations` is not.
  */
 interface ReadCombinationOptions {
   readonly target: NamespaceSyncEntry;
@@ -330,22 +312,19 @@ const readCombination = async ({
  * For every (namespace, language) combination, reads the current repository
  * content and exports the POEditor content, classifies the pair via
  * `DiffClassifier.classify`, then groups the classified combinations into
- * `translationOnly` / `structural` (design.md's PR-granularity invariant —
- * see this file's header comment).
+ * `translationOnly` / `structural` (see this file's header comment).
  *
- * Mirrors `PushSourceSync.runPush`'s all-or-nothing error handling
- * (`PoeditorClient`'s Invariants, design.md: "いずれかの namespace で失敗し
- * たら残りの処理を中止する", Requirement 8.1): if any combination fails to
- * read the current repository file (`read_failed`) or export from POEditor
- * (`export_failed`), the whole run reports failure and no grouping is
- * returned, so a later task can never build a PR out of a partial result.
+ * Mirrors `PushSourceSync.runPush`'s all-or-nothing error handling: if any
+ * combination fails to read the current repository file (`read_failed`) or
+ * export from POEditor (`export_failed`), the whole run reports failure and
+ * no grouping is returned, so a caller can never build a PR out of a
+ * partial result.
  *
  * `invalid_json` (the exported content fails to `JSON.parse`) is the one
- * exception, per design.md's "不正な形式のexportデータ" bullet: export is
- * read-only and never mutates the repository, so it tolerates a single
- * malformed combination rather than aborting. That combination alone is
- * excluded from `translationOnly`/`structural` and reported via `skipped`;
- * the rest of the run proceeds and groups normally.
+ * exception: export is read-only and never mutates the repository, so it
+ * tolerates a single malformed combination rather than aborting. That
+ * combination alone is excluded from `translationOnly`/`structural` and
+ * reported via `skipped`; the rest of the run proceeds and groups normally.
  */
 export const collectClassifications = async (
   options: CollectClassificationsOptions,
@@ -370,11 +349,9 @@ export const collectClassifications = async (
     ),
   );
 
-  // `read_failed` / `export_failed` still abort the whole run (unchanged —
-  // design.md's general "いずれかの namespace で失敗したら残りの処理を中止
-  // する" rule). `invalid_json` is handled separately below: per design.md's
-  // 「不正な形式のexportデータ」 bullet, it only excludes its own
-  // combination and lets the others continue.
+  // `read_failed` / `export_failed` still abort the whole run. `invalid_json`
+  // is handled separately below: it only excludes its own combination and
+  // lets the others continue.
   const abortingFailures = combinationInputs
     .map((input) => input.failure)
     .filter(
@@ -430,8 +407,7 @@ export const collectClassifications = async (
       });
     }
     // 'no_change' combinations are intentionally excluded from both groups —
-    // there is nothing to report for them (design.md: "no_change（変更なし）
-    // の組み合わせのみだった場合は何もしない").
+    // there is nothing to report for them.
   }
 
   return { ok: true, translationOnly, structural, skipped };
@@ -445,9 +421,7 @@ export const collectClassifications = async (
  * rewrites this branch to the current POEditor state, so at most one
  * translation-only PR can ever be open. It is the same reasoning as
  * `sync_terms=1` on the push side — the operation converges to the current
- * state instead of accumulating one artifact per run (design.md
- * PullTranslationSync Batch Contract: 「既存の未マージPRがあれば更新する
- * （重複PRを作らない）」).
+ * state instead of accumulating one artifact per run.
  */
 export const TRANSLATION_ONLY_BRANCH = 'i18n-sync/translation-only';
 
@@ -469,12 +443,12 @@ export interface PullRequestRef {
  * Everything the translation-only path needs to turn locally-written locale
  * files into an open pull request. Deliberately kept separate from
  * `ApprovalReviewer`: the two are performed by *different* GitHub identities
- * (GitHub refuses a self-approval), and the approving identity is scoped to
- * `pull-requests: write` with no content-write permission at all (design.md
- * Security Considerations, `I18N_SYNC_APPROVAL_TOKEN`). Splitting the
- * interfaces makes that separation structural rather than a convention: an
- * implementation of `ApprovalReviewer` is handed no method that could write
- * repository content.
+ * (GitHub refuses a self-approval), and the approving identity
+ * (`I18N_SYNC_APPROVAL_TOKEN`) is scoped to `pull-requests: write` with no
+ * content-write permission at all. Splitting the interfaces makes that
+ * separation structural rather than a convention: an implementation of
+ * `ApprovalReviewer` is handed no method that could write repository
+ * content.
  */
 export interface TranslationOnlyPrPublisher {
   /**
@@ -484,9 +458,7 @@ export interface TranslationOnlyPrPublisher {
    * working tree. A single pull run classifies both groups against the same
    * checkout, so the structural group's locale files can already be modified
    * alongside these; sweeping them in would put a structural change into the
-   * translation-only pull request and merge it with no human review, which
-   * design.md forbids outright (「同一PRの中に構造変更の組み合わせを1件でも
-   * 含めてはならない」, Requirement 3.2).
+   * translation-only pull request and merge it with no human review.
    */
   publishBranch(input: {
     readonly headBranch: string;
@@ -521,10 +493,9 @@ export type LintGateResult =
 
 /**
  * The existing i18n CI gate (`pnpm run lint:i18n` /
- * `apps/app/tools/i18n-audit/`). design.md's Out of Boundary is explicit that
- * this feature only *calls* the gate and never touches its detection logic,
- * so it enters here as an injected collaborator rather than as a direct
- * dependency on the audit tooling.
+ * `apps/app/tools/i18n-audit/`). This feature only *calls* the gate and
+ * never touches its detection logic, so it enters here as an injected
+ * collaborator rather than as a direct dependency on the audit tooling.
  */
 export interface I18nLintGate {
   run(): Promise<LintGateResult>;
@@ -588,7 +559,7 @@ const PR_TITLE = 'chore(i18n): apply translation-only updates from POEditor';
  * Applies the `translation_only` group: writes each combination's exported
  * content to its locale file, gathers them into a *single* pull request, runs
  * the existing i18n CI gate, and — only if the gate passes — has the approval
- * bot submit an approving review (Requirements 3.3, 3.4, 8.1).
+ * bot submit an approving review.
  *
  * **Why approving is enough, and why it does not bypass CI.** The approving
  * review only satisfies the `#approved-reviews-by >= 1` condition of the
@@ -596,13 +567,12 @@ const PR_TITLE = 'chore(i18n): apply translation-only updates from POEditor';
  * merely puts the PR into the merge queue. The queue's own `queue_rules`
  * independently require `check-success ~= ci-app-lint` (which contains
  * `lint:i18n`) before anything merges. So the gate is applied twice and is
- * never circumvented, exactly as Requirement 3.4 demands — this file adds no
- * new merge route and changes no Mergify rule.
+ * never circumvented — this file adds no new merge route and changes no
+ * Mergify rule.
  *
  * **Step order is load-bearing, not incidental.** The gate reads the locale
- * files from disk, so it must run *after* they are written; and design.md's
- * Error Handling requires a failing gate to remain visible 「失敗したチェック
- * として残す」, which needs a pull request to carry that check. Hence:
+ * files from disk, so it must run *after* they are written, and a failing
+ * gate needs an open pull request to attach its failing check to. Hence:
  * write → publish branch → create-or-update the PR → run the gate → approve.
  *
  * **Why writing whole files is safe.** `translation_only` means the two leaf
@@ -612,7 +582,7 @@ const PR_TITLE = 'chore(i18n): apply translation-only updates from POEditor';
  *
  * On a gate failure nothing is approved and the PR is deliberately left open
  * with its failing check; the failure is returned so the caller can fail the
- * workflow (Requirement 8.1).
+ * workflow.
  */
 export const applyTranslationOnlyChanges = async (
   options: ApplyTranslationOnlyChangesOptions,
@@ -622,8 +592,7 @@ export const applyTranslationOnlyChanges = async (
 
   if (combinations.length === 0) {
     // Nothing to propose: opening an empty pull request (and paying for a
-    // gate run on it) would be pure noise (design.md: 「no_change（変更なし）
-    // の組み合わせのみだった場合は何もしない」).
+    // gate run on it) would be pure noise.
     return { ok: true, outcome: 'no_changes' };
   }
 
@@ -644,7 +613,7 @@ export const applyTranslationOnlyChanges = async (
     headBranch: TRANSLATION_ONLY_BRANCH,
     commitMessage: PR_TITLE,
     // Only this group's files: see publishBranch's contract for why staging
-    // anything else would break the PR-granularity invariant.
+    // anything else would carry the other group's changes into this PR.
     filePaths,
   });
 
@@ -685,12 +654,10 @@ export const applyTranslationOnlyChanges = async (
 
 /**
  * The single branch every structural-review sync run converges onto,
- * mirroring `TRANSLATION_ONLY_BRANCH`'s "no duplicate PRs" reasoning
- * (design.md PullTranslationSync Batch Contract: 「既存の未マージPRがあれば
- * 更新する（重複PRを作らない）」). Deliberately a different fixed branch than
- * `TRANSLATION_ONLY_BRANCH` -- the two groups must never land on the same
- * branch, or a structural change would ride along in the no-human-review
- * translation-only PR (design.md's PR-granularity invariant).
+ * mirroring `TRANSLATION_ONLY_BRANCH`'s "no duplicate PRs" reasoning.
+ * Deliberately a different fixed branch than `TRANSLATION_ONLY_BRANCH` --
+ * the two groups must never land on the same branch, or a structural change
+ * would ride along in the no-human-review translation-only PR.
  */
 export const STRUCTURAL_BRANCH = 'i18n-sync/structural-review';
 
@@ -714,8 +681,7 @@ export interface StructuralPrPublisher {
    * Commits the locale files at `filePaths` onto `headBranch` and pushes it.
    * Same "only these paths, never the whole working tree" contract as
    * `TranslationOnlyPrPublisher.publishBranch` -- staging the translation-only
-   * group's files here would break the PR-granularity invariant the other
-   * way around.
+   * group's files here would carry them into this PR instead.
    */
   publishBranch(input: {
     readonly headBranch: string;
@@ -776,16 +742,14 @@ const STRUCTURAL_PR_TITLE =
   'chore(i18n): review structural updates from POEditor';
 
 /**
- * Applies the `structural` group (task 3.3): writes each combination's
- * exported content to its locale file and gathers them into a *single*
- * pull request awaiting human review (Requirement 3.2). Unlike
- * `applyTranslationOnlyChanges`, this function has no `ApprovalReviewer`
- * parameter at all and never runs the i18n lint gate itself -- both are
- * deliberately absent rather than merely unused, so no code path here can
- * submit a bot approval even by mistake. The existing `ci-app-lint` check
- * still runs on this PR the same way it runs on any other pull request;
- * only the auto-approval step is skipped (design.md: 「構造変更PRは通常の
- * レビュー必須PRとして作成するのみで、承認ボットは関与しない」).
+ * Applies the `structural` group: writes each combination's exported
+ * content to its locale file and gathers them into a *single* pull request
+ * awaiting human review. Unlike `applyTranslationOnlyChanges`, this
+ * function has no `ApprovalReviewer` parameter at all and never runs the
+ * i18n lint gate itself -- both are deliberately absent rather than merely
+ * unused, so no code path here can submit a bot approval even by mistake.
+ * The existing `ci-app-lint` check still runs on this PR the same way it
+ * runs on any other pull request; only the auto-approval step is skipped.
  *
  * Mirrors `applyTranslationOnlyChanges`'s idempotency: a fixed branch name
  * (`STRUCTURAL_BRANCH`) means a second run against the same diff updates
@@ -799,8 +763,7 @@ export const applyStructuralChanges = async (
 
   if (combinations.length === 0) {
     // Nothing to propose -- same reasoning as applyTranslationOnlyChanges's
-    // empty-group short circuit (design.md: 「no_change（変更なし）の組み合わ
-    // せのみだった場合は何もしない」).
+    // empty-group short circuit.
     return { ok: true, outcome: 'no_changes' };
   }
 
@@ -846,21 +809,20 @@ export const applyStructuralChanges = async (
 
 /**
  * Everything one full pull run needs, and the pure orchestration function
- * that sequences task 3.1/3.2/3.3's three exported functions the way
- * `main()` (below) is required to (task 3.3's tasks.md text). Kept as its
- * own function -- separate from `main()` -- so the sequencing and failure
- * aggregation are unit-testable with injected fakes, without touching
- * `process.env` or a real process exit (mirrors `push-source.ts`'s
+ * that sequences `collectClassifications` / `applyTranslationOnlyChanges` /
+ * `applyStructuralChanges` the way `main()` (below) is required to. Kept as
+ * its own function -- separate from `main()` -- so the sequencing and
+ * failure aggregation are unit-testable with injected fakes, without
+ * touching `process.env` or a real process exit (mirrors `push-source.ts`'s
  * `runPush`/`main` split).
  *
  * **Step order is load-bearing**: `applyTranslationOnlyChanges` runs before
  * `applyStructuralChanges` on purpose. `applyTranslationOnlyChanges`'s
- * `I18nLintGate` reads the working tree from disk (task 3.2's
- * Implementation Notes), so if the structural group's files were written
- * first, the gate could see structural (key-adding/removing) content and
- * fail for the wrong reason. Running translation-only first, gate included,
- * keeps that check's view of the tree limited to what it is actually
- * judging.
+ * `I18nLintGate` reads the working tree from disk, so if the structural
+ * group's files were written first, the gate could see structural
+ * (key-adding/removing) content and fail for the wrong reason. Running
+ * translation-only first, gate included, keeps that check's view of the
+ * tree limited to what it is actually judging.
  *
  * Both apply steps run even if one fails -- they write to different
  * branches and open different pull requests, so a translation-only gate
@@ -902,12 +864,10 @@ export type RunPullResult =
       readonly ok: true;
       /**
        * (namespace, language) combinations `collectClassifications` excluded
-       * because their POEditor export was not valid JSON (design.md "Error
-       * Handling > Error Categories and Responses" > 「不正な形式の
-       * exportデータ」). The run still succeeds -- this is threaded through so
-       * `main()` can warn about them instead of the run completing silently
-       * with no trace of the skipped combination (Requirement 8.1: 「黙って
-       * 結果をスキップしない」).
+       * because their POEditor export was not valid JSON. The run still
+       * succeeds -- this is threaded through so `main()` can warn about them
+       * instead of the run completing silently with no trace of the skipped
+       * combination.
        */
       readonly skipped: readonly InvalidJsonFailure[];
     }
@@ -1009,13 +969,13 @@ interface GitHubRunConfig {
  * as far as force-pushing a branch and only then discovers it has no
  * approval identity leaves an unapproved pull request behind.
  *
- * The equality check is the runtime backstop for design.md's Security
- * Considerations: `ApprovalReviewer` being its own interface makes it
- * impossible for the approving adapter to write content, but nothing at the
- * type level stops an operator from putting the *same secret* into both
- * workflow inputs. GitHub refuses a self-approval, so such a run could never
- * satisfy `.github/mergify.yml`'s `#approved-reviews-by >= 1` anyway — it
- * would just fail late and confusingly instead of early and clearly.
+ * The equality check is the runtime backstop for the identity separation:
+ * `ApprovalReviewer` being its own interface makes it impossible for the
+ * approving adapter to write content, but nothing at the type level stops
+ * an operator from putting the *same secret* into both workflow inputs.
+ * GitHub refuses a self-approval, so such a run could never satisfy
+ * `.github/mergify.yml`'s `#approved-reviews-by >= 1` anyway — it would
+ * just fail late and confusingly instead of early and clearly.
  */
 const readGitHubRunConfig = (
   env: NodeJS.ProcessEnv,
@@ -1094,11 +1054,11 @@ const readGitHubRunConfig = (
 };
 
 /**
- * `main()`'s real collaborators (task 5.2). The two publishers share one
- * base-ref resolver on purpose — see `createBaseRefResolver`'s doc comment:
- * both sync branches must be cut from the checkout's original commit, or the
+ * `main()`'s real collaborators. The two publishers share one base-ref
+ * resolver on purpose — see `createBaseRefResolver`'s doc comment: both
+ * sync branches must be cut from the checkout's original commit, or the
  * structural pull request would inherit the translation-only commit made
- * moments earlier and design.md's PR-granularity invariant would break.
+ * moments earlier.
  *
  * The approving identity is constructed from `approvalToken` alone and is
  * never handed `publishToken`; conversely the publishers are never handed
@@ -1131,15 +1091,15 @@ const createGitHubCollaborators = (
 /**
  * Process-entrypoint wrapper, mirroring `push-source.ts`'s `main()`: reads
  * the POEditor API token from `process.env`, runs `runPull`, prints the
- * outcome, and sets a non-zero exit code on failure (Requirement 8.1).
+ * outcome, and sets a non-zero exit code on failure.
  *
  * Accepts an optional `overrides` argument -- unlike `push-source.ts`'s
  * `main()`, which takes none -- specifically so tests can exercise this
- * function's own failure-aggregation/exit-code behavior (task 3.3's
- * observable completion criterion) with injected/mocked sub-functions,
- * without needing a real `POEDITOR_API_TOKEN` or GitHub credentials. A real
- * invocation (`main()`, no arguments) uses the real `PoeditorClient` and the
- * real GitHub adapters built by `createGitHubCollaborators`.
+ * function's own failure-aggregation/exit-code behavior with
+ * injected/mocked sub-functions, without needing a real
+ * `POEDITOR_API_TOKEN` or GitHub credentials. A real invocation (`main()`,
+ * no arguments) uses the real `PoeditorClient` and the real GitHub adapters
+ * built by `createGitHubCollaborators`.
  */
 export const main = async (
   overrides: Partial<
@@ -1194,12 +1154,9 @@ export const main = async (
 
   if (result.ok) {
     if (result.skipped.length > 0) {
-      // A skipped combination must never disappear silently (design.md
-      // "Error Handling > Error Categories and Responses" > 「不正な形式の
-      // exportデータ」; Requirement 8.1 「黙って結果をスキップしない」). The
-      // run still succeeds -- design.md requires the other combinations to
-      // keep going -- so this is a warning, not a failing exit code; the
-      // Monitoring section treats this GitHub Actions run log as the
+      // A skipped combination must never disappear silently. The run still
+      // succeeds -- the other combinations keep going -- so this is a
+      // warning, not a failing exit code; this GitHub Actions run log is the
       // maintainer-visible channel for it.
       // biome-ignore lint/suspicious/noConsole: this is a CI script, console output is expected.
       console.error(

--- a/apps/app/tools/i18n-sync/push-source.spec.ts
+++ b/apps/app/tools/i18n-sync/push-source.spec.ts
@@ -128,10 +128,9 @@ describe('runPush', () => {
   });
 
   it('stops uploading at the first upload failure and reports an upload_failed result, never reaching later namespaces', async () => {
-    // design.md's Error Strategy requires upload failures to abort the whole
-    // run just like read failures do — no partial reflection in POEditor.
-    // "admin" (1st) succeeds, "translation" (2nd) fails, and "commons" (3rd)
-    // must never be attempted.
+    // Upload failures must abort the whole run just like read failures do —
+    // no partial reflection in POEditor. "admin" (1st) succeeds,
+    // "translation" (2nd) fails, and "commons" (3rd) must never be attempted.
     const poeditorClient = mock<PoeditorClient>();
     const readNamespaceFile = vi.fn(
       async (absolutePath: string) => FILE_CONTENTS[absolutePath],
@@ -168,10 +167,10 @@ describe('runPush', () => {
   it('relies on PoeditorClient.uploadTerms itself to space out calls (no additional sleep is invoked by PushSourceSync)', async () => {
     // This is a documentation-style assertion: PushSourceSync must not add a
     // second, redundant throttle on top of PoeditorClient's own internal
-    // 20-second gap (design.md: PoeditorClient "responsibility"). Since
-    // `runPush` never receives or calls a `sleep` function at all, there is
-    // nothing here to fake — the absence of such a parameter is itself the
-    // guarantee. This test documents that intent and would fail to compile
+    // 20-second gap. Since `runPush` never receives or calls a `sleep`
+    // function at all, there is nothing here to fake — the absence of such a
+    // parameter is itself the guarantee. This test documents that intent and
+    // would fail to compile
     // if `RunPushOptions` ever grew a redundant sleep-injection parameter
     // that the implementation started calling directly instead of trusting
     // the client's own throttle.

--- a/apps/app/tools/i18n-sync/push-source.ts
+++ b/apps/app/tools/i18n-sync/push-source.ts
@@ -1,27 +1,17 @@
 /**
- * PushSourceSync (design.md: Components and Interfaces > Sync Tooling >
- * PushSourceSync（CLI）). Reads the en_US (source language) locale file for
- * each namespace declared in `SyncConfig` and pushes it to that namespace's
- * POEditor project via `PoeditorClient.uploadTerms`.
+ * Reads the en_US (source language) locale file for each namespace declared
+ * in `SyncConfig` and pushes it to that namespace's POEditor project via
+ * `PoeditorClient.uploadTerms`.
  *
- * Responsibilities & constraints this file must uphold (design.md):
- * - Read every namespace file first, then upload. If any namespace file
- *   fails to read, abort the whole run and call `uploadTerms` zero times
- *   (Requirement 2.3, 8.1: no partial reflection — a namespace must never
- *   be silently skipped, and a failure must never let some namespaces sync
- *   while others don't).
- * - Upload sequentially, once per namespace declared in `SYNC_TARGETS`. The
- *   at-least-20-second gap between uploads is already enforced inside
- *   `PoeditorClient.uploadTerms` itself (its internal throttle, injectable
- *   via `sleep` for tests) — this file must not duplicate that wait.
- * - Follows the dependency direction SyncConfig -> PoeditorClient ->
- *   PushSourceSync (design.md "依存方向"): this file reads `SYNC_TARGETS`
- *   and calls `PoeditorClient`, never the reverse.
+ * - Reads every namespace file first, then uploads. If any namespace file
+ *   fails to read, the whole run aborts and `uploadTerms` is called zero
+ *   times — a namespace must never sync while another silently fails.
+ * - Uploads sequentially, once per namespace. The at-least-20-second gap
+ *   between uploads is already enforced inside `PoeditorClient.uploadTerms`
+ *   itself, so this file must not duplicate that wait.
  * - The POEditor API token is read from `process.env` only in the
  *   process-entrypoint wrapper (`main`), never inside `runPush` itself, so
- *   the pure orchestration logic stays testable without touching env vars
- *   (mirrors apps/app/tools/i18n-audit/run-audit.ts's two-execution-mode
- *   pattern).
+ *   the orchestration logic stays testable without touching env vars.
  */
 
 import { readFile } from 'node:fs/promises';
@@ -35,7 +25,7 @@ import {
 } from './poeditor-client.ts';
 import { type NamespaceSyncEntry, SYNC_TARGETS } from './sync-config.ts';
 
-/** The language this CLI pushes: en_US is GROWI's source language (Requirement 2.1). */
+/** The language this CLI pushes: en_US is GROWI's source language. */
 export const SOURCE_LANGUAGE = 'en_US';
 
 /** Injectable file-reading function, so tests can simulate a read failure without touching the real filesystem. */
@@ -87,9 +77,9 @@ const APP_ROOT = fileURLToPath(new URL('../../', import.meta.url));
 /**
  * Reads every declared namespace's en_US file first, then uploads them all
  * sequentially. Reading everything before uploading anything is what makes
- * the "abort before any upload" guarantee (Requirement 2.3) hold cleanly:
- * there is no interleaved read+upload step where a later read failure could
- * leave an earlier namespace already pushed.
+ * the "abort before any upload" guarantee hold cleanly: there is no
+ * interleaved read+upload step where a later read failure could leave an
+ * earlier namespace already pushed.
  */
 export const runPush = async (options: RunPushOptions): Promise<PushResult> => {
   const targets = options.targets ?? SYNC_TARGETS;
@@ -127,21 +117,17 @@ export const runPush = async (options: RunPushOptions): Promise<PushResult> => {
     return { ok: false, reason: 'read_failed', failures: readFailures };
   }
 
-  // Upload sequentially and stop at the first failure. design.md's Error
-  // Strategy ("一部のnamespaceで失敗した場合は残りを継続せず、ワークフロー
-  // 全体を失敗として終了する") and PoeditorClient's Invariants both require
-  // this to be symmetric with the read-failure path above: a namespace must
-  // never be pushed while a preceding one is known to have failed, so a
-  // partial reflection in POEditor (some namespaces updated, some not) can
-  // never happen.
+  // Upload sequentially and stop at the first failure, symmetric with the
+  // read-failure path above: a namespace must never be pushed while a
+  // preceding one is known to have failed, so POEditor never ends up with
+  // some namespaces updated and others not.
   for (const result of readResults) {
     // Safe: readFailures.length === 0 above guarantees every result has a
     // fileContent, since the only way to reach here is with zero errors.
     const fileContent = result.fileContent as string;
-    // Uploads must run sequentially, not in parallel via Promise.all —
-    // PoeditorClient enforces a 20-second gap between consecutive
-    // uploadTerms calls (design.md), which only holds if each call starts
-    // after the previous one settles.
+    // Must run sequentially, not via Promise.all — PoeditorClient enforces
+    // a 20-second gap between consecutive uploadTerms calls, which only
+    // holds if each call starts after the previous one settles.
     // biome-ignore lint/performance/noAwaitInLoops: sequential by design, see comment above.
     const uploadResult = await options.poeditorClient.uploadTerms({
       projectId: result.target.poeditorProjectId,
@@ -174,8 +160,7 @@ const formatFailure = (
 /**
  * Process-entrypoint wrapper: reads the POEditor API token from
  * `process.env`, runs `runPush`, prints the outcome, and sets a non-zero
- * exit code on failure (Requirement 8.1 — surfaced as a GitHub Actions
- * workflow failure). Kept separate from `runPush` so the orchestration
+ * exit code on failure. Kept separate from `runPush` so the orchestration
  * logic stays testable without an env var or a real process exit.
  */
 export const main = async (): Promise<void> => {

--- a/apps/app/tools/i18n-sync/sync-config.ts
+++ b/apps/app/tools/i18n-sync/sync-config.ts
@@ -1,29 +1,17 @@
 /**
- * SyncConfig (design.md: Components and Interfaces > Sync Tooling >
- * SyncConfig). The single source of truth for the namespace <-> POEditor
- * project ID mapping, and for resolving a namespace's locale file path.
- *
- * `PushSourceSync` / `PullTranslationSync` read `SYNC_TARGETS` and never
- * hard-code a namespace name or project ID themselves (coding-style.md's
- * Executor pattern: executors take their work-set as input).
- *
- * This module has no dependencies on any other component in this feature —
- * it is the base of the dependency chain (design.md: "依存方向: SyncConfig
- * -> PoeditorClient -> PushSourceSync / PullTranslationSync").
+ * The single source of truth for the namespace <-> POEditor project ID
+ * mapping. `PushSourceSync` / `PullTranslationSync` read `SYNC_TARGETS`
+ * rather than hard-coding a namespace name or project ID themselves.
  */
 
 export interface NamespaceSyncEntry {
   readonly namespace: 'admin' | 'translation' | 'commons';
   /**
-   * POEditor project ID for this namespace's dedicated project (design.md:
-   * "namespace ごとに POEditor プロジェクトを1つ割り当てる"). Public,
-   * non-secret data — safe to commit (design.md State Management: "POEditor
-   * プロジェクトIDは公開してよい情報（トークンではない）").
+   * POEditor project ID for this namespace's dedicated project. Public,
+   * non-secret data — safe to commit (it is not a token).
    *
-   * Note (POEditor provisioning, tracked as a separate operational task —
-   * design.md "Operational Prerequisites"): these are placeholder values.
-   * The 3 POEditor projects have not been created yet, so no real project
-   * ID exists. Replace with the real IDs once
+   * Placeholder value: the 3 POEditor projects have not been created yet.
+   * Replace with the real IDs once
    * `docs/i18n-community-translation-setup.md`'s provisioning steps run.
    */
   readonly poeditorProjectId: string;
@@ -44,11 +32,8 @@ const buildLocaleFilePath = (
 /**
  * The 3 real namespaces the repository has locale files for
  * (`admin.json` / `translation.json` / `commons.json`), each mapped to its
- * own POEditor project (Requirement 2.1). `translation` is included here,
- * which is what carries `packages/editor`'s `toolbar.*` keys into the same
- * sync range as the rest of apps/app's translation keys (Requirement 6.1) —
- * those keys already live inside `translation.json`, so no separate
- * declaration is needed for them.
+ * own POEditor project. `packages/editor`'s `toolbar.*` keys already live
+ * inside `translation.json`, so they need no separate declaration here.
  */
 export const SYNC_TARGETS: readonly NamespaceSyncEntry[] = [
   {


### PR DESCRIPTION
## Summary
- `apps/app/tools/i18n-sync/` のコメントには design.md / research.md / tasks.md の本文引用や要件番号(Requirement 3.2 など)・タスク番号(task 3.2 など)への参照が多数残っていた
- 実装が「なぜそうなっているか」の説明自体は残しつつ、仕様書への参照だけを削って読みやすくした

## Test plan
- [x] `pnpm biome check tools/i18n-sync`
- [x] `pnpm vitest run tools/i18n-sync` (75 tests passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)