### PR TITLE
feat: Add slash command extended elements (drawio / plantuml / lsx / callout / link / table-builder)

### DIFF
--- a/.changeset/callout-variants-to-core.md
+++ b/.changeset/callout-variants-to-core.md
@@ -1,0 +1,5 @@
+---
+"@growi/core": patch
+---
+
+Add callout variant constants (`AllCallout` / `Callout`) to `@growi/core` as the single source of truth, shared by the callout renderer and the editor slash commands.

--- a/apps/app/public/static/locales/en_US/translation.json
+++ b/apps/app/public/static/locales/en_US/translation.json
@@ -1141,6 +1141,48 @@
     "table": {
       "label": "Table",
       "description": ""
+    },
+    "plantuml": {
+      "label": "PlantUML",
+      "description": ""
+    },
+    "lsx": {
+      "label": "Dynamic list (lsx)",
+      "description": ""
+    },
+    "drawio": {
+      "label": "Diagram (drawio)",
+      "description": ""
+    },
+    "link": {
+      "label": "Link",
+      "description": ""
+    },
+    "tableBuilder": {
+      "label": "Table builder",
+      "description": ""
+    },
+    "callout": {
+      "note": {
+        "label": "Callout (Note)",
+        "description": ""
+      },
+      "tip": {
+        "label": "Callout (Tip)",
+        "description": ""
+      },
+      "important": {
+        "label": "Callout (Important)",
+        "description": ""
+      },
+      "warning": {
+        "label": "Callout (Warning)",
+        "description": ""
+      },
+      "caution": {
+        "label": "Callout (Caution)",
+        "description": ""
+      }
     }
   }
 }

--- a/apps/app/public/static/locales/fr_FR/translation.json
+++ b/apps/app/public/static/locales/fr_FR/translation.json
@@ -1133,6 +1133,14 @@
     "table": {
       "label": "Tableau",
       "description": ""
+    },
+    "link": {
+      "label": "Lien",
+      "description": ""
+    },
+    "tableBuilder": {
+      "label": "Générateur de tableau",
+      "description": ""
     }
   }
 }

--- a/apps/app/public/static/locales/ja_JP/translation.json
+++ b/apps/app/public/static/locales/ja_JP/translation.json
@@ -1172,6 +1172,48 @@
     "table": {
       "label": "テーブル",
       "description": ""
+    },
+    "plantuml": {
+      "label": "PlantUML",
+      "description": ""
+    },
+    "lsx": {
+      "label": "動的リスト（lsx）",
+      "description": ""
+    },
+    "drawio": {
+      "label": "図表（drawio）",
+      "description": ""
+    },
+    "link": {
+      "label": "リンク",
+      "description": ""
+    },
+    "tableBuilder": {
+      "label": "テーブルビルダー",
+      "description": ""
+    },
+    "callout": {
+      "note": {
+        "label": "コールアウト（Note）",
+        "description": ""
+      },
+      "tip": {
+        "label": "コールアウト（Tip）",
+        "description": ""
+      },
+      "important": {
+        "label": "コールアウト（Important）",
+        "description": ""
+      },
+      "warning": {
+        "label": "コールアウト（Warning）",
+        "description": ""
+      },
+      "caution": {
+        "label": "コールアウト（Caution）",
+        "description": ""
+      }
     }
   }
 }

--- a/apps/app/public/static/locales/ko_KR/translation.json
+++ b/apps/app/public/static/locales/ko_KR/translation.json
@@ -1109,6 +1109,14 @@
     "table": {
       "label": "표",
       "description": ""
+    },
+    "link": {
+      "label": "링크",
+      "description": ""
+    },
+    "tableBuilder": {
+      "label": "표 빌더",
+      "description": ""
     }
   }
 }

--- a/apps/app/public/static/locales/zh_CN/translation.json
+++ b/apps/app/public/static/locales/zh_CN/translation.json
@@ -1144,6 +1144,14 @@
     "table": {
       "label": "表格",
       "description": ""
+    },
+    "link": {
+      "label": "链接",
+      "description": ""
+    },
+    "tableBuilder": {
+      "label": "表格构建器",
+      "description": ""
     }
   }
 }

--- a/apps/app/src/features/callout/services/consts.ts
+++ b/apps/app/src/features/callout/services/consts.ts
@@ -1,13 +1,4 @@
-// Ref: https://github.com/Microflash/remark-callout-directives/blob/fabe4d8adc7738469f253836f0da346591ea2a2b/themes/github/index.js
-// Ref: https://github.com/orgs/community/discussions/16925
-
-export const AllCallout = [
-  'note',
-  'tip',
-  'important',
-  'info',
-  'warning',
-  'danger',
-  'caution',
-] as const;
-export type Callout = (typeof AllCallout)[number];
+// Single source of truth moved to @growi/core (packages/core/src/consts/callout.ts),
+// shared with the editor slash commands. Re-exported here so existing importers
+// (callout.ts / CalloutViewer.tsx) keep working unchanged.
+export { AllCallout, type Callout } from '@growi/core/dist/consts';

--- a/packages/core/src/consts/callout.ts
+++ b/packages/core/src/consts/callout.ts
@@ -1,0 +1,19 @@
+// Ref: https://github.com/Microflash/remark-callout-directives/blob/fabe4d8adc7738469f253836f0da346591ea2a2b/themes/github/index.js
+// Ref: https://github.com/orgs/community/discussions/16925
+
+/**
+ * Callout (admonition) variant names — the single source of truth shared by the
+ * renderer (the remark plugin in apps/app `features/callout`) and the editor
+ * slash commands (`packages/editor` extended-elements). Adding or removing a
+ * variant is a one-line change here that propagates to both.
+ */
+export const AllCallout = [
+  'note',
+  'tip',
+  'important',
+  'info',
+  'warning',
+  'danger',
+  'caution',
+] as const;
+export type Callout = (typeof AllCallout)[number];

--- a/packages/core/src/consts/index.ts
+++ b/packages/core/src/consts/index.ts
@@ -1,4 +1,5 @@
 export * from './accepted-upload-file-type.js';
+export * from './callout.js';
 export * from './growi-plugin.js';
 export * from './renderer.js';
 export * from './system.js';

--- a/packages/editor/src/client/components-internal/CodeMirrorEditor/CodeMirrorEditor.tsx
+++ b/packages/editor/src/client/components-internal/CodeMirrorEditor/CodeMirrorEditor.tsx
@@ -87,7 +87,7 @@ export const CodeMirrorEditor = (props: Props): JSX.Element => {
     cmProps,
   );
 
-  useDefaultExtensions(codeMirrorEditor);
+  useDefaultExtensions(codeMirrorEditor, editorKey);
   useEditorSettings(codeMirrorEditor, editorSettings, onSave);
 
   useShowTableIcon(codeMirrorEditor);

--- a/packages/editor/src/client/services-internal/slash-command/extended-elements/callout-variants.ts
+++ b/packages/editor/src/client/services-internal/slash-command/extended-elements/callout-variants.ts
@@ -1,0 +1,50 @@
+import type { Callout } from '@growi/core/dist/consts';
+
+/**
+ * The visually-distinct callout types offered in the slash menu.
+ *
+ * GROWI's renderer (apps/app `CalloutViewer`'s `CALLOUT_TO_TYPE`) renders `info`
+ * identically to `important` and `danger` identically to `caution`, so only these
+ * five are visually distinct. The alias names are exposed as filter keywords below
+ * (e.g. `/info` reaches `important`, `/danger` reaches `caution`) rather than as
+ * duplicate menu entries.
+ *
+ * `@growi/core`'s `AllCallout` keeps all seven names as valid directives for the
+ * parser/renderer; this list is only the slash-menu subset. Keep it in sync with
+ * the renderer's `CALLOUT_TO_TYPE` aliasing. Typed as `Callout[]` so a typo is
+ * caught against the shared `@growi/core` definition.
+ */
+const DISTINCT_CALLOUTS: readonly Callout[] = [
+  'note',
+  'tip',
+  'important',
+  'warning',
+  'caution',
+];
+
+/**
+ * Extra filter aliases per distinct type (the type name itself is added below).
+ * `info` / `danger` are the alias directive names that render as `important` /
+ * `caution` respectively, so they filter to those commands.
+ */
+const KEYWORDS: Partial<Record<Callout, readonly string[]>> = {
+  tip: ['hint'],
+  important: ['info', 'information'],
+  warning: ['warn'],
+  caution: ['danger'],
+};
+
+export interface CalloutVariant {
+  readonly type: Callout;
+  readonly keywords: readonly string[];
+}
+
+/**
+ * callout variants for the slash menu: one command per visually-distinct type,
+ * with alias directive names folded in as filter keywords.
+ */
+export const CALLOUT_VARIANTS: readonly CalloutVariant[] =
+  DISTINCT_CALLOUTS.map((type) => ({
+    type,
+    keywords: [type, ...(KEYWORDS[type] ?? [])],
+  }));

--- a/packages/editor/src/client/services-internal/slash-command/extended-elements/composition.integ.ts
+++ b/packages/editor/src/client/services-internal/slash-command/extended-elements/composition.integ.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { currentCompletions, startCompletion } from '@codemirror/autocomplete';
+import { EditorSelection, EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import type { TFunction } from 'i18next';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  baseExtensions,
+  createSlashCommandExtension,
+} from '../../../stores/use-default-extensions';
+import {
+  buildExtendedElementCommands,
+  type ExtendedElementModalOpeners,
+} from './use-extended-element-commands';
+
+/**
+ * Guards the composition point: extended commands passed to
+ * `createSlashCommandExtension(t, extended)` (the real merge done in
+ * `useDefaultExtensions`) actually surface through the shared autocomplete
+ * facility — not just in isolation. Complements the base-only coexistence integ
+ * (`slash-command-source.integ.ts`), which calls `createSlashCommandExtension(t)`
+ * without extended commands.
+ *
+ * `t` is an identity stub, so labels surface as their raw `slash_command.*` keys.
+ */
+const t = ((key: string) => key) as unknown as TFunction;
+
+const noopOpeners = (): ExtendedElementModalOpeners => ({
+  openDrawio: vi.fn(),
+  openLink: vi.fn(),
+  openTableBuilder: vi.fn(),
+});
+
+describe('extended commands surface through the composed slash extension', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  const labelsAt = async (
+    doc: string,
+    pos: number,
+    editorKey?: string,
+  ): Promise<string[]> => {
+    const extended = buildExtendedElementCommands(editorKey, noopOpeners());
+    const view = new EditorView({
+      state: EditorState.create({
+        doc,
+        selection: EditorSelection.cursor(pos),
+        extensions: [
+          ...baseExtensions,
+          createSlashCommandExtension(t, extended),
+        ],
+      }),
+    });
+    startCompletion(view);
+    await vi.advanceTimersByTimeAsync(50);
+    const labels = currentCompletions(view.state).map((c) => c.label);
+    view.destroy();
+    return labels;
+  };
+
+  it('offers the static extended commands (plantuml / callout / lsx)', async () => {
+    expect(await labelsAt('/plantuml', 9)).toContain(
+      'slash_command.plantuml.label',
+    );
+    expect(await labelsAt('/callout', 8)).toContain(
+      'slash_command.callout.note.label',
+    );
+    expect(await labelsAt('/lsx', 4)).toContain('slash_command.lsx.label');
+    // id is `lsx`, so `/ls` reaches it too
+    expect(await labelsAt('/ls', 3)).toContain('slash_command.lsx.label');
+  });
+
+  it('offers drawio only when editorKey is present', async () => {
+    expect(await labelsAt('/drawio', 7, 'main')).toContain(
+      'slash_command.drawio.label',
+    );
+    expect(await labelsAt('/drawio', 7, undefined)).not.toContain(
+      'slash_command.drawio.label',
+    );
+  });
+
+  it('still offers base commands alongside the extended ones', async () => {
+    // `/head` matches the base heading commands; extended merge must not drop them
+    expect(await labelsAt('/head', 5, 'main')).toContain(
+      'slash_command.heading1.label',
+    );
+  });
+});

--- a/packages/editor/src/client/services-internal/slash-command/extended-elements/ensure-block-line-start.spec.ts
+++ b/packages/editor/src/client/services-internal/slash-command/extended-elements/ensure-block-line-start.spec.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { EditorSelection, EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { describe, expect, it } from 'vitest';
+
+import { ensureBlockLineStart } from './ensure-block-line-start.js';
+
+const createView = (doc: string, from: number): EditorView => {
+  const state = EditorState.create({
+    doc,
+    selection: EditorSelection.create([EditorSelection.cursor(from)]),
+  });
+  return new EditorView({ state });
+};
+
+/**
+ * The contract: after normalization the cursor sits at the start of a line whose
+ * previous line is blank, so a block inserted at the cursor is separated from any
+ * preceding paragraph by a blank line (required for a GFM table to render).
+ */
+const expectSeparatedFromParagraph = (view: EditorView): void => {
+  const { head } = view.state.selection.main;
+  const cursorLine = view.state.doc.lineAt(head);
+  expect(head).toBe(cursorLine.from); // cursor at line start
+  const prevLine = view.state.doc.line(cursorLine.number - 1);
+  expect(prevLine.text).toBe(''); // blank line precedes the insertion point
+};
+
+describe('ensureBlockLineStart', () => {
+  it('leaves the document untouched at line start', () => {
+    const view = createView('foo\n', 4); // start of the empty second line
+
+    ensureBlockLineStart(view, 4);
+
+    expect(view.state.doc.toString()).toBe('foo\n');
+    expect(view.state.selection.main.head).toBe(4);
+  });
+
+  it('treats a whitespace-only prefix as line start', () => {
+    const view = createView('  ', 2);
+
+    ensureBlockLineStart(view, 2);
+
+    expect(view.state.doc.toString()).toBe('  ');
+    expect(view.state.selection.main.head).toBe(2);
+  });
+
+  it('mid-line: inserts a BLANK line so the following block is separated from the paragraph', () => {
+    const view = createView('図: ', 3); // preceding non-whitespace text
+
+    ensureBlockLineStart(view, 3);
+
+    // a single '\n' would leave the block absorbed into the paragraph (rendered as
+    // literal text); a blank line is required
+    expect(view.state.doc.toString()).toBe('図: \n\n');
+    expect(view.state.selection.main.head).toBe(5);
+    expectSeparatedFromParagraph(view);
+  });
+
+  it('normalizes right after a bare slash trigger position (foo/)', () => {
+    const view = createView('foo/', 4);
+
+    ensureBlockLineStart(view, 4);
+
+    expect(view.state.doc.toString()).toBe('foo/\n\n');
+    expect(view.state.selection.main.head).toBe(6);
+    expectSeparatedFromParagraph(view);
+  });
+});

--- a/packages/editor/src/client/services-internal/slash-command/extended-elements/ensure-block-line-start.ts
+++ b/packages/editor/src/client/services-internal/slash-command/extended-elements/ensure-block-line-start.ts
@@ -1,0 +1,28 @@
+import type { EditorView } from '@codemirror/view';
+
+/**
+ * Ensure a block element a `run` command is about to insert lands on its own line,
+ * separated from any preceding paragraph text (Req 5.4).
+ *
+ * If `pos` is not at line start — some non-whitespace text precedes it on the same
+ * line, e.g. `図: /drawio` — insert a BLANK line (`\n\n`) at `pos` and move the
+ * cursor to the start of the resulting empty line, so the modal's later block
+ * insertion is separated from the preceding paragraph by a blank line. A single
+ * newline is not enough: GFM cannot let a table (or other block) interrupt a
+ * paragraph without a blank line, so it would otherwise be absorbed and rendered as
+ * literal text — the base `insertion-builders` use the same `\n\n` rule for
+ * tables/fences. Otherwise the document is left untouched. At most one `view.dispatch`.
+ *
+ * Only block-element run commands (drawio / table-builder) call this; the inline
+ * link command and the static inline lsx insert must NOT normalize (Req 9.1).
+ */
+export const ensureBlockLineStart = (view: EditorView, pos: number): void => {
+  const line = view.state.doc.lineAt(pos);
+  const before = line.text.slice(0, pos - line.from);
+  if (before.trim() === '') return; // already at (effective) line start
+
+  view.dispatch({
+    changes: { from: pos, insert: '\n\n' },
+    selection: { anchor: pos + 2 },
+  });
+};

--- a/packages/editor/src/client/services-internal/slash-command/extended-elements/index.ts
+++ b/packages/editor/src/client/services-internal/slash-command/extended-elements/index.ts
@@ -1,0 +1,2 @@
+export { STATIC_EXTENDED_COMMANDS } from './static-commands.js';
+export { useExtendedElementCommands } from './use-extended-element-commands.js';

--- a/packages/editor/src/client/services-internal/slash-command/extended-elements/insertion-builders.spec.ts
+++ b/packages/editor/src/client/services-internal/slash-command/extended-elements/insertion-builders.spec.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { EditorSelection, EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { describe, expect, it } from 'vitest';
+
+import {
+  calloutInsertion,
+  lsxInsertion,
+  plantumlInsertion,
+} from './insertion-builders.js';
+
+const createView = (doc: string, from: number): EditorView => {
+  const state = EditorState.create({
+    doc,
+    selection: EditorSelection.create([EditorSelection.cursor(from)]),
+    extensions: [markdown({ base: markdownLanguage })],
+  });
+  return new EditorView({ state });
+};
+
+const PLANTUML_BODY = '```plantuml\n\n```';
+const PLANTUML_CURSOR = '```plantuml\n'.length;
+
+describe('plantumlInsertion', () => {
+  it('at line start: inserts the fence with the cursor on the empty inner line', () => {
+    const view = createView('', 0);
+
+    const result = plantumlInsertion(view, 0);
+
+    expect(result.insert).toBe(PLANTUML_BODY);
+    expect(result.cursorOffset).toBe(PLANTUML_CURSOR);
+    // cursor is on an empty line: newline on both sides
+    expect(result.insert[result.cursorOffset - 1]).toBe('\n');
+    expect(result.insert[result.cursorOffset]).toBe('\n');
+  });
+
+  it('treats a whitespace-only prefix as line start (no separator)', () => {
+    const view = createView('  ', 2);
+
+    expect(plantumlInsertion(view, 2).insert).toBe(PLANTUML_BODY);
+  });
+
+  it('mid-line: prefixes a blank line so the fence is not absorbed into the paragraph', () => {
+    const view = createView('foo ', 4);
+
+    const result = plantumlInsertion(view, 4);
+
+    expect(result.insert).toBe(`\n\n${PLANTUML_BODY}`);
+    expect(result.cursorOffset).toBe('\n\n'.length + PLANTUML_CURSOR);
+  });
+});
+
+describe('calloutInsertion', () => {
+  it('at line start: inserts the directive with the cursor on the empty body line', () => {
+    const view = createView('', 0);
+
+    const result = calloutInsertion('warning')(view, 0);
+
+    expect(result.insert).toBe(':::warning\n\n:::');
+    expect(result.cursorOffset).toBe(':::warning\n'.length);
+    expect(result.insert[result.cursorOffset - 1]).toBe('\n');
+    expect(result.insert[result.cursorOffset]).toBe('\n');
+  });
+
+  it('builds the directive for each type', () => {
+    const view = createView('', 0);
+
+    expect(calloutInsertion('note')(view, 0).insert).toBe(':::note\n\n:::');
+    expect(calloutInsertion('tip')(view, 0).insert).toBe(':::tip\n\n:::');
+    expect(calloutInsertion('caution')(view, 0).insert).toBe(
+      ':::caution\n\n:::',
+    );
+  });
+
+  it('mid-line: prefixes a blank line', () => {
+    const view = createView('foo ', 4);
+
+    const result = calloutInsertion('info')(view, 4);
+
+    expect(result.insert).toBe('\n\n:::info\n\n:::');
+    expect(result.cursorOffset).toBe('\n\n'.length + ':::info\n'.length);
+  });
+});
+
+describe('lsxInsertion', () => {
+  it('inserts `$lsx()` with the cursor inside the parentheses', () => {
+    const result = lsxInsertion();
+
+    expect(result.insert).toBe('$lsx()');
+    expect(result.cursorOffset).toBe('$lsx('.length);
+    // cursor sits right after `(`, before `)`
+    expect(result.insert[result.cursorOffset - 1]).toBe('(');
+    expect(result.insert[result.cursorOffset]).toBe(')');
+  });
+
+  it('is inline: never prefixes a separator (no replaceFromOffset)', () => {
+    const result = lsxInsertion();
+
+    expect(result.insert.startsWith('\n')).toBe(false);
+    expect(result.replaceFromOffset ?? 0).toBe(0);
+  });
+});

--- a/packages/editor/src/client/services-internal/slash-command/extended-elements/insertion-builders.ts
+++ b/packages/editor/src/client/services-internal/slash-command/extended-elements/insertion-builders.ts
@@ -1,0 +1,76 @@
+import type { EditorView } from '@codemirror/view';
+import type { Callout } from '@growi/core/dist/consts';
+
+import type { SlashInsertion } from '../slash-command-types.js';
+
+/**
+ * Whether `from` sits in the middle of a line (some non-whitespace precedes it on
+ * the same line). A small local copy of the base `insertion-builders`' helper: the
+ * base module's public surface stays unchanged (this spec touches only the
+ * composition point), so the primitive is duplicated rather than exported. Keep in
+ * sync with `../insertion-builders.ts`.
+ */
+const hasPrecedingText = (view: EditorView, from: number): boolean => {
+  const line = view.state.doc.lineAt(from);
+  const before = line.text.slice(0, from - line.from);
+  return before.trim() !== '';
+};
+
+/**
+ * Build a position-free block {@link SlashInsertion}. When `from` is mid-line a
+ * blank line (`\n\n`) is prefixed so the block starts fresh without being absorbed
+ * into the preceding paragraph — both a fence and a container directive are block
+ * constructs that need a blank line to interrupt a paragraph in GFM — and the
+ * cursor offset shifts by the prefix length. `view` is read-only here (no dispatch).
+ */
+const buildBlockInsertion = (
+  view: EditorView,
+  from: number,
+  body: string,
+  bodyCursorOffset: number,
+): SlashInsertion => {
+  const prefix = hasPrecedingText(view, from) ? '\n\n' : '';
+  return {
+    insert: `${prefix}${body}`,
+    cursorOffset: prefix.length + bodyCursorOffset,
+  };
+};
+
+/**
+ * Empty plantuml fenced block; the cursor lands on the empty content line.
+ * `@startuml`/`@enduml` are omitted on purpose: `remark-simple-plantuml` encodes
+ * the fence body as-is and the PlantUML server auto-wraps missing tags, so they are
+ * not required — an empty fence (like a code block) keeps the template minimal.
+ */
+const PLANTUML_BODY = '```plantuml\n\n```';
+const PLANTUML_CURSOR_OFFSET = '```plantuml\n'.length;
+
+export const plantumlInsertion = (
+  view: EditorView,
+  from: number,
+): SlashInsertion =>
+  buildBlockInsertion(view, from, PLANTUML_BODY, PLANTUML_CURSOR_OFFSET);
+
+/**
+ * callout container directive (`:::<type>` … `:::`) with an empty body line; the
+ * cursor lands on that body line so the user can type the content immediately.
+ */
+export const calloutInsertion =
+  (type: Callout) =>
+  (view: EditorView, from: number): SlashInsertion => {
+    const body = `:::${type}\n\n:::`;
+    const bodyCursorOffset = `:::${type}\n`.length;
+    return buildBlockInsertion(view, from, body, bodyCursorOffset);
+  };
+
+/**
+ * lsx directive `$lsx()` with the cursor placed inside the parentheses so the user
+ * types options directly. Unlike plantuml/callout this is an INLINE growi directive
+ * (`@growi/remark-growi-directive` Text/Leaf), so it needs no block separator and is
+ * valid anywhere — including a table cell or list item. Position-free: it ignores
+ * line context and always returns the same insertion (hence no `view`/`from`).
+ */
+export const lsxInsertion = (): SlashInsertion => ({
+  insert: '$lsx()',
+  cursorOffset: '$lsx('.length,
+});

--- a/packages/editor/src/client/services-internal/slash-command/extended-elements/static-commands.spec.ts
+++ b/packages/editor/src/client/services-internal/slash-command/extended-elements/static-commands.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import { CALLOUT_VARIANTS } from './callout-variants.js';
+import { STATIC_EXTENDED_COMMANDS } from './static-commands.js';
+
+describe('STATIC_EXTENDED_COMMANDS', () => {
+  const byId = new Map(STATIC_EXTENDED_COMMANDS.map((c) => [c.id, c]));
+
+  it('provides plantuml + lsx + one command per distinct callout variant', () => {
+    expect(STATIC_EXTENDED_COMMANDS).toHaveLength(2 + CALLOUT_VARIANTS.length);
+    expect(byId.has('plantuml')).toBe(true);
+    expect(byId.has('lsx')).toBe(true);
+    for (const v of CALLOUT_VARIANTS) {
+      expect(byId.has(`callout-${v.type}`)).toBe(true);
+    }
+  });
+
+  it('offers only the 5 visually-distinct callout types (info/danger are aliases, not commands)', () => {
+    expect(CALLOUT_VARIANTS.map((v) => v.type)).toEqual([
+      'note',
+      'tip',
+      'important',
+      'warning',
+      'caution',
+    ]);
+    // info renders as important and danger as caution, so no separate commands
+    expect(byId.has('callout-info')).toBe(false);
+    expect(byId.has('callout-danger')).toBe(false);
+  });
+
+  it('does not offer unselected elements (math / mermaid / image)', () => {
+    for (const forbidden of ['math', 'katex', 'mermaid', 'image']) {
+      expect(byId.has(forbidden)).toBe(false);
+      expect(
+        STATIC_EXTENDED_COMMANDS.some((c) => c.keywords.includes(forbidden)),
+      ).toBe(false);
+    }
+  });
+
+  it('is an insert command in every case', () => {
+    for (const c of STATIC_EXTENDED_COMMANDS) {
+      expect(c.action.kind).toBe('insert');
+    }
+  });
+
+  it('excludes block-level commands (plantuml/callout) from list/table, but not inline lsx', () => {
+    expect(byId.get('plantuml')?.disallowedIn).toEqual(['list', 'table']);
+    for (const v of CALLOUT_VARIANTS) {
+      expect(byId.get(`callout-${v.type}`)?.disallowedIn).toEqual([
+        'list',
+        'table',
+      ]);
+    }
+    // lsx is an inline directive → no disallowedIn (offered everywhere)
+    expect(byId.get('lsx')?.disallowedIn).toBeUndefined();
+  });
+
+  it('plantuml carries its i18n keys and uml keywords', () => {
+    const plantuml = byId.get('plantuml');
+    expect(plantuml?.labelKey).toBe('slash_command.plantuml.label');
+    expect(plantuml?.descriptionKey).toBe('slash_command.plantuml.description');
+    expect(plantuml?.keywords).toEqual(
+      expect.arrayContaining(['uml', 'sequence']),
+    );
+  });
+
+  it('lsx carries its i18n keys and is reachable via /ls and /lsx', () => {
+    const lsx = byId.get('lsx');
+    expect(lsx?.action.kind).toBe('insert');
+    expect(lsx?.labelKey).toBe('slash_command.lsx.label');
+    expect(lsx?.descriptionKey).toBe('slash_command.lsx.description');
+    expect(lsx?.id).toBe('lsx');
+    expect(lsx?.keywords).toEqual(
+      expect.arrayContaining(['ls', 'list', 'pages', 'tree']),
+    );
+  });
+
+  it('each callout command shares the "callout" keyword and per-type i18n keys', () => {
+    for (const v of CALLOUT_VARIANTS) {
+      const cmd = byId.get(`callout-${v.type}`);
+      expect(cmd?.keywords).toContain('callout');
+      expect(cmd?.keywords).toContain(v.type);
+      expect(cmd?.labelKey).toBe(`slash_command.callout.${v.type}.label`);
+      expect(cmd?.descriptionKey).toBe(
+        `slash_command.callout.${v.type}.description`,
+      );
+    }
+  });
+
+  it('reaches aliased types via their directive names: warn→warning, info→important, danger→caution', () => {
+    expect(byId.get('callout-warning')?.keywords).toContain('warn');
+    // `info` renders as important, so it filters to the important command
+    expect(byId.get('callout-important')?.keywords).toContain('info');
+    // `danger` renders as caution, so it filters to the caution command
+    expect(byId.get('callout-caution')?.keywords).toContain('danger');
+  });
+});

--- a/packages/editor/src/client/services-internal/slash-command/extended-elements/static-commands.ts
+++ b/packages/editor/src/client/services-internal/slash-command/extended-elements/static-commands.ts
@@ -1,0 +1,51 @@
+import type { SlashCommand } from '../slash-command-types.js';
+import { CALLOUT_VARIANTS } from './callout-variants.js';
+import {
+  calloutInsertion,
+  lsxInsertion,
+  plantumlInsertion,
+} from './insertion-builders.js';
+
+/**
+ * Static (side-effect-free) extended commands: plantuml + one command per callout
+ * variant + lsx.
+ *
+ * plantuml and callout are block elements, so they declare
+ * `disallowedIn: ['list','table']` (base context exclusion — a fence or `:::`
+ * directive would break a list item / table cell). lsx is an INLINE growi directive
+ * (`$lsx()`), so it declares no `disallowedIn` and is offered everywhere. The callout
+ * set is generated from {@link CALLOUT_VARIANTS} so a variant added in `@growi/core`
+ * propagates here.
+ *
+ * i18n keys follow the base convention `slash_command.<id>.(label|description)`;
+ * callout ids are `callout-<type>` and its keys `slash_command.callout.<type>.*`.
+ */
+export const STATIC_EXTENDED_COMMANDS: readonly SlashCommand[] = [
+  {
+    id: 'plantuml',
+    labelKey: 'slash_command.plantuml.label',
+    descriptionKey: 'slash_command.plantuml.description',
+    keywords: ['uml', 'sequence'],
+    disallowedIn: ['list', 'table'],
+    action: { kind: 'insert', buildInsertion: plantumlInsertion },
+  },
+  ...CALLOUT_VARIANTS.map(
+    (v): SlashCommand => ({
+      id: `callout-${v.type}`,
+      labelKey: `slash_command.callout.${v.type}.label`,
+      descriptionKey: `slash_command.callout.${v.type}.description`,
+      keywords: ['callout', ...v.keywords],
+      disallowedIn: ['list', 'table'],
+      action: { kind: 'insert', buildInsertion: calloutInsertion(v.type) },
+    }),
+  ),
+  {
+    id: 'lsx',
+    labelKey: 'slash_command.lsx.label',
+    descriptionKey: 'slash_command.lsx.description',
+    // id `lsx` so both `/ls` and `/lsx` reach it by prefix match on the id.
+    keywords: ['ls', 'list', 'pages', 'tree'],
+    // Inline directive: no `disallowedIn` — valid inside a table cell / list item.
+    action: { kind: 'insert', buildInsertion: lsxInsertion },
+  },
+];

--- a/packages/editor/src/client/services-internal/slash-command/extended-elements/use-extended-element-commands.spec.ts
+++ b/packages/editor/src/client/services-internal/slash-command/extended-elements/use-extended-element-commands.spec.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { EditorSelection, EditorState } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { SlashCommand } from '../slash-command-types.js';
+import {
+  buildExtendedElementCommands,
+  type ExtendedElementModalOpeners,
+} from './use-extended-element-commands.js';
+
+const createView = (doc: string, pos: number): EditorView =>
+  new EditorView({
+    state: EditorState.create({
+      doc,
+      selection: EditorSelection.create([EditorSelection.cursor(pos)]),
+    }),
+  });
+
+const makeOpeners = (): ExtendedElementModalOpeners => ({
+  openDrawio: vi.fn(),
+  openLink: vi.fn(),
+  openTableBuilder: vi.fn(),
+});
+
+const byId = (cmds: readonly SlashCommand[]) =>
+  new Map(cmds.map((c) => [c.id, c]));
+
+/** Narrow to a `run` action's callback or fail the test. */
+const runOf = (cmd: SlashCommand | undefined) => {
+  if (cmd == null || cmd.action.kind !== 'run') {
+    throw new Error('expected a run command');
+  }
+  return cmd.action.run;
+};
+
+describe('buildExtendedElementCommands', () => {
+  it('offers drawio only when editorKey is present', () => {
+    expect(
+      byId(buildExtendedElementCommands('main', makeOpeners())).has('drawio'),
+    ).toBe(true);
+    expect(
+      byId(buildExtendedElementCommands(undefined, makeOpeners())).has(
+        'drawio',
+      ),
+    ).toBe(false);
+  });
+
+  it('always offers link, table-builder and the static commands (editorKey or not)', () => {
+    for (const editorKey of ['main', undefined] as const) {
+      const m = byId(buildExtendedElementCommands(editorKey, makeOpeners()));
+      expect(m.has('link')).toBe(true);
+      expect(m.has('tableBuilder')).toBe(true);
+      expect(m.has('plantuml')).toBe(true);
+      expect(m.has('lsx')).toBe(true);
+      expect(m.has('callout-note')).toBe(true);
+    }
+  });
+
+  it('drawio: block-normalizes the line, then opens the modal with editorKey', () => {
+    const openers = makeOpeners();
+    const drawio = byId(buildExtendedElementCommands('main', openers)).get(
+      'drawio',
+    );
+    const view = createView('図: ', 3); // mid-line trigger
+
+    runOf(drawio)(view, 3);
+
+    // observable: a blank line now separates the insertion point from the paragraph
+    expect(view.state.doc.toString()).toBe('図: \n\n');
+    expect(openers.openDrawio).toHaveBeenCalledWith('main');
+  });
+
+  it('table-builder: block-normalizes the line, then opens the modal with the view', () => {
+    const openers = makeOpeners();
+    const tableBuilder = byId(
+      buildExtendedElementCommands('main', openers),
+    ).get('tableBuilder');
+    const view = createView('図: ', 3);
+
+    runOf(tableBuilder)(view, 3);
+
+    expect(view.state.doc.toString()).toBe('図: \n\n');
+    expect(openers.openTableBuilder).toHaveBeenCalledWith(view);
+  });
+
+  it('link: inline — does NOT normalize; opens with a write-back onSave that inserts the link', () => {
+    const openers = makeOpeners();
+    const link = byId(buildExtendedElementCommands('main', openers)).get(
+      'link',
+    );
+    const view = createView('図: ', 3);
+
+    runOf(link)(view, 3);
+
+    // inline element: the document is left untouched (no blank line inserted)
+    expect(view.state.doc.toString()).toBe('図: ');
+    expect(openers.openLink).toHaveBeenCalledTimes(1);
+
+    // the onSave handed to the modal writes the confirmed link back into the editor
+    const onSave = vi.mocked(openers.openLink).mock.calls[0][1];
+    onSave('[title](https://example.com)');
+    expect(view.state.doc.toString()).toContain('[title](https://example.com)');
+  });
+});

--- a/packages/editor/src/client/services-internal/slash-command/extended-elements/use-extended-element-commands.ts
+++ b/packages/editor/src/client/services-internal/slash-command/extended-elements/use-extended-element-commands.ts
@@ -1,0 +1,128 @@
+import { useMemo, useRef } from 'react';
+import type { EditorView } from '@codemirror/view';
+
+import { useDrawioModalForEditorActions } from '../../../../states/modal/drawio-for-editor.js';
+import { useHandsontableModalForEditorActions } from '../../../../states/modal/handsontable.js';
+import { useLinkEditModalActions } from '../../../../states/modal/link-edit.js';
+import {
+  getMarkdownLink,
+  replaceFocusedMarkdownLinkWithEditor,
+} from '../../link-util/markdown-link-util.js';
+import type { SlashCommand } from '../slash-command-types.js';
+import { ensureBlockLineStart } from './ensure-block-line-start.js';
+import { STATIC_EXTENDED_COMMANDS } from './static-commands.js';
+
+/**
+ * The modal openers the run commands bind. Derived from the existing trigger hooks
+ * so the signatures (e.g. drawio's `open(editorKey)` vs table-builder's
+ * `open(view)`) stay in sync with them.
+ */
+export interface ExtendedElementModalOpeners {
+  readonly openDrawio: ReturnType<
+    typeof useDrawioModalForEditorActions
+  >['open'];
+  readonly openLink: ReturnType<typeof useLinkEditModalActions>['open'];
+  readonly openTableBuilder: ReturnType<
+    typeof useHandsontableModalForEditorActions
+  >['open'];
+}
+
+/**
+ * Build the extended-element command set (pure): side-effect (`run`) commands that
+ * open existing modals, plus the static ({@link STATIC_EXTENDED_COMMANDS}) ones. The
+ * base composition point concats this after `SLASH_COMMANDS`.
+ *
+ * `editorKey` is required only by drawio (its opener takes `open(editorKey)`);
+ * link/table-builder take the `EditorView` that `run` already receives, and the
+ * static commands (plantuml/callout/lsx) are context-free. When `editorKey` is
+ * absent (e.g. the diff editor) only drawio is omitted.
+ *
+ * Extracted from the hook so the gating/ordering/normalization logic is unit-testable
+ * without a React renderer.
+ */
+export const buildExtendedElementCommands = (
+  editorKey: string | undefined,
+  openers: ExtendedElementModalOpeners,
+): readonly SlashCommand[] => {
+  const runCommands: SlashCommand[] = [];
+
+  // drawio needs editorKey; skip it when unavailable (lsx is a static inline
+  // insert in STATIC_EXTENDED_COMMANDS, not a run command gated by editorKey).
+  if (editorKey != null) {
+    runCommands.push({
+      id: 'drawio',
+      labelKey: 'slash_command.drawio.label',
+      descriptionKey: 'slash_command.drawio.description',
+      keywords: ['diagram', 'draw'],
+      disallowedIn: ['list', 'table'], // block element (```drawio fence)
+      action: {
+        kind: 'run',
+        run: (view: EditorView, from: number) => {
+          ensureBlockLineStart(view, from);
+          openers.openDrawio(editorKey);
+        },
+      },
+    });
+  }
+
+  runCommands.push({
+    id: 'link',
+    labelKey: 'slash_command.link.label',
+    descriptionKey: 'slash_command.link.description',
+    keywords: ['url', 'href'],
+    // inline element: no disallowedIn, no line-start normalization (Req 9.1)
+    action: {
+      kind: 'run',
+      run: (view: EditorView) => {
+        openers.openLink(getMarkdownLink(view), (linkText) =>
+          replaceFocusedMarkdownLinkWithEditor(view, linkText),
+        );
+      },
+    },
+  });
+
+  runCommands.push({
+    id: 'tableBuilder',
+    labelKey: 'slash_command.tableBuilder.label',
+    descriptionKey: 'slash_command.tableBuilder.description',
+    keywords: ['table', 'grid', 'builder'],
+    disallowedIn: ['list', 'table'], // block element (Markdown table)
+    action: {
+      kind: 'run',
+      run: (view: EditorView, from: number) => {
+        ensureBlockLineStart(view, from);
+        openers.openTableBuilder(view);
+      },
+    },
+  });
+
+  return [...runCommands, ...STATIC_EXTENDED_COMMANDS];
+};
+
+/**
+ * React wrapper over {@link buildExtendedElementCommands}: reads the modal openers
+ * from their trigger hooks and memoizes the command list on `editorKey`.
+ *
+ * The openers are fresh functions each render but close over stable jotai setters,
+ * so they are held in a ref and excluded from the memo deps — keeping the returned
+ * list stable across renders so the slash extension is not re-registered every render.
+ */
+export const useExtendedElementCommands = (
+  editorKey?: string,
+): readonly SlashCommand[] => {
+  const { open: openDrawio } = useDrawioModalForEditorActions();
+  const { open: openLink } = useLinkEditModalActions();
+  const { open: openTableBuilder } = useHandsontableModalForEditorActions();
+
+  const openersRef = useRef<ExtendedElementModalOpeners>({
+    openDrawio,
+    openLink,
+    openTableBuilder,
+  });
+  openersRef.current = { openDrawio, openLink, openTableBuilder };
+
+  return useMemo(
+    () => buildExtendedElementCommands(editorKey, openersRef.current),
+    [editorKey],
+  );
+};

--- a/packages/editor/src/client/services-internal/slash-command/index.ts
+++ b/packages/editor/src/client/services-internal/slash-command/index.ts
@@ -1,4 +1,8 @@
 export {
+  STATIC_EXTENDED_COMMANDS,
+  useExtendedElementCommands,
+} from './extended-elements/index.js';
+export {
   codeBlockInsertion,
   lineMarkerInsertion,
   tableInsertion,

--- a/packages/editor/src/client/stores/use-default-extensions.ts
+++ b/packages/editor/src/client/stores/use-default-extensions.ts
@@ -20,10 +20,13 @@ import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 
 import type { UseCodeMirrorEditor } from '../services/index.js';
+import type { SlashCommand } from '../services-internal/index.js';
 import {
   createSlashCommandSource,
   emojiAutocompletionSettings,
   resolveSlashCommands,
+  SLASH_COMMANDS,
+  useExtendedElementCommands,
 } from '../services-internal/index.js';
 
 // set new markdownKeymap instead of default one
@@ -81,9 +84,16 @@ const defaultExtensions: Extension[] = [
 // and break mention). Labels are resolved via `t`; no `/` keybinding is added, so
 // the slash menu fires from typed input and the global `/` (page search) is
 // preserved (Req 6.4).
-export const createSlashCommandExtension = (t: TFunction): Extension =>
+export const createSlashCommandExtension = (
+  t: TFunction,
+  extendedCommands: readonly SlashCommand[] = [],
+): Extension =>
   markdownLanguage.data.of({
-    autocomplete: createSlashCommandSource(resolveSlashCommands(t)),
+    autocomplete: createSlashCommandSource(
+      // Base commands + extended commands (static plantuml/callout and, when an
+      // editorKey is available, the run commands drawio/lsx/link/table-builder).
+      resolveSlashCommands(t, [...SLASH_COMMANDS, ...extendedCommands]),
+    ),
   });
 
 /**
@@ -101,12 +111,14 @@ export const buildDefaultExtensionsArg = (
 
 export const useDefaultExtensions = (
   codeMirrorEditor?: UseCodeMirrorEditor,
+  editorKey?: string,
 ): void => {
   const { t } = useTranslation('translation');
+  const extendedCommands = useExtendedElementCommands(editorKey);
 
   const slashCommandExtension = useMemo(
-    () => createSlashCommandExtension(t),
-    [t],
+    () => createSlashCommandExtension(t, extendedCommands),
+    [t, extendedCommands],
   );
 
   const view = codeMirrorEditor?.view;


### PR DESCRIPTION
https://redmine.weseek.co.jp/issues/188117
## 概要

基盤 `editor-slash-command` の上に、**GROWI 固有の拡張要素**と**基盤が対象外としていた要素（リンク・テーブルビルダー）**をスラッシュコマンドとして追加します。基盤のコマンド集合に合流させる形（`use-default-extensions` の合成点）で、基盤の型・`apply` は変更していません。

Spec: `editor-slash-extended-elements`（子スペック。最新版は別ブランチ `feat/188115-188116-editor-slash-extended-elements`）

## 追加コマンド

**静的挿入（insert）**
- `/plantuml` — 空の ```plantuml フェンスを挿入（カーソルは中）。`@startuml/@enduml` は付けない（`remark-simple-plantuml` は本文をそのままエンコードし、PlantUML サーバがタグを自動補完するため不要）
- `/callout` — **視覚的に区別できる5種**（note / tip / important / warning / caution）を種別ごとに挿入。`info`・`danger` は描画側（`CalloutViewer` の `CALLOUT_TO_TYPE`）で important・caution と同一表示になるため、**別コマンドにせず絞り込み別名**として到達（`/info`→important、`/danger`→caution、`/warn`→warning）
- `/lsx`（`/ls` でも到達）— `$lsx()` をインライン挿入し、カーソルをカッコ内に置く（オプションは手入力）。インラインディレクティブなので `disallowedIn`・行頭正規化なし

**副作用起動（run、既存モーダルを再利用）**
- `/drawio` — 既存 drawio モーダル起動（`editorKey` を要する）
- `/link` — 既存 Edit Link モーダル起動（インライン。行頭正規化しない）
- テーブルビルダー — 既存 Handsontable モーダル起動（ブロック）

