### PR TITLE
fix(page): keep a page on the tree when a rename fails midway

### DIFF
--- a/apps/app/src/server/service/page/index.ts
+++ b/apps/app/src/server/service/page/index.ts
@@ -725,36 +725,67 @@ class PageService implements IPageService {
     }
 
     // 1. Take target off from tree
+    //
+    // This commits `parent: null` on its own, and no mongo session wraps the steps
+    // below, so steps 2-3 are not atomic with it. Remember the original parent: if
+    // either of them throws, the page has to be put back, otherwise it is stranded
+    // off-tree at its old path and drops out of the page tree entirely -- present in
+    // the database but absent from the sidebar and from any parent-based lookup.
+    // See https://github.com/growilabs/growi/issues/9755
+    const exParentId = page.parent;
     await Page.takeOffFromTree(page._id);
 
-    // 2. Find new parent
     let newParent: PageDocument | undefined;
-    // If renaming to under target, run getParentAndforceCreateEmptyTree to fill new ancestors
-    if (this.isRenamingToUnderTarget(page.path, newPagePathSanitized)) {
-      newParent = await this.getParentAndforceCreateEmptyTree(
-        page,
-        newPagePathSanitized,
-      );
-    } else {
-      newParent = await this.getParentAndFillAncestorsByUser(
-        user,
-        newPagePathSanitized,
-      );
-    }
+    let renamedPage: PageDocument | null = null;
+    try {
+      // 2. Find new parent
+      // If renaming to under target, run getParentAndforceCreateEmptyTree to fill new ancestors
+      if (this.isRenamingToUnderTarget(page.path, newPagePathSanitized)) {
+        newParent = await this.getParentAndforceCreateEmptyTree(
+          page,
+          newPagePathSanitized,
+        );
+      } else {
+        newParent = await this.getParentAndFillAncestorsByUser(
+          user,
+          newPagePathSanitized,
+        );
+      }
 
-    // 3. Put back target page to tree (also update the other attrs)
-    const update: Partial<IPage> = {};
-    update.path = newPagePathSanitized;
-    update.parent = newParent?._id;
-    if (updateMetadata) {
-      update.lastUpdateUser = user;
-      update.updatedAt = new Date();
+      // 3. Put back target page to tree (also update the other attrs)
+      const update: Partial<IPage> = {};
+      update.path = newPagePathSanitized;
+      update.parent = newParent?._id;
+      if (updateMetadata) {
+        update.lastUpdateUser = user;
+        update.updatedAt = new Date();
+      }
+      renamedPage = await Page.findByIdAndUpdate(
+        page._id,
+        { $set: update },
+        { new: true },
+      );
+    } catch (err) {
+      // Undo step 1 only. The rename still fails and the caller still sees the
+      // error -- what changes is that the page stays where it was instead of
+      // vanishing from the tree. Steps after this block run only once step 3 has
+      // committed the new parent, so they must not be covered by this rollback.
+      try {
+        await Page.findByIdAndUpdate(page._id, {
+          $set: { parent: exParentId },
+        });
+      } catch (rollbackErr) {
+        // Log and fall through: the original error is the one worth propagating,
+        // but the page is now off-tree and needs Admin > App Settings > V5 page
+        // migration to be reattached, so that must not be swallowed silently.
+        logger.error(
+          `Failed to reattach "${page.path}" to its original parent after a failed rename. ` +
+            'The page is off-tree and will not appear in the page tree until it is normalized.',
+          rollbackErr,
+        );
+      }
+      throw err;
     }
-    const renamedPage = await Page.findByIdAndUpdate(
-      page._id,
-      { $set: update },
-      { new: true },
-    );
 
     // 5.increase parent's descendantCount.
     // see: https://dev.growi.org/62149d019311629d4ecd91cf#Handling%20of%20descendantCount%20in%20case%20of%20unexpected%20process%20interruption

--- a/apps/app/src/server/service/page/rename-orphan-invariant.integ.ts
+++ b/apps/app/src/server/service/page/rename-orphan-invariant.integ.ts
@@ -1,0 +1,146 @@
+/**
+ * Integration test for issue #9755: a rename that fails must not leave the page
+ * detached from the page tree.
+ *
+ * WHY this needs guarding: renameMainOperation performs
+ *   1. takeOffFromTree(page._id)   -- commits parent: null
+ *   2. resolve/create the new parent  -- can throw
+ *   3. findByIdAndUpdate(new path + new parent)
+ * with no mongo session and no rollback. When step 2 throws, step 1 stays committed
+ * and the page is stranded off-tree at its OLD path: invisible in the sidebar (which
+ * walks `parent`) and missed by a `pages/list` query rooted at the intended
+ * destination (which is a path-prefix match).
+ *
+ * A page in the trash is the reachable trigger: deleteNonEmptyTarget sets
+ * `status: deleted` and `parent: null` while leaving `grant` public. That state falls
+ * into a gap between two filters that disagree:
+ *   - createEmptyPagesByPaths' "already exists" filter matches on
+ *     `{$or: [{grant: PUBLIC}, {parent: {$ne: null}}, {path: '/'}]}` -- no status
+ *     check, so it treats the trashed page as existing and back-fills nothing.
+ *   - connectPageTree's addConditionToFilterByApplicableAncestors requires
+ *     `status: STATUS_PUBLISHED` in every clause, so it never re-parents it.
+ * getParentAndFillAncestorsByUser is then left with no on-tree parent to return and
+ * throws 'Failed to find the created parent by getParentAndFillAncestorsByUser'.
+ *
+ * The assertion is on observable page state after an ordinary rename call, not on the
+ * mechanism, so moving where the invariant is enforced will not break it.
+ */
+
+import type { Model } from 'mongoose';
+import mongoose from 'mongoose';
+import { vi } from 'vitest';
+
+import { getInstance } from '^/test/setup/crowi';
+
+import type Crowi from '~/server/crowi';
+import type { PageDocument, PageModel } from '~/server/models/page';
+
+describe('a failed rename must not orphan the page (#9755)', () => {
+  let crowi: Crowi;
+  let Page: PageModel;
+  // biome-ignore lint/suspicious/noExplicitAny: the User model is an untyped JS module
+  let User: Model<any>;
+  // biome-ignore lint/suspicious/noExplicitAny: no User document type is available
+  let user: any;
+
+  const base = '/test-rename-orphan';
+
+  const create = async (path: string, body: string, options = {}) => {
+    const mocked = vi
+      .spyOn(crowi.pageService, 'createSubOperation')
+      .mockReturnValue(Promise.resolve());
+    const createdPage = await crowi.pageService.create(
+      path,
+      body,
+      user,
+      options,
+    );
+    const args = mocked.mock.calls[0];
+    mocked.mockRestore();
+    await crowi.pageService.createSubOperation(
+      ...(args as Parameters<typeof crowi.pageService.createSubOperation>),
+    );
+    return createdPage;
+  };
+
+  // renameMainOperation fires renameSubOperation WITHOUT awaiting it, so a test that
+  // asserts straight after renamePage() races it. Capture and run it explicitly.
+  const rename = async (page, newPagePath: string, options = {}) => {
+    const mocked = vi
+      .spyOn(crowi.pageService, 'renameSubOperation')
+      .mockReturnValue(Promise.resolve());
+    try {
+      await crowi.pageService.renamePage(page, newPagePath, user, options, {
+        ip: '::ffff:127.0.0.1',
+        endpoint: '/_api/v3/pages/rename',
+      });
+      const args = mocked.mock.calls[0];
+      mocked.mockRestore();
+      if (args != null) {
+        await crowi.pageService.renameSubOperation(
+          ...(args as Parameters<typeof crowi.pageService.renameSubOperation>),
+        );
+      }
+      return null;
+    } catch (err) {
+      mocked.mockRestore();
+      return err as Error;
+    }
+  };
+
+  beforeAll(async () => {
+    crowi = await getInstance();
+    await crowi.configManager.updateConfig('app:isV5Compatible', true);
+
+    Page = mongoose.model<PageDocument, PageModel>('Page');
+    User = mongoose.model('User');
+
+    if ((await Page.findOne({ path: '/' })) == null) {
+      await Page.create({ path: '/', grant: Page.GRANT_PUBLIC });
+    }
+
+    user =
+      (await User.findOne({ username: 'renameOrphanUser' })) ??
+      (await User.create({
+        name: 'renameOrphanUser',
+        username: 'renameOrphanUser',
+        email: 'rename-orphan@example.com',
+      }));
+  });
+
+  afterEach(async () => {
+    // the trash copy lives under /trash<base>, so both prefixes need clearing
+    await Page.deleteMany({
+      path: { $in: [new RegExp(`^${base}`), new RegExp(`^/trash${base}`)] },
+    });
+  });
+
+  it('leaves the page on the tree when the destination parent is a trashed page', async () => {
+    await create(base, 'base body');
+    const victim = await create(`${base}/deleted-later`, 'body');
+    const target = await create(`${base}/target`, 'body');
+
+    // real deletion -> path becomes /trash<path>, status deleted, parent null,
+    // grant left public: the exact state the two filters disagree about
+    await crowi.pageService.deletePage(victim, user, {}, false, {
+      ip: '::ffff:127.0.0.1',
+      endpoint: '/_api/v3/pages/delete',
+    });
+    const trashed = await Page.findById(victim._id);
+    expect(trashed?.parent).toBeNull();
+    expect(trashed?.status).toBe('deleted');
+
+    const err = await rename(target, `${trashed?.path}/moved`);
+
+    const after = await Page.findById(target._id);
+
+    // The rename is allowed to fail. What it must not do is strand the page:
+    // whether it moved or stayed put, it must still be reachable from the tree.
+    expect(after).not.toBeNull();
+    expect(
+      after?.parent,
+      `rename failed with "${err?.message}" and left the page off-tree at ` +
+        `"${after?.path}" (parent: null) — it is now invisible in the page tree`,
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Tickets
- https://redmine.weseek.co.jp/issues/189202
- https://redmine.weseek.co.jp/issues/189754

## Summary

A failed page move (rename) could leave the page **detached from the page tree** — still in the database, but gone from the sidebar and from any parent-based lookup. To the user, the page had simply disappeared.

This adds the missing rollback so a failed rename leaves the page where it was, plus an integration test pinning the invariant.

Refs #9755

> **Scope note (please read before reviewing).** This restores the page's `parent` on every rename that *throws*, so the symptom reported in #9755 stops being produced that way, and the invariant break is reproduced by test. It is a rollback, not a transaction — see [Deliberately out of scope](#deliberately-out-of-scope) for what survives it. It does **not** identify which trigger the reporter actually hit, and one route to the same end state — process death mid-operation — is identified here but deliberately left open. See [What is and is not established](#what-is-and-is-not-established). Linked with `Refs` rather than `Fixes` so the issue stays open for that question.

## Root cause

`renameMainOperation` detaches the page *before* resolving its new parent:

```js
// 1. commits `parent: null`
await Page.takeOffFromTree(page._id);
// 2. resolve/create the new parent  <-- can throw
// 3. findByIdAndUpdate(new path + new parent)
```

No mongo session wraps these (there is no `startSession` / `withTransaction` anywhere in the file), so a throw in step 2 left step 1 committed and the page stranded off-tree **at its old path**. `renamePage`'s `catch` deletes the `PageOperation` and rethrows — it never restored `parent`. Deleting the `PageOperation` also means no resume record survives, so nothing ever reattaches the page afterwards.

That state is hard to spot, which is why the original report looked like a deletion:

| Where the user looked | Why it was not there |
|---|---|
| Sidebar page tree | built by walking `parent`; an orphan has `parent: null` |
| `pages/list?path=<destination>` | path-prefix query, but the page is still at its **old** path |
| same, from a broad root | `limit` defaults to `customize:showPageLimitationS` (10) and paginates |
| Trash | nothing was deleted, so nothing went there |
| Audit log | create + update present, no delete entry — because nothing was deleted |

### A trigger that makes step 2 throw without any crash

A page in the trash is one trigger. `deleteNonEmptyTarget` sets `status: 'deleted'` and `parent: null` but leaves `grant` public — and that state falls into a gap between two filters that disagree about it:

- `createEmptyPagesByPaths`' "already exists" filter matches on `{$or: [{grant: PUBLIC}, {parent: {$ne: null}}, {path: '/'}]}` and **does not look at `status`**, so it treats the page as existing and back-fills nothing.
- `connectPageTree`'s `addConditionToFilterByApplicableAncestors` requires `status: STATUS_PUBLISHED` in **every** clause, so it never re-parents it.

`getParentAndFillAncestorsByUser` is then left with no on-tree parent and throws `Failed to find the created parent by getParentAndFillAncestorsByUser`.

Precondition matrix (run on `master`, calling `pageService.renamePage` directly) — moving a page under a parent seeded in each state:

| Parent state | Threw? | Moved page orphaned? |
|---|---|---|
| off-tree + **public** + **status deleted** | yes | **yes** |
| off-tree + public + published | no | no (self-heals) |
| off-tree + `isEmpty` + public | no | no (self-heals) |
| **on-tree** + status deleted | no | no |
| off-tree + `GRANT_OWNER` / `GRANT_USER_GROUP` / `GRANT_RESTRICTED` | no | no — but creates a **duplicate page** at that path |

Orphaning needs all three conditions; off-tree alone self-heals because `createEmptyPagesByPaths` back-fills the gap.

## What is and is not established

**Established — the defect.** `takeOffFromTree` commits `parent: null` on its own, steps 2–3 are wrapped by no session and no rollback, and a throw anywhere in them strands the page. `rename-orphan-invariant.integ.ts` reproduces it on `master`:

```
× leaves the page on the tree when the destination parent is a trashed page
  → rename failed with "Failed to find the created parent by getParentAndFillAncestorsByUser"
    and left the page off-tree at "/test-rename-orphan/target" (parent: null)
```

**Not established — the reporter's trigger.** Every orphaning row in the matrix above needs an ancestor at a `/trash/...` path, and **that is unreachable from the product**: the rename route evaluates `isCreatablePage(newPagePath)` before calling `pageService.renamePage` (`apps/app/src/server/routes/apiv3/pages/index.js`), and `/trash` is in `restrictedPatternsToCreate` (`packages/core/src/utils/page-path-utils/index.ts`), so any `/trash/...` destination is rejected with `409 invalid_path` first. The rename modal and sidebar drag-and-drop both go through that endpoint. The trashed-parent trigger is therefore reachable only from code, which is what the integration test does.

Two details in the report argue that nothing threw at all:

- **No rename row in the audit log.** `ACTION_PAGE_RENAME` and `ACTION_PAGE_RECURSIVELY_RENAME` are in `EssentialActionGroup`, and `getAvailableActions` returns `AllEssentialActions` even when `app:auditLogEnabled` is false — so rename is recorded **unconditionally**, in the same group as `ACTION_PAGE_CREATE` and `ACTION_PAGE_UPDATE`, the two the reporter did see. `renamePage` calls `createActivity` before any failure-prone work and the row is persisted immediately. A throw in step 2/3 would have left a rename entry next to the create and update entries.
- **No error was mentioned.** A throw surfaces as a 500 toast. The reporter was attentive enough to note 「エラーなし」 about the saves and reported nothing for the move.

### Not covered: process death during the Main stage

A crash or restart between step 1 and the end of step 3 produces the **identical** end state by a route this PR does not close, and nothing recovers from it:

- No `catch` runs, so the rollback added here never executes.
- The rename `PageOperation` is created at `actionStage: Main` and flips to `Sub` only *after* step 3. The startup sweep `PageOperationService#afterExpressServerReady` queries **only** `actionStage: Sub`, so a Main-stage record is never picked up.
- `canOperate` runs an unfiltered `PageOperation.find()` with no expiry or `isProcessable` check, so that leftover record then permanently blocks any later rename overlapping those paths.

This also fits 「過去2度発生した」 better than a one-off transient failure would.

Closing it needs either a mongo session around steps 1–3 or a Main-stage entry in the startup sweep. Worth being explicit about how that relates to this PR: **a session around steps 1–3 would close both routes at once** — an uncommitted transaction aborts when the session dies, so it subsumes this rollback rather than complementing it. So it is the larger *remainder* of this fix, not optional polish on top of it. It is still not folded in here because the session has to be threaded through helpers shared with page creation and the v5 migration, which is a materially bigger and riskier change; this rollback is strictly better than the current behaviour in the meantime.

### Why the trigger will probably stay unknown

The issue is 18 months old, and `app:activityExpirationSeconds` defaults to 30 days with a TTL index — the audit-log rows for the incident expired long ago, so the reporter's original statement is the only evidence there will be about them.

`PageOperation` has no TTL, so one durable artifact could still exist: a leftover `{ actionStage: 'Main' }` record on that instance would be direct evidence of an interrupted rename, and its `fromPath` would name the missing page. That is a DB check rather than a memory question, so it is the only follow-up worth asking for.

## Changes

- `apps/app/src/server/service/page/index.ts` — capture the original parent before `takeOffFromTree`, and restore it if step 2 or 3 throws. The rename still fails and the caller still sees the error; what changes is that the page stays reachable from the tree.
  - The rollback covers **steps 2–3 only** — everything after them runs once step 3 has committed the new parent, so it must not be undone.
  - A failure of the rollback write itself is logged, not propagated, so it cannot mask the original error.
- `apps/app/src/server/service/page/rename-orphan-invariant.integ.ts` — new integration test. It builds the precondition through the **real** `deletePage` API (no hand-written DB state) and asserts on observable page state rather than on the mechanism, so relocating where the invariant is enforced will not break it.

What this guarantees is that **`parent` is restored on every route that throws**, not just the trashed-page one — which is the point, given that the reporter's route is unknown.

It is not a full undo of step 2. `getParentAndFillAncestorsByUser` runs `createEmptyPagesByPaths` *before* `connectPageTree` and before its own `throw`, so empty ancestor pages already inserted at the destination survive the rollback (same for the under-target branch's `insertMany`; see below). The target page is back on the tree at its old path, which is the invariant that matters here, but the destination can be left holding empty pages. The test pins `parent`, not that.

It also does not cover process death mid-operation; see below.

## Deliberately out of scope

- **Aligning the two filters' `status` conditions** would additionally let the rename *succeed* in the trashed-parent case rather than fail cleanly. It touches shared helpers used by page creation and by the v5 migration, so it belongs in its own change.
- **Duplicate pages at one path** (last row of the matrix): a non-public off-tree ancestor gets an empty page created over it, shadowing its content. Same `onlyMigratedAsExistingPages` filter, separate defect — worth its own issue.
- **Empty pages created by step 2 are not rolled back — on either branch.** The rollback undoes step 1 only, so anything step 2 inserted before throwing stays:
  - main branch: `getParentAndFillAncestorsByUser` calls `createEmptyPagesByPaths` first, then `connectPageTree`, then throws `Failed to find the created parent` — so a throw at or after `connectPageTree` leaves those empty ancestors behind. (Not exercised by the trashed-parent case in the test, where `createEmptyPagesByPaths` back-fills nothing by design.)
  - under-target branch: `getParentAndforceCreateEmptyTree` `insertMany`s the intermediate empty pages and then `bulkWrite`s their parents. Its own `throw Error('Original parent not found')` fires *before* the insert, so nothing is left behind there — but if the `bulkWrite` throws (a DB-level error), the freshly inserted empty pages stay.

  Narrow, and strictly better than the current behaviour — an empty page is visible and normalizable, an off-tree page is neither — but not a full undo. A session around steps 1–3 is what removes this residual too.
- **No test covers `isRenamingToUnderTarget`.** The existing "rename/move to under …" tests move a page beneath a *different* page, which takes the `getParentAndFillAncestorsByUser` branch; the under-target branch has no coverage in the repo today, and the precondition matrix above does not exercise it either. Pre-existing gap, called out here because this change wraps that branch in the new `try`.
- **Process death between step 1 and step 3** — see [above](#not-covered-process-death-during-the-main-stage). Same end state, no `catch` to roll back, no startup sweep for `actionStage: Main`, and `canOperate` blocked afterwards. Needs a session around steps 1–3 or a Main-stage sweep; both are larger than this change.
- **`renamedPage == null` still returns 200 OK** from `apiv3/pages/index.js` with stale data. Reachable only if the page is concurrently deleted; unchanged here.

## Test plan

- [x] `pnpm vitest run rename-orphan-invariant` — fails on `master` (RED), passes with this change (GREEN)
- [x] `pnpm vitest run v5.public-page v5.page v5.non-public-page v5.migration page.integ wip-expiration-invariant rename.integ page-redirect rename-orphan-invariant` — 179 tests across 15 files pass
- [x] `turbo run lint --filter @growi/app` — 22/22 tasks pass (includes `tsgo --noEmit` typecheck and biome)

### Reproducing it by hand

Because no product-reachable trigger is known, the manual check injects the failure instead. This needs no seeded state and exercises the actual root cause:

1. On `master`, add one line to `apps/app/src/server/service/page/index.ts` immediately after `await Page.takeOffFromTree(page._id);`:
   ```js
   throw new Error('repro #9755');   // temporary
   ```
2. Start the dev server, create `/target` and `/dest`, then move `/target` → `/dest/target` from the ordinary rename modal.
3. Observe the full symptom set from the issue: a 500 toast; `/target` **gone from the sidebar**; `/target` still opens by typing its URL; `pages/list` rooted at `/dest` does not find it; nothing in trash; `db.pages.findOne({ path: '/target' })` shows `parent: null`.
4. Remove the line, apply this PR, repeat: the move still errors, but `/target` stays in the tree.

Note what this does and does not show: because the failure is injected, it confirms the **window** and the full symptom set, but it cannot discriminate between "something threw in steps 2–3" and "the process died mid-operation" — both end in the same state, and only the first is closed here.

