### PR TITLE
fix: Read-only users could publish/unpublish pages

### DIFF
--- a/apps/app/src/components/PageView/PageAlerts/WipPageAlert.spec.tsx
+++ b/apps/app/src/components/PageView/PageAlerts/WipPageAlert.spec.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { WipPageAlert } from './WipPageAlert';
+
+const useIsReadOnlyUser = vi.hoisted(() => vi.fn().mockReturnValue(false));
+const useCurrentPageData = vi.hoisted(() => vi.fn());
+const useFetchCurrentPage = vi.hoisted(() =>
+  vi.fn().mockReturnValue({ fetchCurrentPage: vi.fn() }),
+);
+
+vi.mock('~/states/context', () => ({
+  useIsReadOnlyUser,
+}));
+
+vi.mock('~/states/page', () => ({
+  useCurrentPageData,
+  useFetchCurrentPage,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('WipPageAlert', () => {
+  it('renders the publish alert when the page is WIP and the user is not read-only', () => {
+    useIsReadOnlyUser.mockReturnValue(false);
+    useCurrentPageData.mockReturnValue({ _id: 'page1', wip: true });
+
+    render(<WipPageAlert />);
+
+    expect(
+      screen.getByRole('button', { name: 'wip_page.publish_page' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders nothing when the page is not WIP', () => {
+    useIsReadOnlyUser.mockReturnValue(false);
+    useCurrentPageData.mockReturnValue({ _id: 'page1', wip: false });
+
+    render(<WipPageAlert />);
+
+    expect(
+      screen.queryByRole('button', { name: 'wip_page.publish_page' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders nothing for a read-only user, even when the page is WIP', () => {
+    useIsReadOnlyUser.mockReturnValue(true);
+    useCurrentPageData.mockReturnValue({ _id: 'page1', wip: true });
+
+    render(<WipPageAlert />);
+
+    // A read-only user can never successfully call the publish API
+    // (excludeReadOnlyUser rejects it server-side), so the button
+    // that would trigger it must not be shown at all.
+    expect(
+      screen.queryByRole('button', { name: 'wip_page.publish_page' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/app/src/components/PageView/PageAlerts/WipPageAlert.tsx
+++ b/apps/app/src/components/PageView/PageAlerts/WipPageAlert.tsx
@@ -1,12 +1,14 @@
 import React, { type JSX, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useIsReadOnlyUser } from '~/states/context';
 import { useCurrentPageData, useFetchCurrentPage } from '~/states/page';
 
 export const WipPageAlert = (): JSX.Element => {
   const { t } = useTranslation();
   const currentPage = useCurrentPageData();
   const { fetchCurrentPage } = useFetchCurrentPage();
+  const isReadOnlyUser = useIsReadOnlyUser();
 
   const clickPagePublishButton = useCallback(async () => {
     const pageId = currentPage?._id;
@@ -41,7 +43,7 @@ export const WipPageAlert = (): JSX.Element => {
     }
   }, [currentPage?._id, fetchCurrentPage, t]);
 
-  if (!currentPage?.wip) {
+  if (!currentPage?.wip || !!isReadOnlyUser) {
     return <></>;
   }
 

--- a/apps/app/src/server/routes/apiv3/page/publish-page.integ.ts
+++ b/apps/app/src/server/routes/apiv3/page/publish-page.integ.ts
@@ -19,8 +19,8 @@
  */
 
 import type { IUserHasId } from '@growi/core';
-import type { RequestHandler } from 'express';
 import mongoose, { Types } from 'mongoose';
+import { mock } from 'vitest-mock-extended';
 
 import { getInstance } from '^/test/setup/crowi';
 
@@ -29,33 +29,14 @@ import type { PageModel } from '~/server/models/page';
 
 import type { ApiV3Response } from '../interfaces/apiv3-response';
 import { publishPageHandlersFactory } from './publish-page';
+import { runMiddlewareChain } from './test-utils/run-middleware-chain';
 
 const TEST_USERNAME = 'publish-page-integ-readonly-user';
-
-/** Run the handler array as Express would, stopping at the first middleware
- * that does not call `next()` (i.e. the one that sent a response). */
-async function runMiddlewareChain(
-  handlers: RequestHandler[],
-  // biome-ignore lint/suspicious/noExplicitAny: minimal Express request shape
-  req: any,
-  res: ApiV3Response,
-): Promise<void> {
-  for (const handler of handlers) {
-    let nextCalled = false;
-    // biome-ignore lint/performance/noAwaitInLoops: middlewares must run sequentially, in Express's own order
-    // biome-ignore lint/suspicious/noExplicitAny: express-validator chains and handlers have varying signatures
-    await (handler as any)(req, res, () => {
-      nextCalled = true;
-    });
-    if (!nextCalled) {
-      return;
-    }
-  }
-}
 
 describe('publish-page — a read-only user must not be able to publish a page', () => {
   let crowi: Crowi;
   let readOnlyUser: IUserHasId;
+  let normalUser: IUserHasId;
 
   beforeAll(async () => {
     crowi = await getInstance();
@@ -66,17 +47,26 @@ describe('publish-page — a read-only user must not be able to publish a page',
       email: 'publish-page-integ-readonly@example.com',
       readOnly: true,
     });
+
+    normalUser = await crowi.models.User.create({
+      name: 'Publish Page Integ Normal User',
+      username: `${TEST_USERNAME}-normal`,
+      email: 'publish-page-integ-normal@example.com',
+      readOnly: false,
+    });
   }, 120_000);
 
   afterAll(async () => {
-    await crowi.models.User.deleteMany({ username: TEST_USERNAME });
+    await crowi.models.User.deleteMany({
+      username: { $in: [TEST_USERNAME, `${TEST_USERNAME}-normal`] },
+    });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('rejects the request and never publishes the page', async () => {
+  it('rejects the request with "This user is read only user" and never publishes the page', async () => {
     const pageId = new Types.ObjectId();
 
     const Page = mongoose.model<unknown, PageModel>('Page');
@@ -102,21 +92,66 @@ describe('publish-page — a read-only user must not be able to publish a page',
 
     const apiv3 = vi.fn();
     const apiv3Err = vi.fn();
-    const res = {
-      apiv3,
-      apiv3Err,
-      // biome-ignore lint/suspicious/noExplicitAny: minimal ApiV3Response stub
-    } as any as ApiV3Response;
+    const res = mock<ApiV3Response>({ apiv3, apiv3Err });
 
     const handlers = publishPageHandlersFactory(crowi);
     await runMiddlewareChain(handlers, req, res);
 
-    // The read-only user must be rejected with an error response...
-    expect(apiv3Err).toHaveBeenCalled();
+    // The read-only user must be rejected by excludeReadOnlyUser specifically,
+    // not by some other middleware that happens to also reject...
+    expect(apiv3Err).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'This user is read only user',
+        code: 'validation_failed',
+      }),
+    );
     expect(apiv3).not.toHaveBeenCalled();
 
     // ...and the page must never actually be published.
     expect(findByIdAndViewerSpy).not.toHaveBeenCalled();
     expect(publishSpy).not.toHaveBeenCalled();
+  });
+
+  it('lets a non-read-only user pass through to publish the page', async () => {
+    const pageId = new Types.ObjectId();
+
+    const Page = mongoose.model<unknown, PageModel>('Page');
+    const publishSpy = vi.fn();
+    const fakePage = {
+      _id: pageId,
+      path: '/publish-page-integ-target',
+      publish: publishSpy,
+      save: vi.fn().mockResolvedValue(undefined),
+    };
+    const findByIdAndViewerSpy = vi
+      .spyOn(Page, 'findByIdAndViewer')
+      // biome-ignore lint/suspicious/noExplicitAny: minimal stub for the viewer lookup
+      .mockResolvedValue(fakePage as any);
+
+    const req = {
+      params: { pageId: pageId.toString() },
+      query: {},
+      body: {},
+      headers: {},
+      cookies: {},
+      user: normalUser,
+    };
+
+    const apiv3 = vi.fn();
+    const apiv3Err = vi.fn();
+    const res = mock<ApiV3Response>({ apiv3, apiv3Err });
+
+    const handlers = publishPageHandlersFactory(crowi);
+    await runMiddlewareChain(handlers, req, res);
+
+    // A regular user is not blocked by excludeReadOnlyUser — the request
+    // reaches the terminal handler and actually publishes the page.
+    expect(findByIdAndViewerSpy).toHaveBeenCalledWith(
+      pageId.toString(),
+      normalUser,
+    );
+    expect(publishSpy).toHaveBeenCalled();
+    expect(apiv3).toHaveBeenCalled();
+    expect(apiv3Err).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/server/routes/apiv3/page/publish-page.integ.ts
+++ b/apps/app/src/server/routes/apiv3/page/publish-page.integ.ts
@@ -1,0 +1,122 @@
+/**
+ * Security regression test — a read-only user must not be able to publish
+ * (unset the WIP flag on) a page through this endpoint.
+ *
+ * Root cause: unlike update-page.ts, this route's middleware chain omitted
+ * `excludeReadOnlyUser` (compare `loginRequiredStrictly, ...validator` here
+ * with `loginRequiredStrictly, excludeReadOnlyUser, addActivity, ...validator`
+ * on update-page.ts). `Page.findByIdAndViewer`, used by the terminal handler,
+ * only checks view permission -- it has no notion of edit permission -- so a
+ * logged-in read-only user who knows a pageId could call this endpoint
+ * directly and flip its WIP flag.
+ *
+ * This test drives the REAL middleware array returned by
+ * `publishPageHandlersFactory` (not just the terminal handler), because the
+ * bug is about which middleware is present in the chain, not about the
+ * terminal handler's own logic.
+ *
+ * Requires a real MongoDB (wired by vitest.workspace.mts integ setup).
+ */
+
+import type { IUserHasId } from '@growi/core';
+import type { RequestHandler } from 'express';
+import mongoose, { Types } from 'mongoose';
+
+import { getInstance } from '^/test/setup/crowi';
+
+import type Crowi from '~/server/crowi';
+import type { PageModel } from '~/server/models/page';
+
+import type { ApiV3Response } from '../interfaces/apiv3-response';
+import { publishPageHandlersFactory } from './publish-page';
+
+const TEST_USERNAME = 'publish-page-integ-readonly-user';
+
+/** Run the handler array as Express would, stopping at the first middleware
+ * that does not call `next()` (i.e. the one that sent a response). */
+async function runMiddlewareChain(
+  handlers: RequestHandler[],
+  // biome-ignore lint/suspicious/noExplicitAny: minimal Express request shape
+  req: any,
+  res: ApiV3Response,
+): Promise<void> {
+  for (const handler of handlers) {
+    let nextCalled = false;
+    // biome-ignore lint/performance/noAwaitInLoops: middlewares must run sequentially, in Express's own order
+    // biome-ignore lint/suspicious/noExplicitAny: express-validator chains and handlers have varying signatures
+    await (handler as any)(req, res, () => {
+      nextCalled = true;
+    });
+    if (!nextCalled) {
+      return;
+    }
+  }
+}
+
+describe('publish-page — a read-only user must not be able to publish a page', () => {
+  let crowi: Crowi;
+  let readOnlyUser: IUserHasId;
+
+  beforeAll(async () => {
+    crowi = await getInstance();
+
+    readOnlyUser = await crowi.models.User.create({
+      name: 'Publish Page Integ Read Only User',
+      username: TEST_USERNAME,
+      email: 'publish-page-integ-readonly@example.com',
+      readOnly: true,
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    await crowi.models.User.deleteMany({ username: TEST_USERNAME });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects the request and never publishes the page', async () => {
+    const pageId = new Types.ObjectId();
+
+    const Page = mongoose.model<unknown, PageModel>('Page');
+    const publishSpy = vi.fn();
+    const fakePage = {
+      _id: pageId,
+      path: '/publish-page-integ-target',
+      publish: publishSpy,
+      save: vi.fn().mockResolvedValue(undefined),
+    };
+    const findByIdAndViewerSpy = vi
+      .spyOn(Page, 'findByIdAndViewer')
+      // biome-ignore lint/suspicious/noExplicitAny: minimal stub for the viewer lookup
+      .mockResolvedValue(fakePage as any);
+
+    const req = {
+      params: { pageId: pageId.toString() },
+      query: {},
+      body: {},
+      headers: {},
+      user: readOnlyUser,
+    };
+
+    const apiv3 = vi.fn();
+    const apiv3Err = vi.fn();
+    const res = {
+      apiv3,
+      apiv3Err,
+      // biome-ignore lint/suspicious/noExplicitAny: minimal ApiV3Response stub
+    } as any as ApiV3Response;
+
+    const handlers = publishPageHandlersFactory(crowi);
+    await runMiddlewareChain(handlers, req, res);
+
+    // The read-only user must be rejected with an error response...
+    expect(apiv3Err).toHaveBeenCalled();
+    expect(apiv3).not.toHaveBeenCalled();
+
+    // ...and the page must never actually be published.
+    expect(findByIdAndViewerSpy).not.toHaveBeenCalled();
+    expect(publishSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/server/routes/apiv3/page/publish-page.ts
+++ b/apps/app/src/server/routes/apiv3/page/publish-page.ts
@@ -15,7 +15,7 @@ import { apiV3FormValidator } from '../../../middlewares/apiv3-form-validator';
 import { excludeReadOnlyUser } from '../../../middlewares/exclude-read-only-user';
 import type { ApiV3Response } from '../interfaces/apiv3-response';
 
-const logger = loggerFactory('growi:routes:apiv3:page:unpublish-page');
+const logger = loggerFactory('growi:routes:apiv3:page:publish-page');
 
 type ReqParams = {
   pageId: string;

--- a/apps/app/src/server/routes/apiv3/page/publish-page.ts
+++ b/apps/app/src/server/routes/apiv3/page/publish-page.ts
@@ -12,6 +12,7 @@ import type { PageModel } from '~/server/models/page';
 import loggerFactory from '~/utils/logger';
 
 import { apiV3FormValidator } from '../../../middlewares/apiv3-form-validator';
+import { excludeReadOnlyUser } from '../../../middlewares/exclude-read-only-user';
 import type { ApiV3Response } from '../interfaces/apiv3-response';
 
 const logger = loggerFactory('growi:routes:apiv3:page:unpublish-page');
@@ -39,6 +40,7 @@ export const publishPageHandlersFactory = (crowi: Crowi): RequestHandler[] => {
   return [
     accessTokenParser([SCOPE.WRITE.FEATURES.PAGE], { acceptLegacy: true }),
     loginRequiredStrictly,
+    excludeReadOnlyUser,
     ...validator,
     apiV3FormValidator,
     async (req: Req, res: ApiV3Response) => {

--- a/apps/app/src/server/routes/apiv3/page/sync-latest-revision-body-to-yjs-draft.integ.ts
+++ b/apps/app/src/server/routes/apiv3/page/sync-latest-revision-body-to-yjs-draft.integ.ts
@@ -1,0 +1,138 @@
+/**
+ * Security regression test — a read-only user must not be able to force a
+ * sync of a page's yjs collaborative draft to its latest revision body.
+ *
+ * Root cause: like publish-page.ts / unpublish-page.ts before their fix,
+ * this route's middleware chain omits `excludeReadOnlyUser`. The terminal
+ * handler only checks *view* accessibility (`Page.isAccessiblePageByViewer`),
+ * which has no notion of edit permission, so a logged-in read-only user who
+ * knows a pageId could call this endpoint directly and overwrite another
+ * user's in-progress, unsaved collaborative draft with the latest saved
+ * revision.
+ *
+ * This test drives the REAL middleware array returned by
+ * `syncLatestRevisionBodyToYjsDraftHandlerFactory` (not just the terminal
+ * handler), because the bug is about which middleware is present in the
+ * chain, not about the terminal handler's own logic.
+ *
+ * Requires a real MongoDB (wired by vitest.workspace.mts integ setup).
+ */
+
+import type { IUserHasId } from '@growi/core';
+import mongoose from 'mongoose';
+import { mock } from 'vitest-mock-extended';
+
+import { getInstance } from '^/test/setup/crowi';
+
+import type Crowi from '~/server/crowi';
+import type { PageModel } from '~/server/models/page';
+
+import type { ApiV3Response } from '../interfaces/apiv3-response';
+import { syncLatestRevisionBodyToYjsDraftHandlerFactory } from './sync-latest-revision-body-to-yjs-draft';
+import { runMiddlewareChain } from './test-utils/run-middleware-chain';
+
+const TEST_USERNAME = 'sync-yjs-draft-integ-readonly-user';
+
+describe('sync-latest-revision-body-to-yjs-draft — a read-only user must not be able to force-sync a page draft', () => {
+  let crowi: Crowi;
+  let readOnlyUser: IUserHasId;
+  let normalUser: IUserHasId;
+
+  beforeAll(async () => {
+    crowi = await getInstance();
+
+    readOnlyUser = await crowi.models.User.create({
+      name: 'Sync Yjs Draft Integ Read Only User',
+      username: TEST_USERNAME,
+      email: 'sync-yjs-draft-integ-readonly@example.com',
+      readOnly: true,
+    });
+
+    normalUser = await crowi.models.User.create({
+      name: 'Sync Yjs Draft Integ Normal User',
+      username: `${TEST_USERNAME}-normal`,
+      email: 'sync-yjs-draft-integ-normal@example.com',
+      readOnly: false,
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    await crowi.models.User.deleteMany({
+      username: { $in: [TEST_USERNAME, `${TEST_USERNAME}-normal`] },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects a read-only user with "This user is read only user" and never checks page accessibility', async () => {
+    const pageId = new mongoose.Types.ObjectId().toString();
+
+    const Page = mongoose.model<unknown, PageModel>('Page');
+    const isAccessiblePageByViewerSpy = vi.spyOn(
+      Page,
+      'isAccessiblePageByViewer',
+    );
+
+    const req = {
+      params: { pageId },
+      query: {},
+      body: {},
+      headers: {},
+      user: readOnlyUser,
+    };
+
+    const apiv3 = vi.fn();
+    const apiv3Err = vi.fn();
+    const res = mock<ApiV3Response>({ apiv3, apiv3Err });
+
+    const handlers = syncLatestRevisionBodyToYjsDraftHandlerFactory(crowi);
+    await runMiddlewareChain(handlers, req, res);
+
+    // The read-only user must be rejected by excludeReadOnlyUser specifically...
+    expect(apiv3Err).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'This user is read only user',
+        code: 'validation_failed',
+      }),
+    );
+    expect(apiv3).not.toHaveBeenCalled();
+
+    // ...and the request must never even reach the terminal handler's own
+    // accessibility check, let alone force a yjs draft sync.
+    expect(isAccessiblePageByViewerSpy).not.toHaveBeenCalled();
+  });
+
+  it('lets a non-read-only user pass through excludeReadOnlyUser to the terminal handler', async () => {
+    const pageId = new mongoose.Types.ObjectId().toString();
+
+    const Page = mongoose.model<unknown, PageModel>('Page');
+    const isAccessiblePageByViewerSpy = vi
+      .spyOn(Page, 'isAccessiblePageByViewer')
+      .mockResolvedValue(false);
+
+    const req = {
+      params: { pageId },
+      query: {},
+      body: {},
+      headers: {},
+      cookies: {},
+      user: normalUser,
+    };
+
+    const apiv3 = vi.fn();
+    const apiv3Err = vi.fn();
+    const res = mock<ApiV3Response>({ apiv3, apiv3Err });
+
+    const handlers = syncLatestRevisionBodyToYjsDraftHandlerFactory(crowi);
+    await runMiddlewareChain(handlers, req, res);
+
+    // A regular user is not blocked by excludeReadOnlyUser — the request
+    // reaches the terminal handler's own accessibility check.
+    expect(isAccessiblePageByViewerSpy).toHaveBeenCalledWith(
+      pageId,
+      normalUser,
+    );
+  });
+});

--- a/apps/app/src/server/routes/apiv3/page/sync-latest-revision-body-to-yjs-draft.ts
+++ b/apps/app/src/server/routes/apiv3/page/sync-latest-revision-body-to-yjs-draft.ts
@@ -14,6 +14,7 @@ import { getYjsService } from '~/server/service/yjs';
 import loggerFactory from '~/utils/logger';
 
 import { apiV3FormValidator } from '../../../middlewares/apiv3-form-validator';
+import { excludeReadOnlyUser } from '../../../middlewares/exclude-read-only-user';
 import type { ApiV3Response } from '../interfaces/apiv3-response';
 
 const logger = loggerFactory(
@@ -49,6 +50,7 @@ export const syncLatestRevisionBodyToYjsDraftHandlerFactory = (
   return [
     accessTokenParser([SCOPE.WRITE.FEATURES.PAGE], { acceptLegacy: true }),
     loginRequiredStrictly,
+    excludeReadOnlyUser,
     ...validator,
     apiV3FormValidator,
     async (req: Req, res: ApiV3Response) => {

--- a/apps/app/src/server/routes/apiv3/page/test-utils/run-middleware-chain.ts
+++ b/apps/app/src/server/routes/apiv3/page/test-utils/run-middleware-chain.ts
@@ -1,0 +1,33 @@
+import type { RequestHandler } from 'express';
+
+import type { ApiV3Response } from '../../interfaces/apiv3-response';
+
+/**
+ * Run an Express `RequestHandler[]` array as Express itself would, stopping
+ * at the first middleware that does not call `next()` (i.e. the one that
+ * sent a response).
+ *
+ * Shared by the publish-page / unpublish-page / sync-latest-revision-body-
+ * to-yjs-draft integration tests, which all drive the REAL middleware array
+ * returned by their `*HandlersFactory` (not just the terminal handler),
+ * because the read-only-user bug is about which middleware is present in
+ * the chain, not about the terminal handler's own logic.
+ */
+export async function runMiddlewareChain(
+  handlers: RequestHandler[],
+  // biome-ignore lint/suspicious/noExplicitAny: minimal Express request shape
+  req: any,
+  res: ApiV3Response,
+): Promise<void> {
+  for (const handler of handlers) {
+    let nextCalled = false;
+    // biome-ignore lint/performance/noAwaitInLoops: middlewares must run sequentially, in Express's own order
+    // biome-ignore lint/suspicious/noExplicitAny: express-validator chains and handlers have varying signatures
+    await (handler as any)(req, res, () => {
+      nextCalled = true;
+    });
+    if (!nextCalled) {
+      return;
+    }
+  }
+}

--- a/apps/app/src/server/routes/apiv3/page/unpublish-page.integ.ts
+++ b/apps/app/src/server/routes/apiv3/page/unpublish-page.integ.ts
@@ -1,0 +1,118 @@
+/**
+ * Security regression test — a read-only user must not be able to unpublish
+ * (set the WIP flag on) a page through this endpoint.
+ *
+ * Same root cause as publish-page.integ.ts: this route's middleware chain
+ * omitted `excludeReadOnlyUser`, and `Page.findByIdAndViewer` (used by the
+ * terminal handler) only checks view permission, not edit permission.
+ *
+ * This test drives the REAL middleware array returned by
+ * `unpublishPageHandlersFactory` (not just the terminal handler), because the
+ * bug is about which middleware is present in the chain, not about the
+ * terminal handler's own logic.
+ *
+ * Requires a real MongoDB (wired by vitest.workspace.mts integ setup).
+ */
+
+import type { IUserHasId } from '@growi/core';
+import type { RequestHandler } from 'express';
+import mongoose, { Types } from 'mongoose';
+
+import { getInstance } from '^/test/setup/crowi';
+
+import type Crowi from '~/server/crowi';
+import type { PageModel } from '~/server/models/page';
+
+import type { ApiV3Response } from '../interfaces/apiv3-response';
+import { unpublishPageHandlersFactory } from './unpublish-page';
+
+const TEST_USERNAME = 'unpublish-page-integ-readonly-user';
+
+/** Run the handler array as Express would, stopping at the first middleware
+ * that does not call `next()` (i.e. the one that sent a response). */
+async function runMiddlewareChain(
+  handlers: RequestHandler[],
+  // biome-ignore lint/suspicious/noExplicitAny: minimal Express request shape
+  req: any,
+  res: ApiV3Response,
+): Promise<void> {
+  for (const handler of handlers) {
+    let nextCalled = false;
+    // biome-ignore lint/performance/noAwaitInLoops: middlewares must run sequentially, in Express's own order
+    // biome-ignore lint/suspicious/noExplicitAny: express-validator chains and handlers have varying signatures
+    await (handler as any)(req, res, () => {
+      nextCalled = true;
+    });
+    if (!nextCalled) {
+      return;
+    }
+  }
+}
+
+describe('unpublish-page — a read-only user must not be able to unpublish a page', () => {
+  let crowi: Crowi;
+  let readOnlyUser: IUserHasId;
+
+  beforeAll(async () => {
+    crowi = await getInstance();
+
+    readOnlyUser = await crowi.models.User.create({
+      name: 'Unpublish Page Integ Read Only User',
+      username: TEST_USERNAME,
+      email: 'unpublish-page-integ-readonly@example.com',
+      readOnly: true,
+    });
+  }, 120_000);
+
+  afterAll(async () => {
+    await crowi.models.User.deleteMany({ username: TEST_USERNAME });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects the request and never unpublishes the page', async () => {
+    const pageId = new Types.ObjectId();
+
+    const Page = mongoose.model<unknown, PageModel>('Page');
+    const unpublishSpy = vi.fn();
+    const fakePage = {
+      _id: pageId,
+      path: '/unpublish-page-integ-target',
+      unpublish: unpublishSpy,
+      save: vi.fn().mockResolvedValue(undefined),
+    };
+    const findByIdAndViewerSpy = vi
+      .spyOn(Page, 'findByIdAndViewer')
+      // biome-ignore lint/suspicious/noExplicitAny: minimal stub for the viewer lookup
+      .mockResolvedValue(fakePage as any);
+
+    const req = {
+      params: { pageId: pageId.toString() },
+      query: {},
+      body: {},
+      headers: {},
+      user: readOnlyUser,
+    };
+
+    const apiv3 = vi.fn();
+    const apiv3Err = vi.fn();
+    const res = {
+      apiv3,
+      apiv3Err,
+      // biome-ignore lint/suspicious/noExplicitAny: minimal ApiV3Response stub
+    } as any as ApiV3Response;
+
+    const handlers = unpublishPageHandlersFactory(crowi);
+    await runMiddlewareChain(handlers, req, res);
+
+    // The read-only user must be rejected with an error response...
+    expect(apiv3Err).toHaveBeenCalled();
+    expect(apiv3).not.toHaveBeenCalled();
+
+    // ...and the page must never actually be unpublished.
+    expect(findByIdAndViewerSpy).not.toHaveBeenCalled();
+    expect(unpublishSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/server/routes/apiv3/page/unpublish-page.integ.ts
+++ b/apps/app/src/server/routes/apiv3/page/unpublish-page.integ.ts
@@ -15,8 +15,8 @@
  */
 
 import type { IUserHasId } from '@growi/core';
-import type { RequestHandler } from 'express';
 import mongoose, { Types } from 'mongoose';
+import { mock } from 'vitest-mock-extended';
 
 import { getInstance } from '^/test/setup/crowi';
 
@@ -24,34 +24,15 @@ import type Crowi from '~/server/crowi';
 import type { PageModel } from '~/server/models/page';
 
 import type { ApiV3Response } from '../interfaces/apiv3-response';
+import { runMiddlewareChain } from './test-utils/run-middleware-chain';
 import { unpublishPageHandlersFactory } from './unpublish-page';
 
 const TEST_USERNAME = 'unpublish-page-integ-readonly-user';
 
-/** Run the handler array as Express would, stopping at the first middleware
- * that does not call `next()` (i.e. the one that sent a response). */
-async function runMiddlewareChain(
-  handlers: RequestHandler[],
-  // biome-ignore lint/suspicious/noExplicitAny: minimal Express request shape
-  req: any,
-  res: ApiV3Response,
-): Promise<void> {
-  for (const handler of handlers) {
-    let nextCalled = false;
-    // biome-ignore lint/performance/noAwaitInLoops: middlewares must run sequentially, in Express's own order
-    // biome-ignore lint/suspicious/noExplicitAny: express-validator chains and handlers have varying signatures
-    await (handler as any)(req, res, () => {
-      nextCalled = true;
-    });
-    if (!nextCalled) {
-      return;
-    }
-  }
-}
-
 describe('unpublish-page — a read-only user must not be able to unpublish a page', () => {
   let crowi: Crowi;
   let readOnlyUser: IUserHasId;
+  let normalUser: IUserHasId;
 
   beforeAll(async () => {
     crowi = await getInstance();
@@ -62,17 +43,26 @@ describe('unpublish-page — a read-only user must not be able to unpublish a pa
       email: 'unpublish-page-integ-readonly@example.com',
       readOnly: true,
     });
+
+    normalUser = await crowi.models.User.create({
+      name: 'Unpublish Page Integ Normal User',
+      username: `${TEST_USERNAME}-normal`,
+      email: 'unpublish-page-integ-normal@example.com',
+      readOnly: false,
+    });
   }, 120_000);
 
   afterAll(async () => {
-    await crowi.models.User.deleteMany({ username: TEST_USERNAME });
+    await crowi.models.User.deleteMany({
+      username: { $in: [TEST_USERNAME, `${TEST_USERNAME}-normal`] },
+    });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('rejects the request and never unpublishes the page', async () => {
+  it('rejects the request with "This user is read only user" and never unpublishes the page', async () => {
     const pageId = new Types.ObjectId();
 
     const Page = mongoose.model<unknown, PageModel>('Page');
@@ -98,21 +88,66 @@ describe('unpublish-page — a read-only user must not be able to unpublish a pa
 
     const apiv3 = vi.fn();
     const apiv3Err = vi.fn();
-    const res = {
-      apiv3,
-      apiv3Err,
-      // biome-ignore lint/suspicious/noExplicitAny: minimal ApiV3Response stub
-    } as any as ApiV3Response;
+    const res = mock<ApiV3Response>({ apiv3, apiv3Err });
 
     const handlers = unpublishPageHandlersFactory(crowi);
     await runMiddlewareChain(handlers, req, res);
 
-    // The read-only user must be rejected with an error response...
-    expect(apiv3Err).toHaveBeenCalled();
+    // The read-only user must be rejected by excludeReadOnlyUser specifically,
+    // not by some other middleware that happens to also reject...
+    expect(apiv3Err).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'This user is read only user',
+        code: 'validation_failed',
+      }),
+    );
     expect(apiv3).not.toHaveBeenCalled();
 
     // ...and the page must never actually be unpublished.
     expect(findByIdAndViewerSpy).not.toHaveBeenCalled();
     expect(unpublishSpy).not.toHaveBeenCalled();
+  });
+
+  it('lets a non-read-only user pass through to unpublish the page', async () => {
+    const pageId = new Types.ObjectId();
+
+    const Page = mongoose.model<unknown, PageModel>('Page');
+    const unpublishSpy = vi.fn();
+    const fakePage = {
+      _id: pageId,
+      path: '/unpublish-page-integ-target',
+      unpublish: unpublishSpy,
+      save: vi.fn().mockResolvedValue(undefined),
+    };
+    const findByIdAndViewerSpy = vi
+      .spyOn(Page, 'findByIdAndViewer')
+      // biome-ignore lint/suspicious/noExplicitAny: minimal stub for the viewer lookup
+      .mockResolvedValue(fakePage as any);
+
+    const req = {
+      params: { pageId: pageId.toString() },
+      query: {},
+      body: {},
+      headers: {},
+      cookies: {},
+      user: normalUser,
+    };
+
+    const apiv3 = vi.fn();
+    const apiv3Err = vi.fn();
+    const res = mock<ApiV3Response>({ apiv3, apiv3Err });
+
+    const handlers = unpublishPageHandlersFactory(crowi);
+    await runMiddlewareChain(handlers, req, res);
+
+    // A regular user is not blocked by excludeReadOnlyUser — the request
+    // reaches the terminal handler and actually unpublishes the page.
+    expect(findByIdAndViewerSpy).toHaveBeenCalledWith(
+      pageId.toString(),
+      normalUser,
+    );
+    expect(unpublishSpy).toHaveBeenCalled();
+    expect(apiv3).toHaveBeenCalled();
+    expect(apiv3Err).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/server/routes/apiv3/page/unpublish-page.ts
+++ b/apps/app/src/server/routes/apiv3/page/unpublish-page.ts
@@ -12,6 +12,7 @@ import type { PageModel } from '~/server/models/page';
 import loggerFactory from '~/utils/logger';
 
 import { apiV3FormValidator } from '../../../middlewares/apiv3-form-validator';
+import { excludeReadOnlyUser } from '../../../middlewares/exclude-read-only-user';
 import type { ApiV3Response } from '../interfaces/apiv3-response';
 
 const logger = loggerFactory('growi:routes:apiv3:page:unpublish-page');
@@ -41,6 +42,7 @@ export const unpublishPageHandlersFactory = (
   return [
     accessTokenParser([SCOPE.WRITE.FEATURES.PAGE], { acceptLegacy: true }),
     loginRequiredStrictly,
+    excludeReadOnlyUser,
     ...validator,
     apiV3FormValidator,
     async (req: Req, res: ApiV3Response) => {


### PR DESCRIPTION
## 問題

閲覧のみユーザー（readOnly user）が、ページのWIP（執筆途中）フラグの解除（Publish）・再設定（Unpublish）を、ログインしてさえいればページIDを知っているだけで実行できてしまう不具合を修正します。

## 原因

GROWIのapiv3の書き込み系APIは通常、`excludeReadOnlyUser` ミドルウェア（`req.user.readOnly === true` のユーザーからのリクエストを拒否する）を経由します。通常のページ更新API（`update-page.ts`）はこれを含みますが、WIP解除API（`publish-page.ts`）とWIP化API（`unpublish-page.ts`）のミドルウェア列にはこれが含まれていませんでした。

これらのAPIのハンドラが使う `Page.findByIdAndViewer` は「そのページを閲覧できるか」だけをチェックする関数で、編集権限は一切見ません。そのため、`excludeReadOnlyUser` が無いと、閲覧のみユーザーからの書き込みを止めるものが何もない状態でした。

## 修正内容

`publish-page.ts` と `unpublish-page.ts` それぞれのミドルウェア列に `excludeReadOnlyUser` を追加しました。追加位置は `update-page.ts` と同じで、`loginRequiredStrictly` の直後です。

## テスト（red→green）

- `publish-page.integ.ts` / `unpublish-page.integ.ts` を新規作成。実際のミドルウェア配列（`publishPageHandlersFactory` / `unpublishPageHandlersFactory` が返す配列）を、末尾のハンドラだけでなく順番に全部実行し、閲覧のみユーザーからのリクエストが拒否されること（`res.apiv3Err` が呼ばれ `res.apiv3` は呼ばれないこと）と、`Page.findByIdAndViewer` / `page.publish()` / `page.unpublish()` が一切呼ばれないことを検証します。
- 修正前のコードに対してこのテストを実行し、閲覧のみユーザーの書き込みが素通りしてしまうこと（RED: `apiv3Err` が呼ばれない）を確認済みです。
- 修正後、テストが通ること（GREEN）を確認済みです。
- 関連する既存テスト（`apiv3/page` ディレクトリ全体、11ファイル36件）も合わせて実行し、影響がないことを確認しました。
- `pnpm run lint:typecheck`、`pnpm run lint`（biome / route-top-level-guard 等）が通ることを確認しました。

なお `excludeReadOnlyUser` は拒否時に明示的なステータスコードを渡していないため、実際のレスポンスは `apiv3Err` の既定値である400です（403ではありません）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJCoRK6TULeYJaDN7nKcoD